### PR TITLE
fix(responsive-composable): add base width & grid value

### DIFF
--- a/packages/vlossom/src/components/vs-checkbox/stories/VsCheckbox.stories.ts
+++ b/packages/vlossom/src/components/vs-checkbox/stories/VsCheckbox.stories.ts
@@ -96,7 +96,7 @@ export const Width: Story = {
         `,
     }),
     args: {
-        width: { xs: '100px', sm: '200px', md: '300px', lg: '400px', xl: '500px' },
+        width: { sm: '200px', md: '300px', lg: '400px', xl: '500px' },
     },
 };
 
@@ -114,7 +114,7 @@ export const Grid: Story = {
         `,
     }),
     args: {
-        grid: { xs: 12, md: 6, lg: 3 },
+        grid: { md: 6, lg: 3 },
     },
 };
 

--- a/packages/vlossom/src/components/vs-input/stories/VsInput.stories.ts
+++ b/packages/vlossom/src/components/vs-input/stories/VsInput.stories.ts
@@ -186,11 +186,12 @@ export const Width: Story = {
         template: `
             <vs-container>
                 <vs-input v-bind="args" />
+                <vs-input v-bind="args" />
             </vs-container>
         `,
     }),
     args: {
-        width: { xs: '100px', sm: '200px', md: '300px', lg: '400px', xl: '500px' },
+        width: { sm: '200px', md: '300px', lg: '400px', xl: '500px' },
     },
 };
 
@@ -202,6 +203,7 @@ export const Grid: Story = {
         },
         template: `
             <vs-container>
+                <vs-input v-bind="args" />
                 <vs-input v-bind="args" />
             </vs-container>
         `,

--- a/packages/vlossom/src/composables/__tests__/responsive-composable.test.ts
+++ b/packages/vlossom/src/composables/__tests__/responsive-composable.test.ts
@@ -27,20 +27,20 @@ describe('useResponsiveWidth composable', () => {
                     lg: '150px',
                     md: '200px',
                     sm: '250px',
-                    xs: '300px',
+                    base: '300px',
                 }),
                 ref({}),
             );
 
             expect(widthVariables.value).toEqual({
-                '--vs-width-xs': '300px',
+                '--vs-width-base': '300px',
                 '--vs-width-sm': '250px',
                 '--vs-width-md': '200px',
                 '--vs-width-lg': '150px',
                 '--vs-width-xl': '100px',
             });
             expect(widthClasses.value).toEqual([
-                'vs-width-xs',
+                'vs-width-base',
                 'vs-width-sm',
                 'vs-width-md',
                 'vs-width-lg',
@@ -56,10 +56,11 @@ describe('useResponsiveWidth composable', () => {
             );
 
             expect(widthVariables.value).toEqual({
+                '--vs-width-base': '100%',
                 '--vs-width-sm': '50%',
                 '--vs-width-lg': '20%',
             });
-            expect(widthClasses.value).toEqual(['vs-width-sm', 'vs-width-lg']);
+            expect(widthClasses.value).toEqual(['vs-width-base', 'vs-width-sm', 'vs-width-lg']);
             expect(widthProperties.value).toEqual(widthVariables.value);
         });
     });
