### PR TITLE
feat(width-grid): change responsive composable

### DIFF
--- a/packages/vlossom/src/components/vs-container/VsContainer.scss
+++ b/packages/vlossom/src/components/vs-container/VsContainer.scss
@@ -1,3 +1,7 @@
 .vs-container {
+    // for grid css
+    display: grid;
+    grid-template-columns: repeat(12, 1fr);
+    // for container query
     container-type: inline-size;
 }

--- a/packages/vlossom/src/components/vs-container/VsContainer.vue
+++ b/packages/vlossom/src/components/vs-container/VsContainer.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="vs-container">
+    <div class="vs-container" :style="containerStyle">
         <slot />
     </div>
 </template>
@@ -10,8 +10,17 @@ import { VsComponent } from '@/declaration';
 
 export default defineComponent({
     name: VsComponent.VsContainer,
-    setup() {
-        return {};
+    props: {
+        rowGap: { type: [Number, String], default: 0 },
+        columnGap: { type: [Number, String], default: 0 },
+    },
+    computed: {
+        containerStyle(): { [key: string]: any } {
+            return {
+                rowGap: isNaN(Number(this.rowGap)) ? this.rowGap : `${this.rowGap}px`,
+                columnGap: isNaN(Number(this.columnGap)) ? this.columnGap : `${this.columnGap}px`,
+            };
+        },
     },
 });
 </script>

--- a/packages/vlossom/src/components/vs-container/__tests__/vs-container.test.ts
+++ b/packages/vlossom/src/components/vs-container/__tests__/vs-container.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { mount } from '@vue/test-utils';
+import VsContainer from './../VsContainer.vue';
+
+describe('vs-container', () => {
+    describe('container style', () => {
+        it('rowGap을 단위와 함께 입력하면 rowGap style을 적용한다', () => {
+            // when
+            const wrapper = mount(VsContainer, {
+                props: { rowGap: '2rem' },
+            });
+
+            // then
+            expect(wrapper.vm.containerStyle).toEqual({ rowGap: '2rem', columnGap: '0px' });
+        });
+
+        it('rowGap을 숫자로만 입력하면 px단위로 rowGap style을 적용한다', () => {
+            // when
+            const wrapper = mount(VsContainer, {
+                props: { rowGap: 20 },
+            });
+
+            // then
+            expect(wrapper.vm.containerStyle).toEqual({ rowGap: '20px', columnGap: '0px' });
+        });
+
+        it('columnGap을 단위와 함께 입력하면 columnGap style을 적용한다', () => {
+            // when
+            const wrapper = mount(VsContainer, {
+                props: { columnGap: '2rem' },
+            });
+
+            // then
+            expect(wrapper.vm.containerStyle).toEqual({ rowGap: '0px', columnGap: '2rem' });
+        });
+
+        it('columnGap을 숫자로만 입력하면 px단위로 columnGap style을 적용한다', () => {
+            // when
+            const wrapper = mount(VsContainer, {
+                props: { columnGap: 20 },
+            });
+
+            // then
+            expect(wrapper.vm.containerStyle).toEqual({ rowGap: '0px', columnGap: '20px' });
+        });
+    });
+});

--- a/packages/vlossom/src/components/vs-wrapper/VsWrapper.scss
+++ b/packages/vlossom/src/components/vs-wrapper/VsWrapper.scss
@@ -1,7 +1,7 @@
 @import '@/styles/mixin.scss';
 
-@include responsive_width;
+@include responsive;
 
 .vs-wrapper {
-    display: inline-block;
+    position: relative;
 }

--- a/packages/vlossom/src/components/vs-wrapper/VsWrapper.vue
+++ b/packages/vlossom/src/components/vs-wrapper/VsWrapper.vue
@@ -1,12 +1,12 @@
 <template>
-    <div class="vs-wrapper" :style="widthProperties" :class="widthClasses">
+    <div class="vs-wrapper" :class="responsiveClasses" :style="responsiveStyles">
         <slot />
     </div>
 </template>
 
 <script lang="ts">
 import { PropType, defineComponent, toRefs } from 'vue';
-import { useResponsiveWidth } from '@/composables';
+import { useResponsive } from '@/composables';
 import { VsComponent, type Breakpoints } from '@/declaration';
 
 export default defineComponent({
@@ -18,11 +18,11 @@ export default defineComponent({
     setup(props) {
         const { width, grid } = toRefs(props);
 
-        const { widthProperties, widthClasses } = useResponsiveWidth(width, grid);
+        const { responsiveClasses, responsiveStyles } = useResponsive(width, grid);
 
         return {
-            widthProperties,
-            widthClasses,
+            responsiveClasses,
+            responsiveStyles,
         };
     },
 });

--- a/packages/vlossom/src/composables/__tests__/anchor-positioning-composable.test.ts
+++ b/packages/vlossom/src/composables/__tests__/anchor-positioning-composable.test.ts
@@ -50,9 +50,9 @@ describe('anchor-positioning-composable', () => {
             const TargetComponent = defineComponent({
                 template: `
                     <div ref="anchorRef">target</div>
-                    <teleport to="vs-overlay">
+                    <Teleport to="vs-overlay">
                         <div ref="attchmentRef">attachment</div>
-                    <teleport>
+                    </Teleport>
                 `,
                 setup() {
                     const anchorRef: Ref<HTMLElement | null> = ref(null);

--- a/packages/vlossom/src/composables/__tests__/responsive-composable.test.ts
+++ b/packages/vlossom/src/composables/__tests__/responsive-composable.test.ts
@@ -1,27 +1,25 @@
 import { describe, expect, it } from 'vitest';
 import { ref } from 'vue';
-import { useResponsiveWidth } from '../responsive-composable';
+import { useResponsive } from '../responsive-composable';
 
-describe('useResponsiveWidth composable', () => {
+describe('useResponsive composable', () => {
     describe('width', () => {
         it('string type width', () => {
-            const { widthVariables, widthClasses, widthProperties } = useResponsiveWidth(ref('400px'), ref({}));
+            const { responsiveClasses, responsiveStyles } = useResponsive(ref('400px'), ref({}));
 
-            expect(widthVariables.value).toEqual({});
-            expect(widthClasses.value).toEqual([]);
-            expect(widthProperties.value).toEqual({ width: '400px' });
+            expect(responsiveClasses.value).toEqual([]);
+            expect(responsiveStyles.value).toEqual({ width: '400px' });
         });
 
         it('default width (null)', () => {
-            const { widthVariables, widthClasses, widthProperties } = useResponsiveWidth(ref(null), ref({}));
+            const { responsiveClasses, responsiveStyles } = useResponsive(ref(null), ref({}));
 
-            expect(widthVariables.value).toEqual({});
-            expect(widthClasses.value).toEqual([]);
-            expect(widthProperties.value).toEqual({ width: '100%' });
+            expect(responsiveClasses.value).toEqual([]);
+            expect(responsiveStyles.value).toEqual({ width: '100%' });
         });
 
         it('width with all breakpoints', () => {
-            const { widthVariables, widthClasses, widthProperties } = useResponsiveWidth(
+            const { responsiveClasses, responsiveStyles } = useResponsive(
                 ref({
                     xl: '100px',
                     lg: '150px',
@@ -32,102 +30,90 @@ describe('useResponsiveWidth composable', () => {
                 ref({}),
             );
 
-            expect(widthVariables.value).toEqual({
+            expect(responsiveClasses.value).toEqual([
+                'vs-width-base',
+                'vs-width-sm',
+                'vs-width-md',
+                'vs-width-lg',
+                'vs-width-xl',
+            ]);
+            expect(responsiveStyles.value).toEqual({
                 '--vs-width-base': '300px',
                 '--vs-width-sm': '250px',
                 '--vs-width-md': '200px',
                 '--vs-width-lg': '150px',
                 '--vs-width-xl': '100px',
             });
-            expect(widthClasses.value).toEqual([
+        });
+
+        it('width with some breakpoints', () => {
+            const { responsiveClasses, responsiveStyles } = useResponsive(ref({ lg: '20%', sm: '50%' }), ref({}));
+
+            expect(responsiveClasses.value).toEqual(['vs-width-base', 'vs-width-sm', 'vs-width-lg']);
+            expect(responsiveStyles.value).toEqual({
+                '--vs-width-base': '100%',
+                '--vs-width-sm': '50%',
+                '--vs-width-lg': '20%',
+            });
+        });
+    });
+
+    describe('grid', () => {
+        it('When both string type width and grid are present, string type width takes precedence', () => {
+            const { responsiveClasses, responsiveStyles } = useResponsive(
+                ref('400px'),
+                ref({ xl: 1, lg: 2, md: 3, sm: 4, base: 6 }),
+            );
+
+            expect(responsiveClasses.value).toEqual([]);
+            expect(responsiveStyles.value).toEqual({ width: '400px' });
+        });
+
+        it('grid with all breakpoints', () => {
+            const { responsiveClasses, responsiveStyles } = useResponsive(
+                ref({}),
+                ref({ xl: 1, lg: 2, md: 3, sm: 4, base: 6 }),
+            );
+
+            expect(responsiveClasses.value).toEqual([
                 'vs-width-base',
                 'vs-width-sm',
                 'vs-width-md',
                 'vs-width-lg',
                 'vs-width-xl',
             ]);
-            expect(widthProperties.value).toEqual(widthVariables.value);
-        });
-
-        it('width with some breakpoints', () => {
-            const { widthVariables, widthClasses, widthProperties } = useResponsiveWidth(
-                ref({ lg: '20%', sm: '50%' }),
-                ref({}),
-            );
-
-            expect(widthVariables.value).toEqual({
-                '--vs-width-base': '100%',
-                '--vs-width-sm': '50%',
-                '--vs-width-lg': '20%',
-            });
-            expect(widthClasses.value).toEqual(['vs-width-base', 'vs-width-sm', 'vs-width-lg']);
-            expect(widthProperties.value).toEqual(widthVariables.value);
-        });
-    });
-
-    describe('grid', () => {
-        it('When both string type width and grid are present, string type width takes precedence', () => {
-            const { widthVariables, widthClasses, widthProperties } = useResponsiveWidth(
-                ref('400px'),
-                ref({ xl: 1, lg: 2, md: 3, sm: 4, base: 6 }),
-            );
-
-            expect(widthVariables.value).toEqual({});
-            expect(widthClasses.value).toEqual([]);
-            expect(widthProperties.value).toEqual({ width: '400px' });
-        });
-
-        it('grid with all breakpoints', () => {
-            const { widthVariables, widthClasses, widthProperties } = useResponsiveWidth(
-                ref({}),
-                ref({ xl: 1, lg: 2, md: 3, sm: 4, base: 6 }),
-            );
-
-            expect(widthVariables.value).toEqual({
+            expect(responsiveStyles.value).toEqual({
                 '--vs-width-base': 'calc(6/12 * 100%)',
                 '--vs-width-sm': 'calc(4/12 * 100%)',
                 '--vs-width-md': 'calc(3/12 * 100%)',
                 '--vs-width-lg': 'calc(2/12 * 100%)',
                 '--vs-width-xl': 'calc(1/12 * 100%)',
             });
-            expect(widthClasses.value).toEqual([
-                'vs-width-base',
-                'vs-width-sm',
-                'vs-width-md',
-                'vs-width-lg',
-                'vs-width-xl',
-            ]);
-            expect(widthProperties.value).toEqual(widthVariables.value);
         });
 
         it('grid with some breakpoints', () => {
-            const { widthVariables, widthClasses, widthProperties } = useResponsiveWidth(
-                ref({}),
-                ref({ lg: 4, md: 6 }),
-            );
+            const { responsiveClasses, responsiveStyles } = useResponsive(ref({}), ref({ lg: 4, md: 6 }));
 
-            expect(widthVariables.value).toEqual({
+            expect(responsiveClasses.value).toEqual(['vs-width-base', 'vs-width-md', 'vs-width-lg']);
+            expect(responsiveStyles.value).toEqual({
                 '--vs-width-base': '100%',
                 '--vs-width-md': 'calc(6/12 * 100%)',
                 '--vs-width-lg': 'calc(4/12 * 100%)',
             });
-            expect(widthClasses.value).toEqual(['vs-width-base', 'vs-width-md', 'vs-width-lg']);
-            expect(widthProperties.value).toEqual(widthVariables.value);
         });
 
         it('grid comes first', () => {
-            const { widthVariables, widthClasses, widthProperties } = useResponsiveWidth(
+            const { responsiveClasses, responsiveStyles } = useResponsive(
                 ref({ lg: '20%', sm: '50%' }),
                 ref({ lg: 4, md: 6 }),
             );
 
-            expect(widthVariables.value).toEqual({
+            expect(responsiveClasses.value).toEqual(['vs-width-base', 'vs-width-md', 'vs-width-lg']);
+            expect(responsiveStyles.value).toEqual({
                 '--vs-width-base': '100%',
                 '--vs-width-md': 'calc(6/12 * 100%)',
                 '--vs-width-lg': 'calc(4/12 * 100%)',
             });
-            expect(widthClasses.value).toEqual(['vs-width-base', 'vs-width-md', 'vs-width-lg']);
-            expect(widthProperties.value).toEqual(widthVariables.value);
         });
     });
 });

--- a/packages/vlossom/src/composables/__tests__/responsive-composable.test.ts
+++ b/packages/vlossom/src/composables/__tests__/responsive-composable.test.ts
@@ -2,117 +2,115 @@ import { describe, expect, it } from 'vitest';
 import { ref } from 'vue';
 import { useResponsive } from '../responsive-composable';
 
-describe('useResponsive composable', () => {
+describe('responsive-composable (useResponsive)', () => {
     describe('width', () => {
-        it('string type width', () => {
-            const { responsiveClasses, responsiveStyles } = useResponsive(ref('400px'), ref({}));
+        it('width가 string type이면 style에 width만 추가한다', () => {
+            const width = ref('400px');
+            const grid = ref({});
+            const { responsiveClasses, responsiveStyles } = useResponsive(width, grid);
 
-            expect(responsiveClasses.value).toEqual([]);
+            expect(responsiveClasses.value).toEqual(['vs-responsive']);
             expect(responsiveStyles.value).toEqual({ width: '400px' });
         });
 
-        it('default width (null)', () => {
-            const { responsiveClasses, responsiveStyles } = useResponsive(ref(null), ref({}));
+        it('width가 null이면 style을 추가하지 않는다', () => {
+            const width = ref(null);
+            const grid = ref({});
+            const { responsiveClasses, responsiveStyles } = useResponsive(width, grid);
 
-            expect(responsiveClasses.value).toEqual([]);
-            expect(responsiveStyles.value).toEqual({ width: '100%' });
+            expect(responsiveClasses.value).toEqual(['vs-responsive']);
+            expect(responsiveStyles.value).toEqual({});
         });
 
-        it('width with all breakpoints', () => {
-            const { responsiveClasses, responsiveStyles } = useResponsive(
-                ref({
-                    xl: '100px',
-                    lg: '150px',
-                    md: '200px',
-                    sm: '250px',
-                    base: '300px',
-                }),
-                ref({}),
-            );
+        describe('각 breakpoints에 해당하는 class와 style이 적용된다', () => {
+            it('모든 breakpoints에 width 값이 설정되어 있는 경우', () => {
+                const width = ref({ xl: '100px', lg: '150px', md: '200px', sm: '250px', base: '300px' });
+                const grid = ref({});
+                const { responsiveClasses, responsiveStyles } = useResponsive(width, grid);
 
-            expect(responsiveClasses.value).toEqual([
-                'vs-width-base',
-                'vs-width-sm',
-                'vs-width-md',
-                'vs-width-lg',
-                'vs-width-xl',
-            ]);
-            expect(responsiveStyles.value).toEqual({
-                '--vs-width-base': '300px',
-                '--vs-width-sm': '250px',
-                '--vs-width-md': '200px',
-                '--vs-width-lg': '150px',
-                '--vs-width-xl': '100px',
+                expect(responsiveClasses.value).toEqual([
+                    'vs-responsive',
+                    'vs-width-sm',
+                    'vs-width-md',
+                    'vs-width-lg',
+                    'vs-width-xl',
+                ]);
+                expect(responsiveStyles.value).toEqual({
+                    '--vs-width-base': '300px',
+                    '--vs-width-sm': '250px',
+                    '--vs-width-md': '200px',
+                    '--vs-width-lg': '150px',
+                    '--vs-width-xl': '100px',
+                });
             });
-        });
 
-        it('width with some breakpoints', () => {
-            const { responsiveClasses, responsiveStyles } = useResponsive(ref({ lg: '20%', sm: '50%' }), ref({}));
+            it('일부 breakpoints에 width 값이 설정되어 있는 경우', () => {
+                const width = ref({ lg: '20%', sm: '50%' });
+                const grid = ref({});
+                const { responsiveClasses, responsiveStyles } = useResponsive(width, grid);
 
-            expect(responsiveClasses.value).toEqual(['vs-width-base', 'vs-width-sm', 'vs-width-lg']);
-            expect(responsiveStyles.value).toEqual({
-                '--vs-width-base': '100%',
-                '--vs-width-sm': '50%',
-                '--vs-width-lg': '20%',
+                expect(responsiveClasses.value).toEqual(['vs-responsive', 'vs-width-sm', 'vs-width-lg']);
+                expect(responsiveStyles.value).toEqual({
+                    '--vs-width-sm': '50%',
+                    '--vs-width-lg': '20%',
+                });
             });
         });
     });
 
     describe('grid', () => {
-        it('When both string type width and grid are present, string type width takes precedence', () => {
-            const { responsiveClasses, responsiveStyles } = useResponsive(
-                ref('400px'),
-                ref({ xl: 1, lg: 2, md: 3, sm: 4, base: 6 }),
-            );
-
-            expect(responsiveClasses.value).toEqual([]);
-            expect(responsiveStyles.value).toEqual({ width: '400px' });
-        });
-
-        it('grid with all breakpoints', () => {
-            const { responsiveClasses, responsiveStyles } = useResponsive(
-                ref({}),
-                ref({ xl: 1, lg: 2, md: 3, sm: 4, base: 6 }),
-            );
+        it('모든 breakpoints에 grid 값이 설정되어 있는 경우', () => {
+            const width = ref(null);
+            const grid = ref({ xl: 1, lg: 2, md: 3, sm: 4, base: 6 });
+            const { responsiveClasses, responsiveStyles } = useResponsive(width, grid);
 
             expect(responsiveClasses.value).toEqual([
-                'vs-width-base',
-                'vs-width-sm',
-                'vs-width-md',
-                'vs-width-lg',
-                'vs-width-xl',
+                'vs-responsive',
+                'vs-grid-sm',
+                'vs-grid-md',
+                'vs-grid-lg',
+                'vs-grid-xl',
             ]);
             expect(responsiveStyles.value).toEqual({
-                '--vs-width-base': 'calc(6/12 * 100%)',
-                '--vs-width-sm': 'calc(4/12 * 100%)',
-                '--vs-width-md': 'calc(3/12 * 100%)',
-                '--vs-width-lg': 'calc(2/12 * 100%)',
-                '--vs-width-xl': 'calc(1/12 * 100%)',
+                '--vs-grid-base': '6',
+                '--vs-grid-sm': '4',
+                '--vs-grid-md': '3',
+                '--vs-grid-lg': '2',
+                '--vs-grid-xl': '1',
             });
         });
 
-        it('grid with some breakpoints', () => {
-            const { responsiveClasses, responsiveStyles } = useResponsive(ref({}), ref({ lg: 4, md: 6 }));
+        it('일부 breakpoints에 grid 값이 설정되어 있는 경우', () => {
+            const width = ref(null);
+            const grid = ref({ lg: 2, sm: 5 });
+            const { responsiveClasses, responsiveStyles } = useResponsive(width, grid);
 
-            expect(responsiveClasses.value).toEqual(['vs-width-base', 'vs-width-md', 'vs-width-lg']);
+            expect(responsiveClasses.value).toEqual(['vs-responsive', 'vs-grid-sm', 'vs-grid-lg']);
             expect(responsiveStyles.value).toEqual({
-                '--vs-width-base': '100%',
-                '--vs-width-md': 'calc(6/12 * 100%)',
-                '--vs-width-lg': 'calc(4/12 * 100%)',
+                '--vs-grid-sm': '5',
+                '--vs-grid-lg': '2',
             });
         });
+    });
 
-        it('grid comes first', () => {
-            const { responsiveClasses, responsiveStyles } = useResponsive(
-                ref({ lg: '20%', sm: '50%' }),
-                ref({ lg: 4, md: 6 }),
-            );
+    describe('width와 grid가 모두 설정되어 있는 경우', () => {
+        it('각각의 class와 style이 모두 적용된다', () => {
+            const width = ref({ lg: '20%', sm: '50%' });
+            const grid = ref({ lg: 2, sm: 5 });
+            const { responsiveClasses, responsiveStyles } = useResponsive(width, grid);
 
-            expect(responsiveClasses.value).toEqual(['vs-width-base', 'vs-width-md', 'vs-width-lg']);
+            expect(responsiveClasses.value).toEqual([
+                'vs-responsive',
+                'vs-width-sm',
+                'vs-width-lg',
+                'vs-grid-sm',
+                'vs-grid-lg',
+            ]);
             expect(responsiveStyles.value).toEqual({
-                '--vs-width-base': '100%',
-                '--vs-width-md': 'calc(6/12 * 100%)',
-                '--vs-width-lg': 'calc(4/12 * 100%)',
+                '--vs-width-sm': '50%',
+                '--vs-width-lg': '20%',
+                '--vs-grid-sm': '5',
+                '--vs-grid-lg': '2',
             });
         });
     });

--- a/packages/vlossom/src/composables/responsive-composable.ts
+++ b/packages/vlossom/src/composables/responsive-composable.ts
@@ -24,16 +24,14 @@ export function useResponsive(width: Ref<string | Breakpoints | null>, grid: Ref
             classes.push(...widthClasses);
         }
 
-        if (grid.value) {
-            const { sm, md, lg, xl } = grid.value;
-            const gridClasses = [
-                ...(sm ? ['vs-grid-sm'] : []),
-                ...(md ? ['vs-grid-md'] : []),
-                ...(lg ? ['vs-grid-lg'] : []),
-                ...(xl ? ['vs-grid-xl'] : []),
-            ];
-            classes.push(...gridClasses);
-        }
+        const { sm, md, lg, xl } = grid.value;
+        const gridClasses = [
+            ...(sm ? ['vs-grid-sm'] : []),
+            ...(md ? ['vs-grid-md'] : []),
+            ...(lg ? ['vs-grid-lg'] : []),
+            ...(xl ? ['vs-grid-xl'] : []),
+        ];
+        classes.push(...gridClasses);
 
         return classes;
     });
@@ -55,17 +53,15 @@ export function useResponsive(width: Ref<string | Breakpoints | null>, grid: Ref
             styles['width'] = width.value;
         }
 
-        if (grid.value) {
-            const { base, sm, md, lg, xl } = grid.value;
-            const gridStyles = {
-                ...(base && { ['--vs-grid-base']: base?.toString() }),
-                ...(sm && { ['--vs-grid-sm']: sm?.toString() }),
-                ...(md && { ['--vs-grid-md']: md?.toString() }),
-                ...(lg && { ['--vs-grid-lg']: lg?.toString() }),
-                ...(xl && { ['--vs-grid-xl']: xl?.toString() }),
-            };
-            Object.assign(styles, gridStyles);
-        }
+        const { base, sm, md, lg, xl } = grid.value;
+        const gridStyles = {
+            ...(base && { ['--vs-grid-base']: base?.toString() }),
+            ...(sm && { ['--vs-grid-sm']: sm?.toString() }),
+            ...(md && { ['--vs-grid-md']: md?.toString() }),
+            ...(lg && { ['--vs-grid-lg']: lg?.toString() }),
+            ...(xl && { ['--vs-grid-xl']: xl?.toString() }),
+        };
+        Object.assign(styles, gridStyles);
 
         return styles;
     });

--- a/packages/vlossom/src/composables/responsive-composable.ts
+++ b/packages/vlossom/src/composables/responsive-composable.ts
@@ -9,69 +9,69 @@ export function getResponsiveProps() {
     };
 }
 
-export function useResponsiveWidth(width: Ref<string | Breakpoints | null>, grid: Ref<Breakpoints>) {
-    const responsiveWidth: ComputedRef<Breakpoints | string> = computed(() => {
-        if (typeof width.value === 'string') {
-            return width.value;
+export function useResponsive(width: Ref<string | Breakpoints | null>, grid: Ref<Breakpoints>) {
+    const responsiveClasses: ComputedRef<string[]> = computed(() => {
+        const classes: string[] = ['vs-responsive'];
+
+        if (width.value && typeof width.value === 'object') {
+            const { sm, md, lg, xl } = width.value;
+            const widthClasses = [
+                ...(sm ? ['vs-width-sm'] : []),
+                ...(md ? ['vs-width-md'] : []),
+                ...(lg ? ['vs-width-lg'] : []),
+                ...(xl ? ['vs-width-xl'] : []),
+            ];
+            classes.push(...widthClasses);
         }
 
-        if (Object.keys(grid.value).length > 0) {
-            return Object.entries(grid.value).reduce((acc, [key, value]) => {
-                return {
-                    ...acc,
-                    [key]: `calc(${value}/12 * 100%)`,
-                };
-            }, {} as Breakpoints);
+        if (grid.value) {
+            const { sm, md, lg, xl } = grid.value;
+            const gridClasses = [
+                ...(sm ? ['vs-grid-sm'] : []),
+                ...(md ? ['vs-grid-md'] : []),
+                ...(lg ? ['vs-grid-lg'] : []),
+                ...(xl ? ['vs-grid-xl'] : []),
+            ];
+            classes.push(...gridClasses);
         }
 
-        return width.value ?? '100%';
+        return classes;
     });
 
-    const widthVariables: ComputedRef<Record<string, string>> = computed(() => {
-        if (typeof responsiveWidth.value === 'string') {
-            return {};
-        }
+    const responsiveStyles: ComputedRef<Record<string, string>> = computed(() => {
+        const styles: Record<string, string> = {};
 
-        const { base = '100%', sm, md, lg, xl } = responsiveWidth.value;
-
-        return {
-            ...(base && { ['--vs-width-base']: base?.toString() }),
-            ...(sm && { ['--vs-width-sm']: sm?.toString() }),
-            ...(md && { ['--vs-width-md']: md?.toString() }),
-            ...(lg && { ['--vs-width-lg']: lg?.toString() }),
-            ...(xl && { ['--vs-width-xl']: xl?.toString() }),
-        };
-    });
-
-    const widthClasses: ComputedRef<string[]> = computed(() => {
-        if (typeof responsiveWidth.value === 'string') {
-            return [];
-        }
-
-        const { base = '100%', sm, md, lg, xl } = responsiveWidth.value;
-
-        return [
-            ...(base ? ['vs-width-base'] : []),
-            ...(sm ? ['vs-width-sm'] : []),
-            ...(md ? ['vs-width-md'] : []),
-            ...(lg ? ['vs-width-lg'] : []),
-            ...(xl ? ['vs-width-xl'] : []),
-        ];
-    });
-
-    const widthProperties: ComputedRef<Record<string, string>> = computed(() => {
-        if (typeof responsiveWidth.value === 'string') {
-            return {
-                width: responsiveWidth.value,
+        if (width.value && typeof width.value === 'object') {
+            const { base, sm, md, lg, xl } = width.value;
+            const widthStyles = {
+                ...(base && { ['--vs-width-base']: base?.toString() }),
+                ...(sm && { ['--vs-width-sm']: sm?.toString() }),
+                ...(md && { ['--vs-width-md']: md?.toString() }),
+                ...(lg && { ['--vs-width-lg']: lg?.toString() }),
+                ...(xl && { ['--vs-width-xl']: xl?.toString() }),
             };
+            Object.assign(styles, widthStyles);
+        } else if (typeof width.value === 'string') {
+            styles['width'] = width.value;
         }
 
-        return widthVariables.value;
+        if (grid.value) {
+            const { base, sm, md, lg, xl } = grid.value;
+            const gridStyles = {
+                ...(base && { ['--vs-grid-base']: base?.toString() }),
+                ...(sm && { ['--vs-grid-sm']: sm?.toString() }),
+                ...(md && { ['--vs-grid-md']: md?.toString() }),
+                ...(lg && { ['--vs-grid-lg']: lg?.toString() }),
+                ...(xl && { ['--vs-grid-xl']: xl?.toString() }),
+            };
+            Object.assign(styles, gridStyles);
+        }
+
+        return styles;
     });
 
     return {
-        widthVariables,
-        widthClasses,
-        widthProperties,
+        responsiveClasses,
+        responsiveStyles,
     };
 }

--- a/packages/vlossom/src/styles/index.scss
+++ b/packages/vlossom/src/styles/index.scss
@@ -1,7 +1,7 @@
 @charset "utf-8";
+@use 'variables';
 @use 'base';
 @use 'animation';
 @use 'color-scheme';
 @use 'theme';
-@use 'variables';
 @import 'ress';

--- a/packages/vlossom/src/styles/mixin.scss
+++ b/packages/vlossom/src/styles/mixin.scss
@@ -9,40 +9,58 @@
     pointer-events: none;
 }
 
-@mixin responsive_width {
-    $base: var(--vs-width-base);
-    $sm: var(--vs-width-sm);
-    $md: var(--vs-width-md);
-    $lg: var(--vs-width-lg);
-    $xl: var(--vs-width-xl);
+@mixin responsive {
+    $width-base: var(--vs-width-base);
+    $width-sm: var(--vs-width-sm);
+    $width-md: var(--vs-width-md);
+    $width-lg: var(--vs-width-lg);
+    $width-xl: var(--vs-width-xl);
+    $grid-base: var(--vs-grid-base);
+    $grid-sm: var(--vs-grid-sm);
+    $grid-md: var(--vs-grid-md);
+    $grid-lg: var(--vs-grid-lg);
+    $grid-xl: var(--vs-grid-xl);
+    $grid: 12;
 
-    .vs-width-base {
-        @container (min-width: 0px) {
-            width: $base;
+    .vs-responsive {
+        box-sizing: border-box;
+        width: $width-base;
+        grid-column-start: span $grid-base;
+    }
+
+    @container (min-width: 480px) {
+        .vs-width-sm {
+            width: $width-sm;
+        }
+        .vs-grid-sm {
+            grid-column-start: span $grid-sm;
         }
     }
 
-    .vs-width-sm {
-        @container (min-width: 480px) {
-            width: $sm;
+    @container (min-width: 768px) {
+        .vs-width-md {
+            width: $width-md;
+        }
+        .vs-grid-md {
+            grid-column-start: span $grid-md;
         }
     }
 
-    .vs-width-md {
-        @container (min-width: 768px) {
-            width: $md;
+    @container (min-width: 992px) {
+        .vs-width-lg {
+            width: $width-lg;
+        }
+        .vs-grid-lg {
+            grid-column-start: span $grid-lg;
         }
     }
 
-    .vs-width-lg {
-        @container (min-width: 992px) {
-            width: $lg;
+    @container (min-width: 1280px) {
+        .vs-width-xl {
+            width: $width-xl;
         }
-    }
-
-    .vs-width-xl {
-        @container (min-width: 1280px) {
-            width: $xl;
+        .vs-grid-xl {
+            grid-column-start: span $grid-xl;
         }
     }
 }

--- a/packages/vlossom/src/styles/mixin.scss
+++ b/packages/vlossom/src/styles/mixin.scss
@@ -20,7 +20,6 @@
     $grid-md: var(--vs-grid-md);
     $grid-lg: var(--vs-grid-lg);
     $grid-xl: var(--vs-grid-xl);
-    $grid: 12;
 
     .vs-responsive {
         box-sizing: border-box;

--- a/packages/vlossom/src/styles/variables.scss
+++ b/packages/vlossom/src/styles/variables.scss
@@ -1,15 +1,17 @@
 $variables: (
-    drawer-z-index: 1000,
-    drawer-width-xs: 10%,
-    drawer-width-sm: 16%,
-    drawer-width-md: 32%,
-    drawer-width-lg: 60%,
-    drawer-width-xl: 80%,
     drawer-height-xs: 12%,
     drawer-height-sm: 20%,
     drawer-height-md: 32%,
     drawer-height-lg: 60%,
     drawer-height-xl: 80%,
+    drawer-width-xs: 10%,
+    drawer-width-sm: 16%,
+    drawer-width-md: 32%,
+    drawer-width-lg: 60%,
+    drawer-width-xl: 80%,
+    drawer-z-index: 1000,
+    grid-base: 12,
+    width-base: 100%,
 );
 
 :root {


### PR DESCRIPTION
## Type of PR (check all applicable)
-   [x] Feature (feat)

## Summary
width와 grid가 각각 동작하도록 구현 변경 합니다 (+ grid gap 추가)

## Description
- width가 width만 설정하지 않고 grid 역할을 하던 부분을 걷어냅니다 (inline-block 제거)
- grid는 grid css를 이용해서 구현하고, row-gap, column-gap 추가합니다
- width와 grid를 모두 설정할 경우 grid 안에서 width를 설정할 수 있도록 독립적인 인자로 취급합니다.

<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
