### PR TITLE
fix(responsive-composable): fix responsiveWidth

### DIFF
--- a/packages/vlossom/src/components/vs-wrapper/VsWrapper.vue
+++ b/packages/vlossom/src/components/vs-wrapper/VsWrapper.vue
@@ -12,7 +12,7 @@ import { VsComponent, type Breakpoints } from '@/declaration/types';
 export default defineComponent({
     name: VsComponent.VsWrapper,
     props: {
-        width: { type: [String, Object] as PropType<string | Breakpoints>, default: '100%' },
+        width: { type: [String, Object] as PropType<string | Breakpoints>, default: null },
         grid: { type: Object as PropType<Breakpoints>, default: () => ({}) },
     },
     setup(props) {

--- a/packages/vlossom/src/composables/__tests__/responsive-composable.test.ts
+++ b/packages/vlossom/src/composables/__tests__/responsive-composable.test.ts
@@ -65,6 +65,17 @@ describe('useResponsiveWidth composable', () => {
     });
 
     describe('grid', () => {
+        it('When both string type width and grid are present, string type width takes precedence', () => {
+            const { widthVariables, widthClasses, widthProperties } = useResponsiveWidth(
+                ref('400px'),
+                ref({ xl: 1, lg: 2, md: 3, sm: 4, xs: 6 }),
+            );
+
+            expect(widthVariables.value).toEqual({});
+            expect(widthClasses.value).toEqual([]);
+            expect(widthProperties.value).toEqual({ width: '400px' });
+        });
+
         it('grid with all breakpoints', () => {
             const { widthVariables, widthClasses, widthProperties } = useResponsiveWidth(
                 ref({}),

--- a/packages/vlossom/src/composables/__tests__/responsive-composable.test.ts
+++ b/packages/vlossom/src/composables/__tests__/responsive-composable.test.ts
@@ -3,84 +3,117 @@ import { useResponsiveWidth } from '../responsive-composable';
 import { ref } from 'vue';
 
 describe('useResponsiveWidth composable', () => {
-    it('string type width', () => {
-        const { widthVariables, widthClasses, widthProperties } = useResponsiveWidth(ref('400px'), ref({}));
+    describe('width', () => {
+        it('string type width', () => {
+            const { widthVariables, widthClasses, widthProperties } = useResponsiveWidth(ref('400px'), ref({}));
 
-        expect(widthVariables.value).toEqual({});
-        expect(widthClasses.value).toEqual([]);
-        expect(widthProperties.value).toEqual({ width: '400px' });
+            expect(widthVariables.value).toEqual({});
+            expect(widthClasses.value).toEqual([]);
+            expect(widthProperties.value).toEqual({ width: '400px' });
+        });
+
+        it('default width (null)', () => {
+            const { widthVariables, widthClasses, widthProperties } = useResponsiveWidth(ref(null), ref({}));
+
+            expect(widthVariables.value).toEqual({});
+            expect(widthClasses.value).toEqual([]);
+            expect(widthProperties.value).toEqual({ width: '100%' });
+        });
+
+        it('width with all breakpoints', () => {
+            const { widthVariables, widthClasses, widthProperties } = useResponsiveWidth(
+                ref({
+                    xl: '100px',
+                    lg: '150px',
+                    md: '200px',
+                    sm: '250px',
+                    xs: '300px',
+                }),
+                ref({}),
+            );
+
+            expect(widthVariables.value).toEqual({
+                '--vs-width-xs': '300px',
+                '--vs-width-sm': '250px',
+                '--vs-width-md': '200px',
+                '--vs-width-lg': '150px',
+                '--vs-width-xl': '100px',
+            });
+            expect(widthClasses.value).toEqual([
+                'vs-width-xs',
+                'vs-width-sm',
+                'vs-width-md',
+                'vs-width-lg',
+                'vs-width-xl',
+            ]);
+            expect(widthProperties.value).toEqual(widthVariables.value);
+        });
+
+        it('width with some breakpoints', () => {
+            const { widthVariables, widthClasses, widthProperties } = useResponsiveWidth(
+                ref({ lg: '20%', sm: '50%' }),
+                ref({}),
+            );
+
+            expect(widthVariables.value).toEqual({
+                '--vs-width-sm': '50%',
+                '--vs-width-lg': '20%',
+            });
+            expect(widthClasses.value).toEqual(['vs-width-sm', 'vs-width-lg']);
+            expect(widthProperties.value).toEqual(widthVariables.value);
+        });
     });
 
-    it('width with all breakpoints', () => {
-        const { widthVariables, widthClasses, widthProperties } = useResponsiveWidth(
-            ref({ xl: '100px', lg: '150px', md: '200px', sm: '250px', xs: '300px' }),
-            ref({}),
-        );
+    describe('grid', () => {
+        it('grid with all breakpoints', () => {
+            const { widthVariables, widthClasses, widthProperties } = useResponsiveWidth(
+                ref({}),
+                ref({ xl: 1, lg: 2, md: 3, sm: 4, xs: 6 }),
+            );
 
-        expect(widthVariables.value).toEqual({
-            '--vs-width-xs': '300px',
-            '--vs-width-sm': '250px',
-            '--vs-width-md': '200px',
-            '--vs-width-lg': '150px',
-            '--vs-width-xl': '100px',
+            expect(widthVariables.value).toEqual({
+                '--vs-width-xs': 'calc(6/12 * 100%)',
+                '--vs-width-sm': 'calc(4/12 * 100%)',
+                '--vs-width-md': 'calc(3/12 * 100%)',
+                '--vs-width-lg': 'calc(2/12 * 100%)',
+                '--vs-width-xl': 'calc(1/12 * 100%)',
+            });
+            expect(widthClasses.value).toEqual([
+                'vs-width-xs',
+                'vs-width-sm',
+                'vs-width-md',
+                'vs-width-lg',
+                'vs-width-xl',
+            ]);
+            expect(widthProperties.value).toEqual(widthVariables.value);
         });
-        expect(widthClasses.value).toEqual(['vs-width-xs', 'vs-width-sm', 'vs-width-md', 'vs-width-lg', 'vs-width-xl']);
-        expect(widthProperties.value).toEqual(widthVariables.value);
-    });
 
-    it('width with some breakpoints', () => {
-        const { widthVariables, widthClasses, widthProperties } = useResponsiveWidth(
-            ref({ lg: '20%', sm: '50%' }),
-            ref({}),
-        );
+        it('grid with some breakpoints', () => {
+            const { widthVariables, widthClasses, widthProperties } = useResponsiveWidth(
+                ref({}),
+                ref({ lg: 4, md: 6 }),
+            );
 
-        expect(widthVariables.value).toEqual({
-            '--vs-width-sm': '50%',
-            '--vs-width-lg': '20%',
+            expect(widthVariables.value).toEqual({
+                '--vs-width-md': 'calc(6/12 * 100%)',
+                '--vs-width-lg': 'calc(4/12 * 100%)',
+            });
+            expect(widthClasses.value).toEqual(['vs-width-md', 'vs-width-lg']);
+            expect(widthProperties.value).toEqual(widthVariables.value);
         });
-        expect(widthClasses.value).toEqual(['vs-width-sm', 'vs-width-lg']);
-        expect(widthProperties.value).toEqual(widthVariables.value);
-    });
 
-    it('grid with all breakpoints', () => {
-        const { widthVariables, widthClasses, widthProperties } = useResponsiveWidth(
-            ref({}),
-            ref({ xl: 1, lg: 2, md: 3, sm: 4, xs: 6 }),
-        );
+        it('grid comes first', () => {
+            const { widthVariables, widthClasses, widthProperties } = useResponsiveWidth(
+                ref({ lg: '20%', sm: '50%' }),
+                ref({ lg: 4, md: 6 }),
+            );
 
-        expect(widthVariables.value).toEqual({
-            '--vs-width-xs': 'calc(6/12 * 100%)',
-            '--vs-width-sm': 'calc(4/12 * 100%)',
-            '--vs-width-md': 'calc(3/12 * 100%)',
-            '--vs-width-lg': 'calc(2/12 * 100%)',
-            '--vs-width-xl': 'calc(1/12 * 100%)',
+            expect(widthVariables.value).toEqual({
+                '--vs-width-md': 'calc(6/12 * 100%)',
+                '--vs-width-lg': 'calc(4/12 * 100%)',
+            });
+            expect(widthClasses.value).toEqual(['vs-width-md', 'vs-width-lg']);
+            expect(widthProperties.value).toEqual(widthVariables.value);
         });
-        expect(widthClasses.value).toEqual(['vs-width-xs', 'vs-width-sm', 'vs-width-md', 'vs-width-lg', 'vs-width-xl']);
-        expect(widthProperties.value).toEqual(widthVariables.value);
-    });
-
-    it('grid with some breakpoints', () => {
-        const { widthVariables, widthClasses, widthProperties } = useResponsiveWidth(ref({}), ref({ lg: 4, md: 6 }));
-
-        expect(widthVariables.value).toEqual({
-            '--vs-width-md': 'calc(6/12 * 100%)',
-            '--vs-width-lg': 'calc(4/12 * 100%)',
-        });
-        expect(widthClasses.value).toEqual(['vs-width-md', 'vs-width-lg']);
-        expect(widthProperties.value).toEqual(widthVariables.value);
-    });
-
-    it('grid comes first', () => {
-        const { widthVariables, widthClasses, widthProperties } = useResponsiveWidth(
-            ref({ lg: '20%', sm: '50%' }),
-            ref({ lg: 4, md: 6 }),
-        );
-
-        expect(widthVariables.value).toEqual({
-            '--vs-width-md': 'calc(6/12 * 100%)',
-            '--vs-width-lg': 'calc(4/12 * 100%)',
-        });
-        expect(widthClasses.value).toEqual(['vs-width-md', 'vs-width-lg']);
-        expect(widthProperties.value).toEqual(widthVariables.value);
     });
 });

--- a/packages/vlossom/src/composables/responsive-composable.ts
+++ b/packages/vlossom/src/composables/responsive-composable.ts
@@ -11,7 +11,7 @@ export function getResponsiveProps() {
 export function useResponsiveWidth(width: Ref<string | Breakpoints | null>, grid: Ref<Breakpoints>) {
     const responsiveWidth: ComputedRef<Breakpoints | string> = computed(() => {
         if (typeof width.value === 'string') {
-            return {};
+            return width.value;
         }
 
         if (Object.keys(grid.value).length > 0) {
@@ -59,15 +59,9 @@ export function useResponsiveWidth(width: Ref<string | Breakpoints | null>, grid
     });
 
     const widthProperties: ComputedRef<Record<string, string>> = computed(() => {
-        if (width.value === null) {
+        if (typeof responsiveWidth.value === 'string') {
             return {
-                width: '100%',
-            };
-        }
-
-        if (typeof width.value === 'string') {
-            return {
-                width: width.value,
+                width: responsiveWidth.value,
             };
         }
 

--- a/packages/vlossom/src/composables/responsive-composable.ts
+++ b/packages/vlossom/src/composables/responsive-composable.ts
@@ -1,15 +1,15 @@
-import { PropType, Ref, computed } from 'vue';
+import { ComputedRef, PropType, Ref, computed } from 'vue';
 import type { Breakpoints } from '@/declaration/types';
 
 export function getResponsiveProps() {
     return {
+        width: { type: [String, Object] as PropType<string | Breakpoints>, default: null },
         grid: { type: Object as PropType<Breakpoints>, default: () => ({}) },
-        width: { type: [String, Object] as PropType<string | Breakpoints>, default: '100%' },
     };
 }
 
-export function useResponsiveWidth(width: Ref<string | Breakpoints>, grid: Ref<Breakpoints>) {
-    const responsiveWidth = computed(() => {
+export function useResponsiveWidth(width: Ref<string | Breakpoints | null>, grid: Ref<Breakpoints>) {
+    const responsiveWidth: ComputedRef<Breakpoints | string> = computed(() => {
         if (typeof width.value === 'string') {
             return {};
         }
@@ -23,10 +23,14 @@ export function useResponsiveWidth(width: Ref<string | Breakpoints>, grid: Ref<B
             }, {} as Breakpoints);
         }
 
-        return width.value;
+        return width.value ?? '100%';
     });
 
-    const widthVariables = computed(() => {
+    const widthVariables: ComputedRef<Record<string, string>> = computed(() => {
+        if (typeof responsiveWidth.value === 'string') {
+            return {};
+        }
+
         const { xs, sm, md, lg, xl } = responsiveWidth.value;
 
         return {
@@ -38,7 +42,11 @@ export function useResponsiveWidth(width: Ref<string | Breakpoints>, grid: Ref<B
         };
     });
 
-    const widthClasses = computed(() => {
+    const widthClasses: ComputedRef<string[]> = computed(() => {
+        if (typeof responsiveWidth.value === 'string') {
+            return [];
+        }
+
         const { xs, sm, md, lg, xl } = responsiveWidth.value;
 
         return [
@@ -50,7 +58,13 @@ export function useResponsiveWidth(width: Ref<string | Breakpoints>, grid: Ref<B
         ];
     });
 
-    const widthProperties = computed(() => {
+    const widthProperties: ComputedRef<Record<string, string>> = computed(() => {
+        if (width.value === null) {
+            return {
+                width: '100%',
+            };
+        }
+
         if (typeof width.value === 'string') {
             return {
                 width: width.value,


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary
-  responsiveWidth 로직 수정

## Description
- VsWrapper 의 width props 디폴트값을 null로 지정
- useResponsiveWidth 수정
   - width가 null 인 경우 responsiveWidth 는 '100%' 리턴
   - width가 null 인 경우 widthProperties는 { width: '100%' } 리턴
  - responsiveWidth 가 string 타입인 경우 widthVariables 와 widthClasses 는 각각 빈객체, 빈배열 리턴

- useResponsiveWidth  테스트코드 수정
   - width, grid 를 각각 describe 로 묶음 
   - default width (null) 테스트 추가 
   
<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