@@ -68,7 +69,7 @@ describe('useResponsiveWidth composable', () => {
         it('When both string type width and grid are present, string type width takes precedence', () => {
             const { widthVariables, widthClasses, widthProperties } = useResponsiveWidth(
                 ref('400px'),
-                ref({ xl: 1, lg: 2, md: 3, sm: 4, xs: 6 }),
+                ref({ xl: 1, lg: 2, md: 3, sm: 4, base: 6 }),
             );
 
             expect(widthVariables.value).toEqual({});
@@ -79,18 +80,18 @@ describe('useResponsiveWidth composable', () => {
         it('grid with all breakpoints', () => {
             const { widthVariables, widthClasses, widthProperties } = useResponsiveWidth(
                 ref({}),
-                ref({ xl: 1, lg: 2, md: 3, sm: 4, xs: 6 }),
+                ref({ xl: 1, lg: 2, md: 3, sm: 4, base: 6 }),
             );
 
             expect(widthVariables.value).toEqual({
-                '--vs-width-xs': 'calc(6/12 * 100%)',
+                '--vs-width-base': 'calc(6/12 * 100%)',
                 '--vs-width-sm': 'calc(4/12 * 100%)',
                 '--vs-width-md': 'calc(3/12 * 100%)',
                 '--vs-width-lg': 'calc(2/12 * 100%)',
                 '--vs-width-xl': 'calc(1/12 * 100%)',
             });
             expect(widthClasses.value).toEqual([
-                'vs-width-xs',
+                'vs-width-base',
                 'vs-width-sm',
                 'vs-width-md',
                 'vs-width-lg',
@@ -106,10 +107,11 @@ describe('useResponsiveWidth composable', () => {
             );
 
             expect(widthVariables.value).toEqual({
+                '--vs-width-base': '100%',
                 '--vs-width-md': 'calc(6/12 * 100%)',
                 '--vs-width-lg': 'calc(4/12 * 100%)',
             });
-            expect(widthClasses.value).toEqual(['vs-width-md', 'vs-width-lg']);
+            expect(widthClasses.value).toEqual(['vs-width-base', 'vs-width-md', 'vs-width-lg']);
             expect(widthProperties.value).toEqual(widthVariables.value);
         });
 
@@ -120,10 +122,11 @@ describe('useResponsiveWidth composable', () => {
             );
 
             expect(widthVariables.value).toEqual({
+                '--vs-width-base': '100%',
                 '--vs-width-md': 'calc(6/12 * 100%)',
                 '--vs-width-lg': 'calc(4/12 * 100%)',
             });
-            expect(widthClasses.value).toEqual(['vs-width-md', 'vs-width-lg']);
+            expect(widthClasses.value).toEqual(['vs-width-base', 'vs-width-md', 'vs-width-lg']);
             expect(widthProperties.value).toEqual(widthVariables.value);
         });
     });

--- a/packages/vlossom/src/composables/responsive-composable.ts
+++ b/packages/vlossom/src/composables/responsive-composable.ts
@@ -31,10 +31,10 @@ export function useResponsiveWidth(width: Ref<string | Breakpoints | null>, grid
             return {};
         }
 
-        const { xs, sm, md, lg, xl } = responsiveWidth.value;
+        const { base = '100%', sm, md, lg, xl } = responsiveWidth.value;
 
         return {
-            ...(xs && { ['--vs-width-xs']: xs?.toString() }),
+            ...(base && { ['--vs-width-base']: base?.toString() }),
             ...(sm && { ['--vs-width-sm']: sm?.toString() }),
             ...(md && { ['--vs-width-md']: md?.toString() }),
             ...(lg && { ['--vs-width-lg']: lg?.toString() }),
@@ -47,10 +47,10 @@ export function useResponsiveWidth(width: Ref<string | Breakpoints | null>, grid
             return [];
         }
 
-        const { xs, sm, md, lg, xl } = responsiveWidth.value;
+        const { base = '100%', sm, md, lg, xl } = responsiveWidth.value;
 
         return [
-            ...(xs ? ['vs-width-xs'] : []),
+            ...(base ? ['vs-width-base'] : []),
             ...(sm ? ['vs-width-sm'] : []),
             ...(md ? ['vs-width-md'] : []),
             ...(lg ? ['vs-width-lg'] : []),

--- a/packages/vlossom/src/declaration/types.ts
+++ b/packages/vlossom/src/declaration/types.ts
@@ -66,7 +66,7 @@ export interface VlossomOptions {
 }
 
 export interface Breakpoints {
-    xs?: string | number;
+    base?: string | number;
     sm?: string | number;
     md?: string | number;
     lg?: string | number;

--- a/packages/vlossom/src/styles/mixin.scss
+++ b/packages/vlossom/src/styles/mixin.scss
@@ -10,15 +10,15 @@
 }
 
 @mixin responsive_width {
-    $xs: var(--vs-width-xs);
+    $base: var(--vs-width-base);
     $sm: var(--vs-width-sm);
     $md: var(--vs-width-md);
     $lg: var(--vs-width-lg);
     $xl: var(--vs-width-xl);
 
-    .vs-width-xs {
+    .vs-width-base {
         @container (min-width: 0px) {
-            width: $xs;
+            width: $base;
         }
     }
 


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary
객체 타입 width와 grid에 base(기존 xs) 값 설정


## Description

- 값이 지정된 breakpoint 들보다 더 좁은 화면에서는 width 기본 100%로 반영되지 않는 버그 수정
 ( ex. sm은 지정하였는데 xs은 지정 안한 경우)
- xs -> base로 이름 변경

<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
