### PR TITLE
style(siblings): add vs-inline-gap class

### DIFF
--- a/packages/vlossom/src/components/vs-button/VsButton.scss
+++ b/packages/vlossom/src/components/vs-button/VsButton.scss
@@ -104,10 +104,6 @@
     }
 }
 
-.vs-button + .vs-button {
-    margin-left: 0.3rem;
-}
-
 @media screen and (max-width: 768px) {
     .vs-button.mobile-full {
         width: 100%;

--- a/packages/vlossom/src/components/vs-button/VsButton.vue
+++ b/packages/vlossom/src/components/vs-button/VsButton.vue
@@ -1,7 +1,7 @@
 <template>
     <button
         type="button"
-        :class="['vs-button', `vs-${computedColorScheme}`, { ...classObj }]"
+        :class="['vs-button', 'vs-inline-gap', `vs-${computedColorScheme}`, { ...classObj }]"
         :style="customProperties"
         :disabled="disabled"
     >

--- a/packages/vlossom/src/components/vs-checkbox-set/types.ts
+++ b/packages/vlossom/src/components/vs-checkbox-set/types.ts
@@ -1,0 +1,5 @@
+import { VsCheckboxStyleSet } from './../vs-checkbox/types';
+
+export interface VsCheckboxSetStyleSet extends VsCheckboxStyleSet {
+    checkboxMargin?: string;
+}

--- a/packages/vlossom/src/components/vs-checkbox-set/types.ts
+++ b/packages/vlossom/src/components/vs-checkbox-set/types.ts
@@ -1,5 +1,0 @@
-import { VsCheckboxStyleSet } from './../vs-checkbox/types';
-
-export interface VsCheckboxSetStyleSet extends VsCheckboxStyleSet {
-    checkboxMargin?: string;
-}

--- a/packages/vlossom/src/components/vs-chip/VsChip.scss
+++ b/packages/vlossom/src/components/vs-chip/VsChip.scss
@@ -58,6 +58,7 @@
         display: inline-flex;
         justify-content: center;
         padding: 0 0.3rem;
+        white-space: nowrap;
     }
 
     &.noRound {
@@ -81,8 +82,4 @@
         background-color: var(--vs-chip-backgroundColor, var(--vs-comp-backgroundColor-primary));
         color: var(--vs-chip-color, var(--vs-comp-color-primary));
     }
-}
-
-.vs-chip + .vs-chip {
-    margin-left: 0.2rem;
 }

--- a/packages/vlossom/src/components/vs-chip/VsChip.vue
+++ b/packages/vlossom/src/components/vs-chip/VsChip.vue
@@ -1,12 +1,12 @@
 <template>
-    <div :class="['vs-chip', `vs-${computedColorScheme}`, { ...classObj }]" :style="customProperties">
+    <div :class="['vs-chip', 'vs-inline-gap', `vs-${computedColorScheme}`, { ...classObj }]" :style="customProperties">
         <span v-if="hasLeadingIcon" class="vs-chip-icon vs-chip-leading-icon">
             <slot name="leading-icon" />
         </span>
 
-        <span class="vs-chip-content">
+        <div class="vs-chip-content">
             <slot />
-        </span>
+        </div>
 
         <button
             v-if="closable"

--- a/packages/vlossom/src/styles/base.scss
+++ b/packages/vlossom/src/styles/base.scss
@@ -1,0 +1,3 @@
+.vs-inline-gap:has(+ .vs-inline-gap) {
+    margin-right: 0.3rem;
+}

--- a/packages/vlossom/src/styles/index.scss
+++ b/packages/vlossom/src/styles/index.scss
@@ -1,4 +1,5 @@
 @charset "utf-8";
+@use 'base';
 @use 'animation';
 @use 'color-scheme';
 @use 'theme';


### PR DESCRIPTION
## Type of PR (check all applicable)
-   [x] Style (style)

## Summary
inline 요소들 중 연속해서 올 때 0.3rem 정도 간격을 주는 class를 추가합니다

## Description
- base.scss 파일을 만들어서 vs-inline-gap class를 추가합니다
- has와 next sibling(+) 선택자를 이용해서 vs-inline-gap 사이를 판별하고 간격을 줍니다
- 이전처럼 각 컴포넌트에서 정의하지 않은 이유는 vs-inline-gap class가 있는 서로 다른 컴포넌트 사이도 간격을 줄 수 있게 하기 위함입니다.
- 예를 들어 vs-button 옆에 vs-chip이 온 경우에도 간격 띄워짐
<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
