### PR TITLE
test: Add input composable test codes

### DIFF
--- a/packages/vlossom/src/components/vs-input-wrapper/VsInputWrapper.vue
+++ b/packages/vlossom/src/components/vs-input-wrapper/VsInputWrapper.vue
@@ -1,24 +1,30 @@
 <template>
-    <label v-if="!noLabel" v-show="label">
-        <slot name="label">
-            <span class="label">{{ label }}</span>
-        </slot>
-        <i class="required-star" v-if="required">*</i>
-    </label>
+    <div class="vs-input-wrapper" :class="{ 'shake-horizontal': needToShake }">
+        <label v-if="!noLabel" v-show="label">
+            <slot name="label">
+                <span class="label">{{ label }}</span>
+            </slot>
+            <i class="required-star" v-if="required">*</i>
+        </label>
 
-    <div>
-        <slot />
-    </div>
-
-    <slot name="messages">
-        <div class="messages" v-if="!noMsg">
-            <vs-message v-for="(message, index) in messages" :key="`${index}-${message.message}`" :message="message" />
+        <div>
+            <slot />
         </div>
-    </slot>
+
+        <slot name="messages">
+            <div class="messages" v-if="!noMsg">
+                <vs-message
+                    v-for="(message, index) in messages"
+                    :key="`${index}-${message.message}`"
+                    :message="message"
+                />
+            </div>
+        </slot>
+    </div>
 </template>
 
 <script lang="ts">
-import { PropType, defineComponent } from 'vue';
+import { PropType, defineComponent, ref, toRefs, watch } from 'vue';
 import { StateMessage } from '@/declaration/types';
 import VsMessage from '@/components/vs-message/VsMessage.vue';
 
@@ -31,6 +37,22 @@ const VsInputWrapper = defineComponent({
         noLabel: { type: Boolean, default: false },
         noMsg: { type: Boolean, default: false },
         required: { type: Boolean, default: false },
+        shake: { type: Boolean, default: false },
+    },
+    setup(props) {
+        const { shake } = toRefs(props);
+
+        const needToShake = ref(false);
+        watch(shake, () => {
+            needToShake.value = true;
+            setTimeout(() => {
+                needToShake.value = false;
+            }, 600);
+        });
+
+        return {
+            needToShake,
+        };
     },
 });
 

--- a/packages/vlossom/src/components/vs-input-wrapper/__tests__/vs-input-wrapper.test.ts
+++ b/packages/vlossom/src/components/vs-input-wrapper/__tests__/vs-input-wrapper.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from 'vitest';
-import VsInputWrapper from '../VsInputWrapper.vue';
+import { describe, expect, it, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
+import VsInputWrapper from '../VsInputWrapper.vue';
+import { nextTick } from 'vue';
 
 describe('vs-input-wrapper', () => {
     describe('label', () => {
@@ -66,6 +67,42 @@ describe('vs-input-wrapper', () => {
 
             // then
             expect(wrapper.find('.messages').exists()).toBe(false);
+        });
+    });
+
+    describe('shake', () => {
+        it('shake props 값이 바뀌면 shake-horizontal class가 붙는다', async () => {
+            // given
+            const wrapper = mount(VsInputWrapper, {
+                props: {
+                    shake: false,
+                },
+            });
+
+            // when
+            await wrapper.setProps({ shake: true });
+
+            // then
+            expect(wrapper.find('.vs-input-wrapper').classes()).toContain('shake-horizontal');
+        });
+
+        it('shake props 값이 바뀌면 shake-horizontal class가 붙었다가 600ms 후에 떨어진다', async () => {
+            // given
+            const wrapper = mount(VsInputWrapper, {
+                props: {
+                    shake: false,
+                },
+            });
+            vi.useFakeTimers();
+
+            // when
+            await wrapper.setProps({ shake: true });
+            vi.advanceTimersByTime(600);
+            await nextTick();
+
+            // then
+            expect(wrapper.find('.vs-input-wrapper').classes()).not.toContain('shake-horizontal');
+            vi.clearAllTimers();
         });
     });
 });

--- a/packages/vlossom/src/composables/__tests__/input-composable.test.ts
+++ b/packages/vlossom/src/composables/__tests__/input-composable.test.ts
@@ -215,7 +215,7 @@ describe('input composable', () => {
         });
     });
 
