### PR TITLE
feat(label): add input component label, messages slot

### DIFF
--- a/packages/vlossom/src/components/vs-checkbox/VsCheckbox.vue
+++ b/packages/vlossom/src/components/vs-checkbox/VsCheckbox.vue
@@ -8,6 +8,10 @@
             :required="required"
             :shake="shake"
         >
+            <template #label v-if="!noLabel">
+                <slot name="label" />
+            </template>
+
             <div :class="['vs-checkbox', `vs-${computedColorScheme}`, { ...classObj }]" :style="customProperties">
                 <div class="checkbox-container">
                     <span class="checkbox">
@@ -27,6 +31,10 @@
                 </div>
                 <label v-if="checkLabel" :for="id">{{ checkLabel }}</label>
             </div>
+
+            <template #messages v-if="!noMsg">
+                <slot name="messages" />
+            </template>
         </vs-input-wrapper>
     </vs-wrapper>
 </template>

--- a/packages/vlossom/src/components/vs-input-wrapper/VsInputWrapper.scss
+++ b/packages/vlossom/src/components/vs-input-wrapper/VsInputWrapper.scss
@@ -1,0 +1,5 @@
+.vs-input-wrapper {
+    .required-star {
+        color: var(--vs-red-600);
+    }
+}

--- a/packages/vlossom/src/components/vs-input-wrapper/VsInputWrapper.vue
+++ b/packages/vlossom/src/components/vs-input-wrapper/VsInputWrapper.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="vs-input-wrapper" :class="{ 'shake-horizontal': needToShake }">
-        <label v-if="!noLabel" v-show="label">
+        <label v-if="!noLabel">
             <slot name="label">
                 <span class="label">{{ label }}</span>
             </slot>

--- a/packages/vlossom/src/components/vs-input-wrapper/VsInputWrapper.vue
+++ b/packages/vlossom/src/components/vs-input-wrapper/VsInputWrapper.vue
@@ -2,7 +2,7 @@
     <div class="vs-input-wrapper" :class="{ 'shake-horizontal': needToShake }">
         <label v-if="!noLabel">
             <slot name="label">
-                <span class="label">{{ label }}</span>
+                <span class="vs-label">{{ label }}</span>
             </slot>
             <i class="required-star" v-if="required">*</i>
         </label>
@@ -12,7 +12,7 @@
         </div>
 
         <slot name="messages">
-            <div class="messages" v-if="!noMsg">
+            <div class="vs-messages" v-if="!noMsg">
                 <vs-message
                     v-for="(message, index) in messages"
                     :key="`${index}-${message.message}`"
@@ -56,3 +56,5 @@ export default defineComponent({
     },
 });
 </script>
+
+<style lang="scss" scoped src="./VsInputWrapper.scss" />

--- a/packages/vlossom/src/components/vs-input-wrapper/__tests__/vs-input-wrapper.test.ts
+++ b/packages/vlossom/src/components/vs-input-wrapper/__tests__/vs-input-wrapper.test.ts
@@ -26,7 +26,6 @@ describe('vs-input-wrapper', () => {
             // then
             const label = wrapper.find('.label');
             expect(label.exists()).toBe(true);
-            expect(label.isVisible()).toBe(false);
             expect(label.text()).toBe('');
         });
 

--- a/packages/vlossom/src/components/vs-input-wrapper/__tests__/vs-input-wrapper.test.ts
+++ b/packages/vlossom/src/components/vs-input-wrapper/__tests__/vs-input-wrapper.test.ts
@@ -14,7 +14,7 @@ describe('vs-input-wrapper', () => {
             });
 
             // then
-            const label = wrapper.find('.label');
+            const label = wrapper.find('.vs-label');
             expect(label.exists()).toBe(true);
             expect(label.isVisible()).toBe(true);
         });
@@ -24,7 +24,7 @@ describe('vs-input-wrapper', () => {
             const wrapper = mount(VsInputWrapper);
 
             // then
-            const label = wrapper.find('.label');
+            const label = wrapper.find('.vs-label');
             expect(label.exists()).toBe(true);
             expect(label.text()).toBe('');
         });
@@ -38,7 +38,7 @@ describe('vs-input-wrapper', () => {
             });
 
             // then
-            expect(wrapper.find('.label').exists()).toBe(false);
+            expect(wrapper.find('.vs-label').exists()).toBe(false);
         });
 
         it('required props를 설정하면 label 영역에 *이 표시된다', () => {
@@ -65,7 +65,7 @@ describe('vs-input-wrapper', () => {
             });
 
             // then
-            expect(wrapper.find('.messages').exists()).toBe(false);
+            expect(wrapper.find('.vs-messages').exists()).toBe(false);
         });
     });
 

--- a/packages/vlossom/src/components/vs-input/VsInput.vue
+++ b/packages/vlossom/src/components/vs-input/VsInput.vue
@@ -8,6 +8,10 @@
             :required="required"
             :shake="shake"
         >
+            <template #label v-if="!noLabel">
+                <slot name="label" />
+            </template>
+
             <div :class="['vs-input', `vs-${computedColorScheme}`, { ...classObj }]" :style="customProperties">
                 <button class="action-button prepend" v-if="hasPrepend" @click="$emit('prepend')">
                     <slot name="prepend-icon" />
@@ -40,6 +44,10 @@
                     <close-icon :size="dense ? 16 : 20" />
                 </button>
             </div>
+
+            <template #messages v-if="!noMsg">
+                <slot name="messages" />
+            </template>
         </vs-input-wrapper>
     </vs-wrapper>
 </template>


### PR DESCRIPTION
## Type of PR (check all applicable)
-   [x] Feature (feat)

## Summary
Input component에 label, messages slot을 추가합니다

## Description
- vs-input-wrapper에 있던 label, messages slot을 input component에서 제공
- required star에 스타일 추가
- label, messages class 이름에 `vs-` prefix 추가

<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
