### PR TITLE
feat(VsTextarea): create vs-textarea component & input modifier composable

### DIFF
--- a/packages/vlossom/src/components/index.ts
+++ b/packages/vlossom/src/components/index.ts
@@ -58,6 +58,9 @@ export { default as VsSection } from './vs-section/VsSection.vue';
 export { type VsTabsStyleSet } from './vs-tabs/types';
 export { default as VsTabs } from './vs-tabs/VsTabs.vue';
 
+export { type VsTextareaStyleSet } from './vs-textarea/types';
+export { default as VsTextarea } from './vs-textarea/VsTextarea.vue';
+
 export { type VsThemeButtonStyleSet } from './vs-theme-button/types';
 export { default as VsThemeButton } from './vs-theme-button/VsThemeButton.vue';
 
@@ -91,6 +94,7 @@ declare module 'vue' {
         VsProgress: typeof import('./')['VsProgress'];
         VsSection: typeof import('./')['VsSection'];
         VsTabs: typeof import('./')['VsTabs'];
+        VsTextarea: typeof import('./')['VsTextarea'];
         VsThemeButton: typeof import('./')['VsThemeButton'];
         VsTooltip: typeof import('./')['VsTooltip'];
         VsValueTag: typeof import('./')['VsValueTag'];

--- a/packages/vlossom/src/components/vs-input/types.ts
+++ b/packages/vlossom/src/components/vs-input/types.ts
@@ -1,3 +1,5 @@
+export type InputValueType = string | number;
+
 export interface VsInputStyleSet {
     appendBackgroundColor?: string;
     appendColor?: string;

--- a/packages/vlossom/src/components/vs-input/vs-input-rules.ts
+++ b/packages/vlossom/src/components/vs-input/vs-input-rules.ts
@@ -1,5 +1,4 @@
 import { Ref } from 'vue';
-import {} from './VsInput.vue';
 import { InputType, InputValueType } from './types';
 
 export function useVsInputRules(

--- a/packages/vlossom/src/components/vs-textarea/VsTextarea.scss
+++ b/packages/vlossom/src/components/vs-textarea/VsTextarea.scss
@@ -7,6 +7,7 @@
     background-color: var(--vs-textarea-backgroundColor, var(--vs-plain-backgroundColor));
     border: var(--vs-textarea-border, solid 1px var(--vs-comp-border-color));
     border-radius: var(--vs-textarea-borderRadius, 0.4rem);
+    width: 100%;
     height: var(--vs-textarea-height, 10rem);
 
     textarea {
@@ -17,7 +18,7 @@
         font-size: var(--vs-textarea-fontSize, 1rem);
         background-color: transparent;
         color: var(--vs-textarea-color, var(--vs-font-color));
-        resize: none;
+        resize: vertical;
     }
 
     &.disabled {

--- a/packages/vlossom/src/components/vs-textarea/VsTextarea.scss
+++ b/packages/vlossom/src/components/vs-textarea/VsTextarea.scss
@@ -1,0 +1,30 @@
+@use '@/styles/mixin' as *;
+
+.vs-textarea {
+    position: relative;
+    display: flex;
+    overflow: hidden;
+    background-color: var(--vs-textarea-backgroundColor, var(--vs-plain-backgroundColor));
+    border: var(--vs-textarea-border, solid 1px var(--vs-comp-border-color));
+    border-radius: var(--vs-textarea-borderRadius, 0.4rem);
+    height: var(--vs-textarea-height, 10rem);
+
+    textarea {
+        width: 100%;
+        padding: 0.6rem;
+        border: none;
+        outline: none;
+        font-size: var(--vs-textarea-fontSize, 1rem);
+        background-color: transparent;
+        color: var(--vs-textarea-color, var(--vs-font-color));
+        resize: none;
+    }
+
+    &.disabled {
+        @include disabled;
+    }
+
+    &:focus-within {
+        @include focus-shadow;
+    }
+}

--- a/packages/vlossom/src/components/vs-textarea/VsTextarea.scss
+++ b/packages/vlossom/src/components/vs-textarea/VsTextarea.scss
@@ -4,22 +4,16 @@
     position: relative;
     display: flex;
     overflow: hidden;
-    background-color: var(--vs-textarea-backgroundColor, var(--vs-plain-backgroundColor));
-    border: var(--vs-textarea-border, solid 1px var(--vs-comp-border-color));
-    border-radius: var(--vs-textarea-borderRadius, 0.4rem);
     width: 100%;
     height: var(--vs-textarea-height, 10rem);
-
-    textarea {
-        width: 100%;
-        padding: 0.6rem;
-        border: none;
-        outline: none;
-        font-size: var(--vs-textarea-fontSize, 1rem);
-        background-color: transparent;
-        color: var(--vs-textarea-color, var(--vs-font-color));
-        resize: vertical;
-    }
+    background-color: var(--vs-textarea-backgroundColor, var(--vs-plain-backgroundColor));
+    color: var(--vs-textarea-color, var(--vs-font-color));
+    font-size: var(--vs-textarea-fontSize, 1rem);
+    border: var(--vs-textarea-border, solid 1px var(--vs-comp-border-color));
+    border-radius: var(--vs-textarea-borderRadius, 0.4rem);
+    padding: 0.6rem;
+    outline: none;
+    resize: vertical;
 
     &.disabled {
         @include disabled;

--- a/packages/vlossom/src/components/vs-textarea/VsTextarea.vue
+++ b/packages/vlossom/src/components/vs-textarea/VsTextarea.vue
@@ -13,23 +13,23 @@
                 <slot name="label" />
             </template>
 
-            <div :class="['vs-textarea', `vs-${computedColorScheme}`, { ...classObj }]" :style="computedStyleSet">
-                <textarea
-                    ref="textareaRef"
-                    :id="id"
-                    :value="inputValue"
-                    :name="name"
-                    :disabled="disabled"
-                    :readonly="readonly"
-                    :required="required"
-                    :placeholder="placeholder"
-                    @input="updateValue($event)"
-                    @focus="onFocus"
-                    @blur="onBlur"
-                    @keyup.enter="onEnter"
-                    @change.stop
-                />
-            </div>
+            <textarea
+                ref="textareaRef"
+                :class="['vs-textarea', `vs-${computedColorScheme}`, { ...classObj }]"
+                :style="computedStyleSet"
+                :id="id"
+                :value="inputValue"
+                :name="name"
+                :disabled="disabled"
+                :readonly="readonly"
+                :required="required"
+                :placeholder="placeholder"
+                @input="updateValue($event)"
+                @focus="onFocus"
+                @blur="onBlur"
+                @keyup.enter="onEnter"
+                @change.stop
+            />
 
             <template #messages v-if="!noMsg">
                 <slot name="messages" />

--- a/packages/vlossom/src/components/vs-textarea/__tests__/vs-textarea.test.ts
+++ b/packages/vlossom/src/components/vs-textarea/__tests__/vs-textarea.test.ts
@@ -68,8 +68,6 @@ describe('vs-textarea', () => {
 
             // when
             await nextTick();
-            await nextTick();
-            await nextTick();
 
             // then
             expect(wrapper.find('textarea').element.value).toBe('');

--- a/packages/vlossom/src/components/vs-textarea/__tests__/vs-textarea.test.ts
+++ b/packages/vlossom/src/components/vs-textarea/__tests__/vs-textarea.test.ts
@@ -1,0 +1,283 @@
+import { describe, expect, it } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { nextTick } from 'vue';
+import VsTextarea from '../VsTextarea.vue';
+
+function mountComponent() {
+    return mount(VsTextarea);
+}
+
+describe('vs-textarea', () => {
+    describe('v-model', () => {
+        it('modelValue의 string 타입 초깃값을 설정할 수 있다', async () => {
+            // given
+            const wrapper: ReturnType<typeof mountComponent> = mount(VsTextarea, {
+                props: {
+                    modelValue: 'initialText',
+                    'onUpdate:modelValue': (e) => wrapper.setProps({ modelValue: e }),
+                },
+            });
+
+            // then
+            expect(wrapper.find('textarea').element.value).toBe('initialText');
+        });
+
+        it('modelValue를 업데이트 할 수 있다', async () => {
+            // given
+            const wrapper: ReturnType<typeof mountComponent> = mount(VsTextarea, {
+                props: {
+                    modelValue: '',
+                    'onUpdate:modelValue': (e) => wrapper.setProps({ modelValue: e }),
+                },
+            });
+
+            // when
+            await wrapper.find('textarea').setValue('test');
+
+            // then
+            const updateModelValueEvent = wrapper.emitted('update:modelValue');
+            expect(updateModelValueEvent).toHaveLength(1);
+            expect(updateModelValueEvent?.[0]).toEqual(['test']);
+        });
+
+        it('modelValue를 바꿔서 textarea 값을 업데이트 할 수 있다', async () => {
+            // given
+            const wrapper: ReturnType<typeof mountComponent> = mount(VsTextarea, {
+                props: {
+                    modelValue: '',
+                    'onUpdate:modelValue': (e) => wrapper.setProps({ modelValue: e }),
+                },
+            });
+
+            // when
+            await wrapper.setProps({ modelValue: 'test' });
+
+            // then
+            expect(wrapper.find('textarea').element.value).toBe('test');
+        });
+
+        it('modelValue가 null이면 빈 문자열로 가공해준다', async () => {
+            // given
+            const wrapper: ReturnType<typeof mountComponent> = mount(VsTextarea, {
+                props: {
+                    // @ts-expect-error: for null test
+                    modelValue: null,
+                    'onUpdate:modelValue': (e) => wrapper.setProps({ modelValue: e }),
+                },
+            });
+
+            // when
+            await nextTick();
+            await nextTick();
+            await nextTick();
+
+            // then
+            expect(wrapper.find('textarea').element.value).toBe('');
+            expect(wrapper.props('modelValue')).toBe('');
+        });
+    });
+
+    describe('v-model modifier', () => {
+        it('capitalize', async () => {
+            // given
+            const wrapper: ReturnType<typeof mountComponent> = mount(VsTextarea, {
+                props: {
+                    modelValue: '',
+                    'onUpdate:modelValue': (e) => wrapper.setProps({ modelValue: e }),
+                    modelModifiers: {
+                        capitalize: true,
+                    },
+                },
+            });
+
+            // when
+            await wrapper.find('textarea').setValue('test');
+
+            // then
+            expect(wrapper.props('modelValue')).toBe('Test');
+        });
+
+        it('lower', async () => {
+            // given
+            const wrapper: ReturnType<typeof mountComponent> = mount(VsTextarea, {
+                props: {
+                    modelValue: '',
+                    'onUpdate:modelValue': (e) => wrapper.setProps({ modelValue: e }),
+                    modelModifiers: {
+                        lower: true,
+                    },
+                },
+            });
+
+            // when
+            await wrapper.find('textarea').setValue('TEST');
+
+            // then
+            expect(wrapper.props('modelValue')).toBe('test');
+        });
+
+        it('upper', async () => {
+            // given
+            const wrapper: ReturnType<typeof mountComponent> = mount(VsTextarea, {
+                props: {
+                    modelValue: '',
+                    'onUpdate:modelValue': (e) => wrapper.setProps({ modelValue: e }),
+                    modelModifiers: {
+                        upper: true,
+                    },
+                },
+            });
+
+            // when
+            await wrapper.find('textarea').setValue('test');
+
+            // then
+            expect(wrapper.props('modelValue')).toBe('TEST');
+        });
+    });
+
+    describe('clear', () => {
+        it('clear 함수를 호출하면 textarea 값을 초기화 할 수 있다', async () => {
+            // given
+            const wrapper: ReturnType<typeof mountComponent> = mount(VsTextarea, {
+                props: {
+                    modelValue: 'initialText',
+                    'onUpdate:modelValue': (e) => wrapper.setProps({ modelValue: e }),
+                },
+            });
+
+            // when
+            wrapper.vm.clear();
+            await nextTick();
+
+            // then
+            expect(wrapper.find('textarea').element.value).toBe('');
+        });
+    });
+
+    describe('focus / blur', () => {
+        it('focus 이벤트를 발생시킬 수 있다', async () => {
+            // given
+            const wrapper: ReturnType<typeof mountComponent> = mount(VsTextarea);
+
+            // when
+            await wrapper.find('textarea').trigger('focus');
+
+            // then
+            expect(wrapper.emitted('focus')).toHaveLength(1);
+        });
+
+        it('blur 이벤트를 발생시킬 수 있다', async () => {
+            // given
+            const wrapper: ReturnType<typeof mountComponent> = mount(VsTextarea);
+
+            // when
+            await wrapper.find('textarea').trigger('blur');
+
+            // then
+            expect(wrapper.emitted('blur')).toHaveLength(1);
+        });
+    });
+
+    describe('enter', () => {
+        it('enter 이벤트를 발생시킬 수 있다', async () => {
+            // given
+            const wrapper: ReturnType<typeof mountComponent> = mount(VsTextarea);
+
+            // when
+            await wrapper.find('textarea').trigger('keyup.enter');
+
+            // then
+            expect(wrapper.emitted('enter')).toHaveLength(1);
+        });
+    });
+
+    describe('rules', () => {
+        it('required 체크가 가능하다', async () => {
+            // given
+            const wrapper: ReturnType<typeof mountComponent> = mount(VsTextarea, {
+                props: {
+                    modelValue: 'test',
+                    'onUpdate:modelValue': (e) => wrapper.setProps({ modelValue: e }),
+                    required: true,
+                },
+            });
+
+            // when
+            await nextTick();
+            await wrapper.find('textarea').setValue('');
+
+            // then
+            expect(wrapper.vm.computedMessages).toHaveLength(1);
+            expect(wrapper.html()).toContain('required');
+        });
+
+        it('max 체크가 가능하다', async () => {
+            // given
+            const wrapper: ReturnType<typeof mountComponent> = mount(VsTextarea, {
+                props: {
+                    modelValue: '',
+                    'onUpdate:modelValue': (e) => wrapper.setProps({ modelValue: e }),
+                    max: 3,
+                },
+            });
+
+            // when
+            await nextTick();
+            await wrapper.find('textarea').setValue('test');
+
+            // then
+            expect(wrapper.vm.computedMessages).toHaveLength(1);
+            expect(wrapper.html()).toContain('max length: 3');
+        });
+
+        it('min 체크가 가능하다', async () => {
+            // given
+            const wrapper: ReturnType<typeof mountComponent> = mount(VsTextarea, {
+                props: {
+                    modelValue: 'test',
+                    'onUpdate:modelValue': (e) => wrapper.setProps({ modelValue: e }),
+                    min: 3,
+                },
+            });
+
+            // when
+            await nextTick();
+            await wrapper.find('textarea').setValue('te');
+
+            // then
+            expect(wrapper.vm.computedMessages).toHaveLength(1);
+            expect(wrapper.html()).toContain('min length: 3');
+        });
+    });
+
+    describe('validate', () => {
+        it('valid 할 때 validate 함수를 호출하면 true를 리턴한다', async () => {
+            // given
+            const wrapper: ReturnType<typeof mountComponent> = mount(VsTextarea, {
+                props: {
+                    modelValue: 'test',
+                    'onUpdate:modelValue': (e) => wrapper.setProps({ modelValue: e }),
+                    required: true,
+                },
+            });
+
+            // then
+            expect(wrapper.vm.validate()).toBe(true);
+        });
+
+        it('invalid 할 때 validate 함수를 호출하면 false를 리턴한다', async () => {
+            // given
+            const wrapper: ReturnType<typeof mountComponent> = mount(VsTextarea, {
+                props: {
+                    modelValue: '',
+                    'onUpdate:modelValue': (e) => wrapper.setProps({ modelValue: e }),
+                    required: true,
+                },
+            });
+
+            // then
+            expect(wrapper.vm.validate()).toBe(false);
+        });
+    });
+});

--- a/packages/vlossom/src/components/vs-textarea/stories/VsTextarea.stories.ts
+++ b/packages/vlossom/src/components/vs-textarea/stories/VsTextarea.stories.ts
@@ -1,0 +1,142 @@
+import { colorScheme, getColorSchemeTemplate, getMetaArguments } from '@/storybook/args';
+import { chromaticParameters } from '@/storybook/parameters';
+import { UIState } from '@/declaration';
+import VsContainer from '@/components/vs-container/VsContainer.vue';
+import VsTextarea from '../VsTextarea.vue';
+
+import type { Meta, StoryObj } from '@storybook/vue3';
+
+const meta: Meta<typeof VsTextarea> = {
+    title: 'Components/Input Components/VsTextarea',
+    component: VsTextarea,
+    render: (args: any) => ({
+        components: { VsTextarea },
+        setup() {
+            return { args };
+        },
+        template: '<vs-textarea v-bind="args" />',
+    }),
+    tags: ['autodocs'],
+    args: {
+        placeholder: 'this is placeholder',
+    },
+    argTypes: {
+        colorScheme,
+    },
+};
+
+meta.args = getMetaArguments(VsTextarea.props, meta.args);
+export default meta;
+type Story = StoryObj<typeof VsTextarea>;
+
+export const Default: Story = {};
+
+export const ColorScheme: Story = {
+    render: (args: any) => ({
+        components: { VsTextarea },
+        setup() {
+            return { args };
+        },
+        template: `
+            <div>
+                ${getColorSchemeTemplate(`
+                    <vs-textarea v-bind="args" color-scheme="{{ color }}" style="marginBottom: 10px" />
+                `)}
+            </div>
+        `,
+    }),
+    args: {
+        placeholder: 'this is placeholder',
+    },
+    parameters: {
+        chromatic: chromaticParameters.theme,
+    },
+};
+
+export const Disabled: Story = {
+    args: {
+        disabled: true,
+    },
+    parameters: {
+        chromatic: chromaticParameters.theme,
+    },
+};
+
+export const Label: Story = {
+    args: {
+        label: 'Label',
+    },
+};
+
+export const Messages: Story = {
+    args: {
+        messages: [{ state: UIState.Success, message: 'This is success message' }],
+    },
+};
+
+export const Placeholder: Story = {
+    args: {
+        placeholder: 'enter name',
+    },
+};
+
+export const Readonly: Story = {
+    args: {
+        readonly: true,
+    },
+};
+
+export const Required: Story = {
+    args: {
+        label: 'Label',
+        required: true,
+    },
+};
+
+export const Width: Story = {
+    render: (args: any) => ({
+        components: { VsTextarea, VsContainer },
+        setup() {
+            return { args };
+        },
+        template: `
+            <vs-container>
+                <vs-textarea v-bind="args" />
+                <vs-textarea v-bind="args" />
+            </vs-container>
+        `,
+    }),
+    args: {
+        width: { sm: '200px', md: '300px', lg: '400px', xl: '500px' },
+    },
+};
+
+export const Grid: Story = {
+    render: (args: any) => ({
+        components: { VsTextarea, VsContainer },
+        setup() {
+            return { args };
+        },
+        template: `
+            <vs-container>
+                <vs-textarea v-bind="args" />
+                <vs-textarea v-bind="args" />
+            </vs-container>
+        `,
+    }),
+    args: {
+        grid: { sm: 6, md: 4, lg: 3 },
+    },
+};
+
+export const StyleSet: Story = {
+    args: {
+        styleSet: { backgroundColor: '#eef1ff', color: '#4851aa', border: '1px solid #4851aa' },
+    },
+};
+
+export const PreDefinedStyleSet: Story = {
+    args: {
+        styleSet: 'myStyleSet',
+    },
+};

--- a/packages/vlossom/src/components/vs-textarea/types.ts
+++ b/packages/vlossom/src/components/vs-textarea/types.ts
@@ -1,0 +1,10 @@
+export type InputValueType = string;
+
+export interface VsTextareaStyleSet {
+    backgroundColor?: string;
+    border?: string;
+    borderRadius?: string;
+    color?: string;
+    fontSize?: string;
+    height?: string;
+}

--- a/packages/vlossom/src/components/vs-textarea/vs-textarea-rules.ts
+++ b/packages/vlossom/src/components/vs-textarea/vs-textarea-rules.ts
@@ -1,13 +1,7 @@
 import { Ref } from 'vue';
-import {} from './VsInput.vue';
-import { InputType, InputValueType } from './types';
+import { InputValueType } from './types';
 
-export function useVsInputRules(
-    required: Ref<boolean>,
-    max: Ref<number | string>,
-    min: Ref<number | string>,
-    type: Ref<string>,
-) {
+export function useVsTextareaRules(required: Ref<boolean>, max: Ref<number | string>, min: Ref<number | string>) {
     function requiredCheck(v: InputValueType) {
         if (required.value && v === '') {
             return 'required';
@@ -23,12 +17,8 @@ export function useVsInputRules(
             return '';
         }
 
-        if (type.value === InputType.Text && typeof v === 'string' && v.length > limit) {
+        if (typeof v === 'string' && v.length > limit) {
             return 'max length: ' + max.value;
-        }
-
-        if (type.value === InputType.Number && typeof v === 'number' && v > limit) {
-            return 'max value: ' + max.value;
         }
 
         return '';
@@ -41,12 +31,8 @@ export function useVsInputRules(
             return '';
         }
 
-        if (type.value === InputType.Text && typeof v === 'string' && v.length < limit) {
+        if (typeof v === 'string' && v.length < limit) {
             return 'min length: ' + min.value;
-        }
-
-        if (type.value === InputType.Number && typeof v === 'number' && v < limit) {
-            return 'min value: ' + min.value;
         }
 
         return '';

--- a/packages/vlossom/src/composables/__tests__/input-modifier-composable.test.ts
+++ b/packages/vlossom/src/composables/__tests__/input-modifier-composable.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { ref } from 'vue';
+import { useStringModifier } from './../input-modifier-composable';
+
+describe('input-modifier-composable', () => {
+    describe('string modifier', () => {
+        describe('modifyStringValue()', () => {
+            it('modifier를 지정하지 않으면 값이 그대로 반환된다', () => {
+                // given
+                const modifiers = ref({});
+                const { modifyStringValue } = useStringModifier(modifiers);
+                const value = 'test';
+
+                // when
+                const result = modifyStringValue(value);
+
+                // then
+                expect(result).toBe(value);
+            });
+
+            it('modifier에 capitalize를 적용할 수 있다', () => {
+                // given
+                const modifiers = ref({ capitalize: true });
+                const { modifyStringValue } = useStringModifier(modifiers);
+                const value = 'test';
+
+                // when
+                const result = modifyStringValue(value);
+
+                // then
+                expect(result).toBe('Test');
+            });
+
+            it('modifier에 lower를 적용할 수 있다', () => {
+                // given
+                const modifiers = ref({ lower: true });
+                const { modifyStringValue } = useStringModifier(modifiers);
+                const value = 'TEST';
+
+                // when
+                const result = modifyStringValue(value);
+
+                // then
+                expect(result).toBe('test');
+            });
+
+            it('modifier에 upper를 적용할 수 있다', () => {
+                // given
+                const modifiers = ref({ upper: true });
+                const { modifyStringValue } = useStringModifier(modifiers);
+                const value = 'test';
+
+                // when
+                const result = modifyStringValue(value);
+
+                // then
+                expect(result).toBe('TEST');
+            });
+        });
+    });
+});

--- a/packages/vlossom/src/composables/index.ts
+++ b/packages/vlossom/src/composables/index.ts
@@ -3,6 +3,7 @@ export * from './color-scheme-composable';
 export * from './form-provide-composable';
 export * from './input-composable';
 export * from './input-form-composable';
+export * from './input-modifier-composable';
 export * from './input-option-composable';
 export * from './responsive-composable';
 export * from './style-set-composable';

--- a/packages/vlossom/src/composables/input-composable.ts
+++ b/packages/vlossom/src/composables/input-composable.ts
@@ -171,12 +171,12 @@ export function useInput<T = unknown>(
 
     onMounted(() => {
         inputValue.value = modelValue.value;
-        checkMessages();
-        checkRules();
-
         if (options?.callbacks?.onMounted) {
             options.callbacks?.onMounted();
         }
+        checkMessages();
+        checkRules();
+
         nextTick(() => {
             isInitialized.value = true;
         });

--- a/packages/vlossom/src/composables/input-modifier-composable.ts
+++ b/packages/vlossom/src/composables/input-modifier-composable.ts
@@ -1,0 +1,26 @@
+import { Ref } from 'vue';
+import { StringModifiers } from '@/declaration';
+
+export function useStringModifier(modifiers: Ref<StringModifiers>) {
+    function modifyStringValue(value: string): string {
+        if (Object.keys(modifiers.value).length === 0) {
+            return value;
+        }
+
+        let modified = value;
+
+        if (modifiers.value.capitalize) {
+            modified = value.charAt(0).toUpperCase() + value.slice(1);
+        }
+        if (modifiers.value.lower) {
+            modified = value.toLowerCase();
+        }
+        if (modifiers.value.upper) {
+            modified = value.toUpperCase();
+        }
+
+        return modified;
+    }
+
+    return { modifyStringValue };
+}

--- a/packages/vlossom/src/declaration/enums.ts
+++ b/packages/vlossom/src/declaration/enums.ts
@@ -21,6 +21,7 @@ export enum VsComponent {
     VsProgress = 'VsProgress',
     VsSection = 'VsSection',
     VsTabs = 'VsTabs',
+    VsTextarea = 'VsTextarea',
     VsThemeButton = 'VsThemeButton',
     VsTooltip = 'VsTooltip',
     VsValueTag = 'VsValueTag',

--- a/packages/vlossom/src/declaration/types.ts
+++ b/packages/vlossom/src/declaration/types.ts
@@ -14,6 +14,7 @@ import type {
     VsProgressStyleSet,
     VsSectionStyleSet,
     VsTabsStyleSet,
+    VsTextareaStyleSet,
     VsThemeButtonStyleSet,
     VsTooltipStyleSet,
     VsValueTagStyleSet,
@@ -43,6 +44,7 @@ export interface StyleSet {
     VsProgress?: { [key: string]: VsProgressStyleSet };
     VsSection?: { [key: string]: VsSectionStyleSet };
     VsTabs?: { [key: string]: VsTabsStyleSet };
+    VsTextarea?: { [key: string]: VsTextareaStyleSet };
     VsThemeButton?: { [key: string]: VsThemeButtonStyleSet };
     VsTooltip?: { [key: string]: VsTooltipStyleSet };
     VsValueTag?: { [key: string]: VsValueTagStyleSet };
@@ -86,6 +88,12 @@ export interface InputComponentOptions<T = unknown> {
         onMounted?: () => void;
         onClear?: () => void;
     };
+}
+
+export interface StringModifiers {
+    capitalize?: boolean;
+    lower?: boolean;
+    upper?: boolean;
 }
 
 export interface VsFormProvide {

--- a/packages/vlossom/src/storybook/style-sets.ts
+++ b/packages/vlossom/src/storybook/style-sets.ts
@@ -16,6 +16,7 @@ import type {
     VsProgressStyleSet,
     VsSectionStyleSet,
     VsTabsStyleSet,
+    VsTextareaStyleSet,
     VsThemeButtonStyleSet,
     VsTooltipStyleSet,
     VsValueTagStyleSet,
@@ -160,6 +161,11 @@ const vsTabs: VsTabsStyleSet = {
     tabWidth: '400px',
 };
 
+const vsTextarea: VsTextareaStyleSet = {
+    border: 'solid 1px #1e88e5',
+    color: '#1e88e5',
+};
+
 const vsTooltip: VsTooltipStyleSet = {
     arrowColor: '#ffd1d1',
     arrowSize: '0.5rem',
@@ -204,6 +210,7 @@ export const styleSet: StyleSet = {
     VsProgress: { myStyleSet: vsProgress },
     VsSection: { myStyleSet: vsSection },
     VsTabs: { myStyleSet: vsTabs },
+    VsTextarea: { myStyleSet: vsTextarea },
     VsThemeButton: { myStyleSet: vsThemeButton },
     VsTooltip: { myStyleSet: vsTooltip },
     VsValueTag: { myStyleSet: vsValueTag },


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Feature (feat)

## Summary
vs-textarea component를 만들었습니다

## Description
- vs-textarea를 만듭니다
- vs-input에서 사용하던 modifier 로직을 input-modifier-composable로 묶어서 vs-textarea에도 적용합니다
- input-modifier-composable에서 String을 정제하기 때문에 useStringModifier로 함수 만듦 (추후 다른 modifier 추가 가능한 형태)
- vs-input에 있던 circular dependency를 제거합니다
- input-composable onMount에서 rule과 message check 위치를 inputValue 조작 후 체크하도록 뒤로 미룹니다
<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