-    describe('rules & validate', () => {
+    describe('rules', () => {
         it('rule이 설정되었어도 값의 변경이 없다면 message가 없다', () => {
             //given
             const wrapper = mount(InputComponent, {
@@ -297,26 +297,6 @@ describe('input composable', () => {
             expect(wrapper.vm.computedMessages).toEqual([{ state: UIState.DANGER, message: 'required' }]);
         });
 
-        it('validate 함수를 호출하면 변경이 없어도 message가 노출된다', async () => {
-            //given
-            const wrapper = mount(InputComponent, {
-                props: {
-                    rules: [(v: string) => (v ? '' : 'required')],
-                },
-            });
-
-            // when
-            const result = wrapper.vm.validate();
-            await nextTick();
-
-            // then
-            expect(result).toBe(false);
-            expect(wrapper.vm.valid).toBe(false);
-            expect(wrapper.vm.changed).toBe(false);
-            expect(wrapper.vm.showRuleMessages).toBe(true);
-            expect(wrapper.vm.computedMessages).toEqual([{ state: UIState.DANGER, message: 'required' }]);
-        });
-
         it('기존 message가 있으면 rule 체크 결과를 danger 타입으로 추가한다', async () => {
             // given
             const infoMsg: StateMessage = { state: UIState.INFO, message: 'info message' };
@@ -341,6 +321,69 @@ describe('input composable', () => {
             expect(wrapper.vm.computedMessages).toHaveLength(2);
             expect(wrapper.vm.computedMessages[0]).toEqual(infoMsg);
             expect(wrapper.vm.computedMessages[1]).toEqual({ state: UIState.DANGER, message: 'required' });
+        });
+    });
+
+    describe('validate', () => {
+        it('validate 함수를 호출하면 변경이 없어도 message가 노출된다', async () => {
+            //given
+            const wrapper = mount(InputComponent, {
+                props: {
+                    rules: [(v: string) => (v ? '' : 'required')],
+                },
+            });
+
+            // when
+            const result = wrapper.vm.validate();
+            await nextTick();
+
+            // then
+            expect(result).toBe(false);
+            expect(wrapper.vm.valid).toBe(false);
+            expect(wrapper.vm.changed).toBe(false);
+            expect(wrapper.vm.showRuleMessages).toBe(true);
+            expect(wrapper.vm.computedMessages).toEqual([{ state: UIState.DANGER, message: 'required' }]);
+        });
+
+        describe('shake', () => {
+            it('validate를 호출 했을 때 값이 유효하면 shake 값(boolean)에 변화가 없다', async () => {
+                // given
+                const wrapper = mount(InputComponent, {
+                    props: {
+                        rules: [(v: string) => (v ? '' : 'required')],
+                    },
+                });
+                const oldShake = wrapper.vm.shake;
+                await nextTick();
+                inputValue.value = 'test';
+                await nextTick();
+
+                // when
+                const result = wrapper.vm.validate();
+                await nextTick();
+
+                // then
+                expect(result).toBe(true);
+                expect(wrapper.vm.shake).toBe(oldShake);
+            });
+
+            it('validate를 호출 했을 때 값이 유효하지 않으면 shake 값(boolean)이 바뀐다', async () => {
+                // given
+                const wrapper = mount(InputComponent, {
+                    props: {
+                        rules: [(v: string) => (v ? '' : 'required')],
+                    },
+                });
+                const oldShake = wrapper.vm.shake;
+
+                // when
+                const result = wrapper.vm.validate();
+                await nextTick();
+
+                // then
+                expect(result).toBe(false);
+                expect(wrapper.vm.shake).toBe(!oldShake);
+            });
         });
     });
 });

--- a/packages/vlossom/src/composables/__tests__/input-composable.test.ts
+++ b/packages/vlossom/src/composables/__tests__/input-composable.test.ts
@@ -1,84 +1,346 @@
-import { describe } from 'vitest';
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { defineComponent, nextTick, ref, toRefs } from 'vue';
+import { getInputProps, useInput } from '@/composables/input-composable';
+import { StateMessage, UIState } from '@/declaration/types';
 
-describe.skip('input composable', () => {
-    describe('inputValue (modelValue)', () => {});
+describe('input composable', () => {
+    let onMountedSpy = vi.fn();
+    let onChangeSpy = vi.fn();
+    const inputValue = ref('');
 
-    describe('messages', () => {});
+    const InputComponent = defineComponent({
+        render: () => null,
+        props: {
+            modelValue: { type: String, default: '' },
+            ...getInputProps<string>(),
+        },
+        setup(props, ctx) {
+            const { modelValue, messages, rules } = toRefs(props);
+
+            return {
+                ...useInput(inputValue, modelValue, ctx, {
+                    callbacks: {
+                        onMounted: onMountedSpy,
+                        onChange: onChangeSpy,
+                    },
+                    messages,
+                    rules,
+                }),
+            };
+        },
+    });
+
+    beforeEach(() => {
+        inputValue.value = '';
+        onMountedSpy = vi.fn();
+        onChangeSpy = vi.fn();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    describe('value binding (inputValue, modelValue)', () => {
+        it('modelValue 초깃값이 있으면 inputValue가 업데이트 된다', async () => {
+            // when
+            const wrapper = mount(InputComponent, {
+                props: {
+                    modelValue: 'test',
+                    'onUpdate:modelValue': (v: string) => wrapper.setProps({ modelValue: v }),
+                },
+            });
+
+            // then
+            expect(inputValue.value).toBe('test');
+            expect(wrapper.vm.changed).toBe(false);
+            expect(wrapper.vm.modelValue).toBe('test');
+        });
+
+        it('inputValue 값을 업데이트 해서 modelValue를 업데이트 할 수 있다', async () => {
+            // given
+            const wrapper = mount(InputComponent, {
+                props: {
+                    modelValue: '',
+                    'onUpdate:modelValue': (v: string) => wrapper.setProps({ modelValue: v }),
+                },
+            });
+
+            // when
+            await nextTick();
+            inputValue.value = 'test';
+            await nextTick();
+
+            // then
+            expect(inputValue.value).toBe('test');
+            expect(wrapper.vm.modelValue).toBe('test');
+            expect(wrapper.vm.changed).toBe(true);
+            expect(wrapper.emitted('update:modelValue')?.[0]).toEqual(['test']);
+        });
+
+        it('modelValue를 바꿔서 inputValue 값을 바꿀 수 있다', async () => {
+            // given
+            const wrapper = mount(InputComponent, {
+                props: {
+                    modelValue: '',
+                    'onUpdate:modelValue': (v: string) => wrapper.setProps({ modelValue: v }),
+                },
+            });
+
+            // when
+            await nextTick();
+            await wrapper.setProps({ modelValue: 'test' });
+
+            // then
+            expect(inputValue.value).toBe('test');
+            expect(wrapper.vm.modelValue).toBe('test');
+            expect(wrapper.vm.changed).toBe(true);
+            expect(wrapper.emitted().change).toHaveLength(1);
+            expect(wrapper.emitted().change?.[0]).toEqual(['test']);
+        });
+
+        it('mount 시점에 onMounted callback을 실행한다', () => {
+            // given
+            // when
+            const wrapper = mount(InputComponent, {
+                props: {
+                    modelValue: '',
+                    'onUpdate:modelValue': (v: string) => wrapper.setProps({ modelValue: v }),
+                },
+            });
+
+            // then
+            expect(onMountedSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it('inputValue가 변경되면 onChange callback을 실행한다', async () => {
+            // given
+            const wrapper = mount(InputComponent, {
+                props: {
+                    modelValue: '',
+                    'onUpdate:modelValue': (v: string) => wrapper.setProps({ modelValue: v }),
+                },
+            });
+
+            // when
+            await nextTick();
+            inputValue.value = 'test';
+            await nextTick();
+
+            // then
+            expect(onChangeSpy).toHaveBeenCalledTimes(1);
+            expect(onChangeSpy).toHaveBeenCalledWith('test', '');
+        });
+    });
+
+    describe('messages', () => {
+        it('messages를 StateMessage[] 형태로 전달할 수 있다', async () => {
+            // given
+            const wrapper = mount(InputComponent, {
+                props: {
+                    messages: [
+                        { state: UIState.INFO, message: 'info message' },
+                        { state: UIState.SUCCESS, message: 'success message' },
+                        { state: UIState.WARN, message: 'warning message' },
+                    ],
+                },
+            });
+
+            // then
+            expect(wrapper.vm.computedMessages).toHaveLength(3);
+            expect(wrapper.vm.computedMessages[0].state).toBe(UIState.INFO);
+            expect(wrapper.vm.computedMessages[0].message).toBe('info message');
+        });
+
+        it('messages를 함수로 전달할 수 있다', () => {
+            // given
+            const wrapper = mount(InputComponent, {
+                props: {
+                    messages: [
+                        () => ({ state: UIState.INFO, message: 'info message' }),
+                        () => ({ state: UIState.SUCCESS, message: 'success message' }),
+                        () => ({ state: UIState.WARN, message: 'warning message' }),
+                    ],
+                },
+            });
+
+            // then
+            expect(wrapper.vm.computedMessages).toHaveLength(3);
+            expect(wrapper.vm.computedMessages[0].state).toBe(UIState.INFO);
+            expect(wrapper.vm.computedMessages[0].message).toBe('info message');
+        });
+
+        it('messages를 PromiseLike를 반환하는 함수로도 전달할 수 있다', async () => {
+            // given
+            const wrapper = mount(InputComponent, {
+                props: {
+                    messages: [
+                        () => Promise.resolve({ state: UIState.INFO, message: 'info message' }),
+                        () => Promise.resolve({ state: UIState.SUCCESS, message: 'success message' }),
+                        () => Promise.resolve({ state: UIState.WARN, message: 'warning message' }),
+                    ],
+                },
+            });
+
+            // call nextTick twice to check PromiseLike rule
+            await nextTick();
+            await nextTick();
+
+            // then
+            expect(wrapper.vm.computedMessages).toHaveLength(3);
+            expect(wrapper.vm.computedMessages[0].state).toBe(UIState.INFO);
+            expect(wrapper.vm.computedMessages[0].message).toBe('info message');
+        });
+
+        it('messages가 바뀌면 바뀐 message를 반영할 수 있다', async () => {
+            // given
+            const wrapper = mount(InputComponent, {
+                props: {
+                    messages: [
+                        { state: UIState.INFO, message: 'info message' },
+                        { state: UIState.SUCCESS, message: 'success message' },
+                        { state: UIState.WARN, message: 'warning message' },
+                    ],
+                },
+            });
+
+            await wrapper.setProps({
+                messages: [{ state: UIState.DANGER, message: 'changed message' }],
+            });
+
+            // then
+            expect(wrapper.vm.computedMessages).toHaveLength(1);
+            expect(wrapper.vm.computedMessages[0].state).toBe(UIState.DANGER);
+            expect(wrapper.vm.computedMessages[0].message).toBe('changed message');
+        });
+    });
 
     describe('rules & validate', () => {
-        // let wrapper: ReturnType<typeof mountComponent>;
-        // const namePromiseCheck = () => {
-        //     return Promise.resolve('Name Promise Check');
-        // };
-        // beforeEach(() => {
-        //     wrapper = mount(VsNameInput, {
-        //         props: {
-        //             props: {
-        //                 modelValue: { firstName: '', lastName: '' },
-        //                 'onUpdate:modelValue': (v: NameInputValue) => wrapper.setProps({ modelValue: v }),
-        //             },
-        //         },
-        //     });
-        // });
-        // afterEach(() => {
-        //     wrapper.unmount();
-        // });
-        // it('rule이 설정되었어도 값의 변경이 없다면 message가 없다', () => {
-        //     // then
-        //     expect(wrapper.vm.changed).toBe(false);
-        //     expect(wrapper.vm.showRuleMessages).toBe(false);
-        //     expect(wrapper.vm.computedMessages).toHaveLength(0);
-        // });
-        // it('설정된 값이 유효하면 message가 없다', async () => {
-        //     // when
-        //     await wrapper.setProps({ modelValue: { firstName: 'Hi', lastName: 'Vlossom' } });
-        //     // then
-        //     expect(wrapper.vm.changed).toBe(true);
-        //     expect(wrapper.vm.showRuleMessages).toBe(true);
-        //     expect(wrapper.vm.computedMessages).toHaveLength(0);
-        // });
-        // it('설정된 값이 유효하지 않으면 message가 있다', async () => {
-        //     // when
-        //     await wrapper.setProps({ modelValue: { firstName: 'hey', lastName: 'why' } });
-        //     await wrapper.setProps({ modelValue: { firstName: '', lastName: '' } });
-        //     // then
-        //     expect(wrapper.vm.changed).toBe(true);
-        //     expect(wrapper.vm.showRuleMessages).toBe(true);
-        //     expect(wrapper.vm.computedMessages).toHaveLength(2);
-        // });
-        // // TODO: nextTick 개수 확인
-        // it('PromiseLike의 rule도 체크할 수 있다', async () => {
-        //     // given
-        //     // when
-        //     await wrapper.setProps({ rules: [namePromiseCheck] });
-        //     await wrapper.setProps({ modelValue: { firstName: 'hey', lastName: 'why' } });
-        //     await nextTick();
-        //     // then
-        //     expect(wrapper.vm.changed).toBe(true);
-        //     expect(wrapper.vm.showRuleMessages).toBe(true);
-        //     expect(wrapper.vm.computedMessages).toHaveLength(1);
-        // });
-        // it('validate 함수를 호출하면 변경이 없어도 message가 노출된다', () => {
-        //     // when
-        //     const result = wrapper.vm.validate();
-        //     // then
-        //     expect(result).toBe(false);
-        //     expect(wrapper.vm.changed).toBe(false);
-        //     expect(wrapper.vm.showRuleMessages).toBe(true);
-        //     expect(wrapper.vm.computedMessages).toHaveLength(2);
-        // });
-        // it('기존 message가 있으면 rule 체크 결과를 danger 타입으로 추가한다', async () => {
-        //     // given
-        //     const infoMsg: StateMessage = { state: UIState.INFO, message: 'info message' };
-        //     wrapper.setProps({ messages: [infoMsg] });
-        //     // when
-        //     await wrapper.setProps({ modelValue: { firstName: '', lastName: 'test' } });
-        //     // then
-        //     expect(wrapper.vm.showRuleMessages).toBe(true);
-        //     expect(wrapper.vm.computedMessages).toHaveLength(2);
-        //     expect(wrapper.vm.computedMessages[0]).toEqual(infoMsg);
-        //     expect(wrapper.vm.computedMessages[1].state).toBe(UIState.DANGER);
-        //     expect(wrapper.vm.computedMessages[1].message).toBe('firstName is required');
-        // });
+        it('rule이 설정되었어도 값의 변경이 없다면 message가 없다', () => {
+            //given
+            const wrapper = mount(InputComponent, {
+                props: {
+                    rules: [(v: string) => (v ? '' : 'required')],
+                },
+            });
+
+            // then
+            expect(wrapper.vm.valid).toBe(false);
+            expect(wrapper.vm.changed).toBe(false);
+            expect(wrapper.vm.showRuleMessages).toBe(false);
+            expect(wrapper.vm.computedMessages).toHaveLength(0);
+        });
+
+        it('값이 유효하면 rule error message가 없다', async () => {
+            //given
+            const wrapper = mount(InputComponent, {
+                props: {
+                    rules: [(v: string) => (v ? '' : 'required')],
+                },
+            });
+
+            // when
+            await nextTick();
+            inputValue.value = 'test';
+            await nextTick();
+
+            // then
+            expect(wrapper.vm.valid).toBe(true);
+            expect(wrapper.vm.changed).toBe(true);
+            expect(wrapper.vm.showRuleMessages).toBe(true);
+            expect(wrapper.vm.computedMessages).toHaveLength(0);
+        });
+
+        it('값이 유효하지 않으면 rule error message가 있다', async () => {
+            //given
+            const wrapper = mount(InputComponent, {
+                props: {
+                    rules: [(v: string) => (v ? '' : 'required')],
+                },
+            });
+
+            // when
+            await nextTick();
+            inputValue.value = 'test';
+            await nextTick();
+            inputValue.value = '';
+            await nextTick();
+
+            // then
+            expect(wrapper.vm.valid).toBe(false);
+            expect(wrapper.vm.changed).toBe(true);
+            expect(wrapper.vm.showRuleMessages).toBe(true);
+            expect(wrapper.vm.computedMessages).toEqual([{ state: UIState.DANGER, message: 'required' }]);
+        });
+
+        it('PromiseLike의 rule도 체크할 수 있다', async () => {
+            //given
+            const wrapper = mount(InputComponent, {
+                props: {
+                    rules: [(v: string) => Promise.resolve(v ? '' : 'required')],
+                },
+            });
+
+            // when
+            await nextTick();
+            inputValue.value = 'test';
+            await nextTick();
+            inputValue.value = '';
+            // call nextTick twice to check PromiseLike rule
+            await nextTick();
+            await nextTick();
+
+            // then
+            expect(wrapper.vm.valid).toBe(false);
+            expect(wrapper.vm.changed).toBe(true);
+            expect(wrapper.vm.showRuleMessages).toBe(true);
+            expect(wrapper.vm.computedMessages).toEqual([{ state: UIState.DANGER, message: 'required' }]);
+        });
+
+        it('validate 함수를 호출하면 변경이 없어도 message가 노출된다', async () => {
+            //given
+            const wrapper = mount(InputComponent, {
+                props: {
+                    rules: [(v: string) => (v ? '' : 'required')],
+                },
+            });
+
+            // when
+            const result = wrapper.vm.validate();
+            await nextTick();
+
+            // then
+            expect(result).toBe(false);
+            expect(wrapper.vm.valid).toBe(false);
+            expect(wrapper.vm.changed).toBe(false);
+            expect(wrapper.vm.showRuleMessages).toBe(true);
+            expect(wrapper.vm.computedMessages).toEqual([{ state: UIState.DANGER, message: 'required' }]);
+        });
+
+        it('기존 message가 있으면 rule 체크 결과를 danger 타입으로 추가한다', async () => {
+            // given
+            const infoMsg: StateMessage = { state: UIState.INFO, message: 'info message' };
+            const wrapper = mount(InputComponent, {
+                props: {
+                    messages: [infoMsg],
+                    rules: [(v: string) => (v ? '' : 'required')],
+                },
+            });
+
+            // when
+            await nextTick();
+            inputValue.value = 'test';
+            await nextTick();
+            inputValue.value = '';
+            await nextTick();
+
+            // then
+            expect(wrapper.vm.valid).toBe(false);
+            expect(wrapper.vm.changed).toBe(true);
+            expect(wrapper.vm.showRuleMessages).toBe(true);
+            expect(wrapper.vm.computedMessages).toHaveLength(2);
+            expect(wrapper.vm.computedMessages[0]).toEqual(infoMsg);
+            expect(wrapper.vm.computedMessages[1]).toEqual({ state: UIState.DANGER, message: 'required' });
+        });
     });
 });

--- a/packages/vlossom/src/composables/input-composable.ts
+++ b/packages/vlossom/src/composables/input-composable.ts
@@ -142,14 +142,20 @@ export function useInput<T = unknown>(
         });
     });
 
+    const shake = ref(false);
     function validate(): boolean {
         showRuleMessages.value = true;
-        return ruleMessages.value.length === 0;
+        const isValid = ruleMessages.value.length === 0;
+        if (!isValid) {
+            shake.value = !shake.value;
+        }
+        return isValid;
     }
 
     return {
         changed,
         valid,
+        shake,
         computedMessages,
         showRuleMessages,
         validate,

--- a/packages/vlossom/src/composables/input-composable.ts
+++ b/packages/vlossom/src/composables/input-composable.ts
@@ -1,15 +1,5 @@
 import { ComputedRef, PropType, Ref, computed, nextTick, onMounted, ref, watch } from 'vue';
-import { StateMessage, Rule, Message, UIState } from '@/declaration/types';
-
-interface InputComponentOptions<T = unknown> {
-    messages?: Ref<Message<T>[]>;
-    rules?: Ref<Rule<T>[]>;
-    clear?: () => void;
-    callbacks?: {
-        onChange?: (newValue: T, oldValue: T) => void;
-        onMounted?: () => void;
-    };
-}
+import { StateMessage, Rule, Message, UIState, InputComponentOptions } from '@/declaration/types';
 
 export function getInputProps<T = unknown>() {
     return {
@@ -140,6 +130,10 @@ export function useInput<T = unknown>(
     });
 
     onMounted(() => {
+        inputValue.value = modelValue.value;
+        checkMessages();
+        checkRules();
+
         if (options?.callbacks?.onMounted) {
             options.callbacks?.onMounted();
         }

--- a/packages/vlossom/src/declaration/types.ts
+++ b/packages/vlossom/src/declaration/types.ts
@@ -1,4 +1,5 @@
 import type { VsButtonStyleSet, VsInputStyleSet, VsSectionStyleSet } from '@/components';
+import { Ref } from 'vue';
 
 export enum VsComponent {
     VsButton = 'VsButton',
@@ -45,3 +46,13 @@ export interface StateMessage {
 
 export type Rule<T = any> = ((v: T) => string) | ((v: T) => PromiseLike<string>);
 export type Message<T = any> = StateMessage | ((v: T) => StateMessage) | ((v: T) => PromiseLike<StateMessage>);
+
+export interface InputComponentOptions<T = unknown> {
+    messages?: Ref<Message<T>[]>;
+    rules?: Ref<Rule<T>[]>;
+    clear?: () => void;
+    callbacks?: {
+        onChange?: (newValue: T, oldValue: T) => void;
+        onMounted?: () => void;
+    };
+}

--- a/packages/vlossom/src/styles/animation.scss
+++ b/packages/vlossom/src/styles/animation.scss
@@ -1,0 +1,27 @@
+.swirl-in-fwd{animation:swirl-in-fwd .6s ease-out both}
+.fade-in{animation:fade-in 1.2s cubic-bezier(.39,.575,.565,1.000) both}
+.fade-in-top{animation:fade-in-top .4s cubic-bezier(.39,.575,.565,1.000) both}
+.fade-in-right{animation:fade-in-right .4s cubic-bezier(.39,.575,.565,1.000) both}
+.fade-in-bottom{animation:fade-in-bottom .4s cubic-bezier(.39,.575,.565,1.000) both}
+.fade-in-left{animation:fade-in-left .4s cubic-bezier(.39,.575,.565,1.000) both}
+.fade-out-top{animation:fade-out-top .4s cubic-bezier(.25,.46,.45,.94) both}
+.fade-out-right{animation:fade-out-right .4s cubic-bezier(.25,.46,.45,.94) both}
+.fade-out-bottom{animation:fade-out-bottom .4s cubic-bezier(.25,.46,.45,.94) both}
+.fade-out-left{animation:fade-out-left .4s cubic-bezier(.25,.46,.45,.94) both}
+.shake-horizontal{animation:shake-horizontal .6s cubic-bezier(.455,.03,.515,.955) both}
+.scale-up-ver-top{animation:scale-up-ver-top .15s cubic-bezier(.39,.575,.565,1.000) both}
+.scale-up-center{animation:scale-up-center .2s cubic-bezier(.39,.575,.565,1.000) both}
+
+@keyframes swirl-in-fwd{0%{transform:rotate(-540deg) scale(0);opacity:0}100%{transform:rotate(0) scale(1);opacity:1}}
+@keyframes fade-in{0%{opacity:0}100%{opacity:1}}
+@keyframes fade-in-top{0%{transform:translateY(-10px);opacity:0}100%{transform:translateY(0);opacity:1}}
+@keyframes fade-in-right{0%{transform:translateX(10px);opacity:0}100%{transform:translateX(0);opacity:1}}
+@keyframes fade-in-bottom{0%{transform:translateY(10px);opacity:0}100%{transform:translateY(0);opacity:1}}
+@keyframes fade-in-left{0%{transform:translateX(-10px);opacity:0}100%{transform:translateX(0);opacity:1}}
+@keyframes fade-out-top{0%{transform:translateY(0);opacity:1}100%{transform:translateY(-10px);opacity:0}}
+@keyframes fade-out-right{0%{transform:translateX(0);opacity:1}100%{transform:translateX(10px);opacity:0}}
+@keyframes fade-out-bottom{0%{transform:translateY(0);opacity:1}100%{transform:translateY(10px);opacity:0}}
+@keyframes fade-out-left{0%{transform:translateX(0);opacity:1}100%{transform:translateX(-10px);opacity:0}}
+@keyframes shake-horizontal{0%,100%{transform:translateX(0)}10%,30%,50%,70%{transform:translateX(-8px)}20%,40%,60%{transform:translateX(8px)}80%{transform:translateX(6px)}90%{transform:translateX(-6px)}}
+@keyframes scale-up-ver-top{0%{transform:scaleY(.4);transform-origin:100% 0}100%{transform:scaleY(1);transform-origin:100% 0}}
+@keyframes scale-up-center{0%{transform:scale(.5)}100%{transform:scale(1)}}

--- a/packages/vlossom/src/styles/index.scss
+++ b/packages/vlossom/src/styles/index.scss
@@ -1,2 +1,3 @@
+@use 'animation';
 @use 'color-scheme';
 @use 'theme';


### PR DESCRIPTION
## Type of PR (check all applicable)
-   [x] Test (test)

## Summary
input composable의 테스트를 추가합니다.

## Description
기존 name input에 작성했던 test 코드의 형태를 빌려 input composable을 작성합니다.
onMounted 같은 lifecycle 함수를 고려해서 임의의 InputComponent를 define하는 형식으로 테스트 코드를 작성했습니다.


## Screenshots
![image](https://github.com/pubg/vlossom/assets/28954218/3c67184e-cd98-458c-8101-f761d142605d)

