### PR TITLE
fix(VsTabs): fix vs-tabs style bug

### DIFF
--- a/packages/vlossom/src/components/vs-tabs/VsTabs.scss
+++ b/packages/vlossom/src/components/vs-tabs/VsTabs.scss
@@ -17,7 +17,7 @@
             overflow: hidden;
             padding: var(--vs-tabs-padding, 0.8rem 1rem);
             transition: color 0.1s;
-            max-width: 100%;
+            width: var(--vs-tabs-tabWidth, auto);
 
             &:not(:last-child) {
                 margin-right: var(--vs-tabs-gap, 0.3rem);
@@ -28,9 +28,10 @@
                 font-size: var(--vs-tabs-fontSize, 1rem);
                 font-weight: var(--vs-tabs-fontWeight, 400);
                 overflow: hidden;
+                text-align: center;
                 text-overflow: ellipsis;
                 white-space: nowrap;
-                width: var(--vs-tabs-tabWidth, auto);
+                width: 100%;
                 word-break: break-word;
             }
 

--- a/packages/vlossom/src/components/vs-tabs/VsTabs.scss
+++ b/packages/vlossom/src/components/vs-tabs/VsTabs.scss
@@ -7,23 +7,24 @@
         display: inline-flex;
         list-style: none;
 
-        button {
+        .tab {
             align-items: center;
             background: transparent;
+            cursor: pointer;
             display: inline-flex;
             height: var(--vs-tabs-height, 1.6rem);
             justify-content: center;
             overflow: hidden;
             padding: var(--vs-tabs-padding, 0.8rem 1rem);
             transition: color 0.1s;
+            width: 100%;
 
             &:not(:last-child) {
                 margin-right: var(--vs-tabs-gap, 0.3rem);
             }
 
-            .vs-tabs-content {
+            .tab-content {
                 color: var(--vs-tabs-color, var(--vs-comp-color));
-                display: inline-block;
                 font-size: var(--vs-tabs-fontSize, 1rem);
                 font-weight: var(--vs-tabs-fontWeight, 400);
                 overflow: hidden;
@@ -41,15 +42,15 @@
                 border-bottom: 2px solid var(--vs-tabs-backgroundColor, var(--vs-comp-backgroundColor-primary));
                 font-weight: calc(var(--vs-tabs-fontWeight, 400) + 200);
             }
-        }
 
-        button[disabled] {
-            opacity: 0.4;
+            &.disabled {
+                opacity: 0.4;
+            }
         }
     }
 
     &.dense {
-        button {
+        .tab {
             height: calc(var(--vs-tabs-height, 1.6rem) - 0.3rem);
             padding: 0;
         }
@@ -67,7 +68,7 @@
                 width: 100%;
             }
 
-            button {
+            .tab {
                 width: 100%;
 
                 &:not(:last-child) {

--- a/packages/vlossom/src/components/vs-tabs/VsTabs.scss
+++ b/packages/vlossom/src/components/vs-tabs/VsTabs.scss
@@ -65,10 +65,6 @@
             flex-direction: column;
             width: 100%;
 
-            li {
-                width: 100%;
-            }
-
             .tab {
                 width: 100%;
 

--- a/packages/vlossom/src/components/vs-tabs/VsTabs.scss
+++ b/packages/vlossom/src/components/vs-tabs/VsTabs.scss
@@ -10,29 +10,23 @@
         .tab {
             align-items: center;
             background: transparent;
+            color: var(--vs-tabs-color, var(--vs-comp-color));
             cursor: pointer;
             display: inline-flex;
+            font-size: var(--vs-tabs-fontSize, 1rem);
+            font-weight: var(--vs-tabs-fontWeight, 400);
             height: var(--vs-tabs-height, 1.6rem);
             justify-content: center;
             overflow: hidden;
             padding: var(--vs-tabs-padding, 0.8rem 1rem);
+            text-align: center;
             transition: color 0.1s;
+            white-space: nowrap;
             width: var(--vs-tabs-tabWidth, auto);
+            word-break: break-word;
 
             &:not(:last-child) {
                 margin-right: var(--vs-tabs-gap, 0.3rem);
-            }
-
-            .tab-content {
-                color: var(--vs-tabs-color, var(--vs-comp-color));
-                font-size: var(--vs-tabs-fontSize, 1rem);
-                font-weight: var(--vs-tabs-fontWeight, 400);
-                overflow: hidden;
-                text-align: center;
-                text-overflow: ellipsis;
-                white-space: nowrap;
-                width: 100%;
-                word-break: break-word;
             }
 
             &:hover {

--- a/packages/vlossom/src/components/vs-tabs/VsTabs.scss
+++ b/packages/vlossom/src/components/vs-tabs/VsTabs.scss
@@ -17,7 +17,7 @@
             overflow: hidden;
             padding: var(--vs-tabs-padding, 0.8rem 1rem);
             transition: color 0.1s;
-            width: 100%;
+            max-width: 100%;
 
             &:not(:last-child) {
                 margin-right: var(--vs-tabs-gap, 0.3rem);

--- a/packages/vlossom/src/components/vs-tabs/VsTabs.scss
+++ b/packages/vlossom/src/components/vs-tabs/VsTabs.scss
@@ -1,3 +1,5 @@
+$fontWeight: var(--vs-tabs-fontWeight, 400);
+
 .vs-tabs {
     overflow: auto hidden;
     border-bottom: 1px solid var(--vs-tabs-borderBottomColor, var(--vs-comp-border-color));
@@ -14,16 +16,14 @@
             cursor: pointer;
             display: inline-flex;
             font-size: var(--vs-tabs-fontSize, 1rem);
-            font-weight: var(--vs-tabs-fontWeight, 400);
-            height: var(--vs-tabs-height, 1.6rem);
+            font-weight: $fontWeight;
+            height: var(--vs-tabs-height, auto);
             justify-content: center;
             overflow: hidden;
-            padding: var(--vs-tabs-padding, 0.8rem 1rem);
+            padding: var(--vs-tabs-padding, 0.2rem 1rem);
             text-align: center;
             transition: color 0.1s;
-            white-space: nowrap;
             width: var(--vs-tabs-tabWidth, auto);
-            word-break: break-word;
 
             &:not(:last-child) {
                 margin-right: var(--vs-tabs-gap, 0.3rem);
@@ -35,7 +35,7 @@
 
             &.primary {
                 border-bottom: 2px solid var(--vs-tabs-backgroundColor, var(--vs-comp-backgroundColor-primary));
-                font-weight: calc(var(--vs-tabs-fontWeight, 400) + 200);
+                font-weight: calc($fontWeight + 200);
             }
 
             &.disabled {
@@ -46,8 +46,7 @@
 
     &.dense {
         .tab {
-            height: calc(var(--vs-tabs-height, 1.6rem) - 0.3rem);
-            padding: 0;
+            padding: var(--vs-tabs-padding, 0.2rem);
         }
     }
 }

--- a/packages/vlossom/src/components/vs-tabs/VsTabs.scss
+++ b/packages/vlossom/src/components/vs-tabs/VsTabs.scss
@@ -16,19 +16,20 @@
             overflow: hidden;
             padding: var(--vs-tabs-padding, 0.8rem 1rem);
             transition: color 0.1s;
-            width: var(--vs-tabs-tabWidth, auto);
 
             &:not(:last-child) {
                 margin-right: var(--vs-tabs-gap, 0.3rem);
             }
 
-            :deep(span) {
+            .vs-tabs-content {
                 color: var(--vs-tabs-color, var(--vs-comp-color));
+                display: inline-block;
                 font-size: var(--vs-tabs-fontSize, 1rem);
                 font-weight: var(--vs-tabs-fontWeight, 400);
                 overflow: hidden;
                 text-overflow: ellipsis;
                 white-space: nowrap;
+                width: var(--vs-tabs-tabWidth, auto);
                 word-break: break-word;
             }
 

--- a/packages/vlossom/src/components/vs-tabs/VsTabs.vue
+++ b/packages/vlossom/src/components/vs-tabs/VsTabs.vue
@@ -1,17 +1,17 @@
 <template>
     <div :class="['vs-tabs', `vs-${computedColorScheme}`, { ...classObj }]" :style="computedStyleSet">
         <ul>
-            <li v-for="(tab, index) in tabs" :key="tab">
-                <div
-                    :class="['tab', { primary: selectedIdx === index, disabled: isDisabled(index) }]"
-                    @click.stop="selectTab(index)"
-                    tabindex="0"
-                >
-                    <div class="tab-content">
-                        <slot :name="tab">
-                            {{ tab }}
-                        </slot>
-                    </div>
+            <li
+                v-for="(tab, index) in tabs"
+                :key="tab"
+                :class="['tab', { primary: selectedIdx === index, disabled: isDisabled(index) }]"
+                @click.stop="selectTab(index)"
+                tabindex="0"
+            >
+                <div class="tab-content">
+                    <slot :name="tab">
+                        {{ tab }}
+                    </slot>
                 </div>
             </li>
         </ul>

--- a/packages/vlossom/src/components/vs-tabs/VsTabs.vue
+++ b/packages/vlossom/src/components/vs-tabs/VsTabs.vue
@@ -1,12 +1,14 @@
 <template>
     <div :class="['vs-tabs', `vs-${computedColorScheme}`, { ...classObj }]" :style="computedStyleSet">
-        <ul>
+        <ul role="tablist">
             <li
                 v-for="(tab, index) in tabs"
                 :key="tab"
-                :class="['tab', { primary: selectedIdx === index, disabled: isDisabled(index) }]"
+                :class="['tab', { primary: isSelected(index), disabled: isDisabled(index) }]"
+                role="tab"
+                :aria-selected="isSelected(index)"
+                :tabindex="isSelected(index) ? 0 : -1"
                 @click.stop="selectTab(index)"
-                tabindex="0"
             >
                 <div class="tab-content">
                     <slot :name="tab">
@@ -57,6 +59,10 @@ export default defineComponent({
             'mobile-full': mobileFull.value,
         }));
 
+        function isSelected(index: number) {
+            return selectedIdx.value === index;
+        }
+
         function isDisabled(index: number) {
             return disabled.value?.includes(index);
         }
@@ -95,6 +101,7 @@ export default defineComponent({
             computedColorScheme,
             computedStyleSet,
             classObj,
+            isSelected,
             isDisabled,
             selectedIdx,
             selectTab,

--- a/packages/vlossom/src/components/vs-tabs/VsTabs.vue
+++ b/packages/vlossom/src/components/vs-tabs/VsTabs.vue
@@ -8,9 +8,11 @@
                     :disabled="isDisabled(index)"
                     @click.stop="selectTab(index)"
                 >
-                    <slot :name="tab">
-                        {{ tab }}
-                    </slot>
+                    <div class="vs-tabs-content">
+                        <slot :name="tab">
+                            {{ tab }}
+                        </slot>
+                    </div>
                 </button>
             </li>
         </ul>

--- a/packages/vlossom/src/components/vs-tabs/VsTabs.vue
+++ b/packages/vlossom/src/components/vs-tabs/VsTabs.vue
@@ -5,6 +5,7 @@
                 <div
                     :class="['tab', { primary: selectedIdx === index, disabled: isDisabled(index) }]"
                     @click.stop="selectTab(index)"
+                    tabindex="0"
                 >
                     <div class="tab-content">
                         <slot :name="tab">

--- a/packages/vlossom/src/components/vs-tabs/VsTabs.vue
+++ b/packages/vlossom/src/components/vs-tabs/VsTabs.vue
@@ -10,11 +10,9 @@
                 :tabindex="isSelected(index) ? 0 : -1"
                 @click.stop="selectTab(index)"
             >
-                <div class="tab-content">
-                    <slot :name="tab">
-                        {{ tab }}
-                    </slot>
-                </div>
+                <slot :name="tab">
+                    {{ tab }}
+                </slot>
             </li>
         </ul>
     </div>

--- a/packages/vlossom/src/components/vs-tabs/VsTabs.vue
+++ b/packages/vlossom/src/components/vs-tabs/VsTabs.vue
@@ -2,18 +2,16 @@
     <div :class="['vs-tabs', `vs-${computedColorScheme}`, { ...classObj }]" :style="computedStyleSet">
         <ul>
             <li v-for="(tab, index) in tabs" :key="tab">
-                <button
-                    type="button"
-                    :class="{ primary: selectedIdx === index }"
-                    :disabled="isDisabled(index)"
+                <div
+                    :class="['tab', { primary: selectedIdx === index, disabled: isDisabled(index) }]"
                     @click.stop="selectTab(index)"
                 >
-                    <div class="vs-tabs-content">
+                    <div class="tab-content">
                         <slot :name="tab">
                             {{ tab }}
                         </slot>
                     </div>
-                </button>
+                </div>
             </li>
         </ul>
     </div>

--- a/packages/vlossom/src/components/vs-tabs/__tests__/vs-tabs.test.ts
+++ b/packages/vlossom/src/components/vs-tabs/__tests__/vs-tabs.test.ts
@@ -68,7 +68,7 @@ describe('VsTabs', () => {
             });
 
             // when
-            await wrapper.findAll('button')[1].trigger('click');
+            await wrapper.findAll('.tab')[1].trigger('click');
 
             // then
             expect(wrapper.emitted('update:modelValue')?.[0]).toEqual([1]);
@@ -87,7 +87,7 @@ describe('VsTabs', () => {
             });
 
             // when
-            await wrapper.findAll('button')[1].trigger('click');
+            await wrapper.findAll('.tab')[1].trigger('click');
             await wrapper.findAll('li')[0].trigger('click');
 
             // then

--- a/packages/vlossom/src/components/vs-tabs/__tests__/vs-tabs.test.ts
+++ b/packages/vlossom/src/components/vs-tabs/__tests__/vs-tabs.test.ts
@@ -5,7 +5,7 @@ import VsTabs from '../VsTabs.vue';
 function mountComponent() {
     return mount(VsTabs);
 }
-describe('VsTabs', () => {
+describe('vs-tabs', () => {
     describe('props & slots', () => {
         it('props tabs에 string 배열을 전달하면, 그 길이만큼 tab이 생기고 배열의 각 요소가 tab의 이름으로 지정된다', () => {
             // given
@@ -68,7 +68,7 @@ describe('VsTabs', () => {
             });
 
             // when
-            await wrapper.findAll('.tab')[1].trigger('click');
+            await wrapper.findAll('li[role=tab]')[1].trigger('click');
 
             // then
             expect(wrapper.emitted('update:modelValue')?.[0]).toEqual([1]);
@@ -87,8 +87,9 @@ describe('VsTabs', () => {
             });
 
             // when
-            await wrapper.findAll('.tab')[1].trigger('click');
-            await wrapper.findAll('li')[0].trigger('click');
+            const tabs = wrapper.findAll('li[role=tab]');
+            await tabs[1].trigger('click');
+            await tabs[0].trigger('click');
 
             // then
             expect(wrapper.emitted('update:modelValue')).toHaveLength(1);


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary
- 이전에 vs-tabs 슬롯 내부의 span 태그를 제거하면서 scss에 정의되어있던 span 태그 관련 스타일이 무효화되었는데, scss 파일을 미처 수정하지 않아 슬롯 컨텐츠에 대한 스타일 적용이 안 되는 버그가 있었습니다. 

- ~~원칙적으로 button 태그 하위에 블록요소를 사용하는 게 권장되지는 않는다고 합니다.
그런데 슬롯 내부에 어떤 태그가 올지 모르기 때문에 슬롯 자체를 div로 감싸고 inline-block 속성을 주었습니다.~~
=> button 태그 제거

## Description

<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
