### PR TITLE
wrapper 타입 정의 추가

### DIFF
--- a/packages/vlossom/src/components/vs-name-input/VsNameInput.vue
+++ b/packages/vlossom/src/components/vs-name-input/VsNameInput.vue
@@ -62,7 +62,7 @@ export default defineComponent({
         lastName: { type: String, default: '' },
     },
     expose: ['validate', 'focus', 'blur', 'clear'],
-    // emits: ['update:modelValue', 'change', 'blur', 'focus', 'clear'],
+    emits: ['update:modelValue', 'change', 'blur', 'focus', 'clear'],
     setup() {
         const computedMessages: ComputedRef<StateMessage[]> = computed(() => []);
         const computedWidth: ComputedRef<string> = computed(() => '');

--- a/packages/vlossom/src/components/vs-name-input/__tests__/vs-name-input.test.ts
+++ b/packages/vlossom/src/components/vs-name-input/__tests__/vs-name-input.test.ts
@@ -3,12 +3,16 @@ import { shallowMount } from '@vue/test-utils';
 import VsNameInput, { NameInputValue, StateMessage, UIState } from '../VsNameInput.vue';
 import { nextTick } from 'vue';
 
+function shallowMountComponent() {
+    return shallowMount(VsNameInput);
+}
+
 describe('Name Input', () => {
     describe('v-model로 수정하고 싶은 값을 two-way binding 할 수 있다', () => {
         // TODO: init event test (not change event)
         it('modelValue의 초깃값을 설정할 수 있다', () => {
             // given
-            const wrapper = shallowMount(VsNameInput, {
+            const wrapper: ReturnType<typeof shallowMountComponent> = shallowMount(VsNameInput, {
                 props: {
                     modelValue: { firstName: 'Hello', lastName: 'World' },
                     'onUpdate:modelValue': (v: NameInputValue) => wrapper.setProps({ modelValue: v }),


### PR DESCRIPTION
wrapper 타입 정의를 추가했습니다.

이렇게 하면 Props 타입 힌트를 읽을 수 있고, 
emits에 대한 타입에러도 해결되는 것 같습니다!

그리고 링크에서 제시해준 아이디어처럼 beforeEach로 wrapper 초기화해주는 것도 괜찮을 것 같습니다

참고한 링크 : https://github.com/vuejs/test-utils/issues/272#issuecomment-1262371657