### PR TITLE
feat(VsInput): add input types & content slot

### DIFF
--- a/packages/vlossom/src/components/vs-input/VsInput.scss
+++ b/packages/vlossom/src/components/vs-input/VsInput.scss
@@ -25,20 +25,21 @@
         display: flex;
         justify-content: center;
         align-items: center;
-
-        &.button {
-            width: 2.5rem;
-            border: none;
-            border-radius: 0;
-        }
     }
 
-    .prepend.button {
+    button.prepend,
+    button.append {
+        width: 2.5rem;
+        border: none;
+        border-radius: 0;
+    }
+
+    button.prepend {
         background-color: var(--vs-input-prependBackgroundColor, var(--vs-comp-backgroundColor-primary));
         color: var(--vs-input-prependColor, var(--vs-comp-color-primary));
     }
 
-    .append.button {
+    button.append {
         background-color: var(--vs-input-appendBackgroundColor, var(--vs-comp-backgroundColor-primary));
         color: var(--vs-input-appendColor, var(--vs-comp-color-primary));
     }

--- a/packages/vlossom/src/components/vs-input/VsInput.scss
+++ b/packages/vlossom/src/components/vs-input/VsInput.scss
@@ -11,7 +11,7 @@
 
     input {
         width: 100%;
-        padding: 0 1rem;
+        padding: 0 0.8rem;
         border: none;
         outline: none;
         font-size: var(--vs-input-fontSize, 1rem);
@@ -19,56 +19,50 @@
         color: var(--vs-input-color, var(--vs-font-color));
     }
 
-    .action-button {
+    .prepend,
+    .append {
         margin: 0;
-        padding: 0 0.6rem;
-        border: none;
-        border-radius: 0;
-        cursor: pointer;
-
-        &.prepend {
-            background-color: var(--vs-input-prependBackgroundColor, var(--vs-comp-backgroundColor-primary));
-            color: var(--vs-input-prependColor, var(--vs-comp-color-primary));
-        }
-
-        &.append {
-            background-color: var(--vs-input-appendBackgroundColor, var(--vs-comp-backgroundColor-primary));
-            color: var(--vs-input-appendColor, var(--vs-comp-color-primary));
-        }
-    }
-
-    .clear-button {
-        position: absolute;
         display: flex;
         justify-content: center;
         align-items: center;
-        top: 50%;
-        right: 0.6rem;
-        opacity: 0;
-        transform: translate(0, -50%);
-        transition: opacity 0.4s;
-        color: var(--vs-input-clearButtonColor, var(--vs-comp-border-color));
-        background: none;
-        border: none;
-        cursor: pointer;
 
-        &.number {
-            right: 2.2rem;
+        &.button {
+            width: 2.5rem;
+            border: none;
+            border-radius: 0;
         }
     }
 
-    .action-button.append + .clear-button {
-        right: 3.2rem;
+    .prepend.button {
+        background-color: var(--vs-input-prependBackgroundColor, var(--vs-comp-backgroundColor-primary));
+        color: var(--vs-input-prependColor, var(--vs-comp-color-primary));
+    }
+
+    .append.button {
+        background-color: var(--vs-input-appendBackgroundColor, var(--vs-comp-backgroundColor-primary));
+        color: var(--vs-input-appendColor, var(--vs-comp-color-primary));
+    }
+
+    .clear-button {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        color: var(--vs-input-clearButtonColor, var(--vs-comp-border-color));
+        opacity: 0;
+        transition: opacity 0.4s;
+        background: none;
+        border: none;
+        margin-right: 0.6rem;
+    }
+
+    &:hover {
+        .clear-button.show {
+            opacity: 1;
+        }
     }
 
     &.disabled {
         @include disabled;
-    }
-
-    &:hover {
-        .clear-button {
-            opacity: 1;
-        }
     }
 
     &:focus-within {
@@ -84,4 +78,19 @@
             font-size: var(--vs-input-fontSize, 0.9rem);
         }
     }
+}
+
+/* clears the ‘X’ from Internet Explorer */
+input[type='search']::-ms-clear,
+input[type='search']::-ms-reveal {
+    display: none;
+    width: 0;
+    height: 0;
+}
+/* clears the ‘X’ from Chrome */
+input[type='search']::-webkit-search-decoration,
+input[type='search']::-webkit-search-cancel-button,
+input[type='search']::-webkit-search-results-button,
+input[type='search']::-webkit-search-results-decoration {
+    display: none;
 }

--- a/packages/vlossom/src/components/vs-input/VsInput.scss
+++ b/packages/vlossom/src/components/vs-input/VsInput.scss
@@ -81,14 +81,9 @@
     }
 }
 
-/* clears the ‘X’ from Internet Explorer */
+/* clears the ‘X’ */
 input[type='search']::-ms-clear,
-input[type='search']::-ms-reveal {
-    display: none;
-    width: 0;
-    height: 0;
-}
-/* clears the ‘X’ from Chrome */
+input[type='search']::-ms-reveal,
 input[type='search']::-webkit-search-decoration,
 input[type='search']::-webkit-search-cancel-button,
 input[type='search']::-webkit-search-results-button,

--- a/packages/vlossom/src/components/vs-input/VsInput.vue
+++ b/packages/vlossom/src/components/vs-input/VsInput.vue
@@ -15,13 +15,17 @@
 
             <div :class="['vs-input', `vs-${computedColorScheme}`, { ...classObj }]" :style="computedStyleSet">
                 <button
-                    class="action-button prepend"
-                    v-if="hasPrepend"
+                    v-if="hasPrependButton"
+                    class="prepend button"
                     @click="$emit('prepend')"
                     aria-label="prepend-action"
                 >
-                    <slot name="prepend-icon" />
+                    <slot name="prepend-button" />
                 </button>
+
+                <div v-if="hasPrependContent" class="prepend">
+                    <slot name="prepend-content" />
+                </div>
 
                 <input
                     ref="inputRef"
@@ -41,22 +45,27 @@
                 />
 
                 <button
-                    class="action-button append"
-                    v-if="hasAppend"
-                    @click="$emit('append')"
-                    aria-label="append-action"
-                >
-                    <slot name="append-icon" />
-                </button>
-
-                <button
-                    v-if="!noClear && inputValue && !readonly && !disabled"
+                    v-if="!noClear && !readonly && !disabled"
                     class="clear-button"
-                    :class="{ number: type === InputType.Number }"
+                    :class="{ show: inputValue }"
+                    :disabled="!inputValue"
                     aria-label="clear"
                     @click.stop="clearWithFocus()"
                 >
                     <vs-icon icon="close" :size="dense ? 16 : 20" />
+                </button>
+
+                <div v-if="hasAppendContent" class="append">
+                    <slot name="append-content" />
+                </div>
+
+                <button
+                    v-if="hasAppendButton"
+                    class="append button"
+                    @click="$emit('append')"
+                    aria-label="append-action"
+                >
+                    <slot name="append-button" />
                 </button>
             </div>
 
@@ -96,11 +105,11 @@ export default defineComponent({
         colorScheme: { type: String as PropType<ColorScheme> },
         styleSet: { type: [String, Object] as PropType<string | VsInputStyleSet>, default: '' },
         dense: { type: Boolean, default: false },
-        type: { type: String as PropType<InputType | string>, default: InputType.Text },
+        type: { type: String as PropType<InputType>, default: InputType.Text },
         max: { type: [Number, String], default: Number.MAX_SAFE_INTEGER },
         min: { type: [Number, String], default: Number.MIN_SAFE_INTEGER },
         // v-model
-        modelValue: { type: [String, Number], default: '' },
+        modelValue: { type: [String, Number, Object] as PropType<InputValueType>, default: '' },
         modelModifiers: {
             type: Object as PropType<StringModifiers>,
             default: () => ({}),
@@ -149,16 +158,16 @@ export default defineComponent({
             disabled: disabled.value,
         }));
 
-        function convertValue(v: InputValueType | null | undefined): InputValueType {
+        function convertValue(v: InputValueType | undefined): InputValueType {
             if (!v) {
-                return type.value === InputType.Text ? '' : 0;
+                return type.value === InputType.Number ? null : '';
             }
 
-            if (type.value === InputType.Text) {
-                return v.toString();
-            } else {
+            if (type.value === InputType.Number) {
                 return Number(v);
             }
+
+            return v.toString();
         }
 
         const allRules = computed(() => [...rules.value, requiredCheck, maxCheck, minCheck]);
@@ -205,8 +214,11 @@ export default defineComponent({
             inputRef.value?.select();
         }
 
-        const hasPrepend = computed(() => !!slots['prepend-icon']);
-        const hasAppend = computed(() => !!slots['append-icon']);
+        const hasPrependButton = computed(() => !!slots['prepend-button']);
+        const hasAppendButton = computed(() => !!slots['append-button']);
+
+        const hasPrependContent = computed(() => !!slots['prepend-content']);
+        const hasAppendContent = computed(() => !!slots['append-content']);
 
         function onFocus() {
             emit('focus');
@@ -219,11 +231,11 @@ export default defineComponent({
         function onEnter() {
             emit('enter');
 
-            if (hasPrepend.value) {
+            if (hasPrependButton.value) {
                 emit('prepend');
             }
 
-            if (hasAppend.value) {
+            if (hasAppendButton.value) {
                 emit('append');
             }
         }
@@ -242,8 +254,10 @@ export default defineComponent({
             inputValue,
             updateValue,
             inputRef,
-            hasPrepend,
-            hasAppend,
+            hasPrependButton,
+            hasAppendButton,
+            hasPrependContent,
+            hasAppendContent,
             computedMessages,
             shake,
             focus,

--- a/packages/vlossom/src/components/vs-input/VsInput.vue
+++ b/packages/vlossom/src/components/vs-input/VsInput.vue
@@ -14,12 +14,7 @@
             </template>
 
             <div :class="['vs-input', `vs-${computedColorScheme}`, { ...classObj }]" :style="computedStyleSet">
-                <button
-                    v-if="hasPrependButton"
-                    class="prepend button"
-                    @click="$emit('prepend')"
-                    aria-label="prepend-action"
-                >
+                <button v-if="hasPrependButton" class="prepend" @click="$emit('prepend')" aria-label="prepend-action">
                     <slot name="prepend-button" />
                 </button>
 
@@ -39,8 +34,8 @@
                     :placeholder="placeholder"
                     :max="isNumberInput ? max : undefined"
                     :min="isNumberInput ? min : undefined"
-                    :max-length="!isNumberInput ? max : undefined"
-                    :min-length="!isNumberInput ? min : undefined"
+                    :maxlength="!isNumberInput ? max : undefined"
+                    :minlength="!isNumberInput ? min : undefined"
                     @input="updateValue($event)"
                     @focus="onFocus"
                     @blur="onBlur"
@@ -63,12 +58,7 @@
                     <slot name="append-content" />
                 </div>
 
-                <button
-                    v-if="hasAppendButton"
-                    class="append button"
-                    @click="$emit('append')"
-                    aria-label="append-action"
-                >
+                <button v-if="hasAppendButton" class="append" @click="$emit('append')" aria-label="append-action">
                     <slot name="append-button" />
                 </button>
             </div>

--- a/packages/vlossom/src/components/vs-input/VsInput.vue
+++ b/packages/vlossom/src/components/vs-input/VsInput.vue
@@ -37,6 +37,10 @@
                     :readonly="readonly"
                     :required="required"
                     :placeholder="placeholder"
+                    :max="isNumberInput ? max : undefined"
+                    :min="isNumberInput ? min : undefined"
+                    :max-length="!isNumberInput ? max : undefined"
+                    :min-length="!isNumberInput ? min : undefined"
                     @input="updateValue($event)"
                     @focus="onFocus"
                     @blur="onBlur"
@@ -109,7 +113,7 @@ export default defineComponent({
         max: { type: [Number, String], default: Number.MAX_SAFE_INTEGER },
         min: { type: [Number, String], default: Number.MIN_SAFE_INTEGER },
         // v-model
-        modelValue: { type: [String, Number, Object] as PropType<InputValueType>, default: '' },
+        modelValue: { type: [String, Number] as PropType<InputValueType>, default: '' },
         modelModifiers: {
             type: Object as PropType<StringModifiers>,
             default: () => ({}),
@@ -158,12 +162,14 @@ export default defineComponent({
             disabled: disabled.value,
         }));
 
+        const isNumberInput = computed(() => type.value === InputType.Number);
+
         function convertValue(v: InputValueType | undefined): InputValueType {
             if (!v) {
-                return type.value === InputType.Number ? null : '';
+                return isNumberInput.value ? null : '';
             }
 
-            if (type.value === InputType.Number) {
+            if (isNumberInput.value) {
                 return Number(v);
             }
 
@@ -200,6 +206,12 @@ export default defineComponent({
             inputValue.value = converted;
         }
 
+        const hasPrependButton = computed(() => !!slots['prepend-button']);
+        const hasAppendButton = computed(() => !!slots['append-button']);
+
+        const hasPrependContent = computed(() => !!slots['prepend-content']);
+        const hasAppendContent = computed(() => !!slots['append-content']);
+
         const inputRef: Ref<HTMLInputElement | null> = ref(null);
 
         function focus() {
@@ -213,12 +225,6 @@ export default defineComponent({
         function select() {
             inputRef.value?.select();
         }
-
-        const hasPrependButton = computed(() => !!slots['prepend-button']);
-        const hasAppendButton = computed(() => !!slots['append-button']);
-
-        const hasPrependContent = computed(() => !!slots['prepend-content']);
-        const hasAppendContent = computed(() => !!slots['append-content']);
 
         function onFocus() {
             emit('focus');
@@ -251,6 +257,7 @@ export default defineComponent({
             computedColorScheme,
             computedStyleSet,
             InputType,
+            isNumberInput,
             inputValue,
             updateValue,
             inputRef,

--- a/packages/vlossom/src/components/vs-input/VsInput.vue
+++ b/packages/vlossom/src/components/vs-input/VsInput.vue
@@ -32,8 +32,6 @@
                     :readonly="readonly"
                     :aria-required="required"
                     :placeholder="placeholder"
-                    :aria-valuemax="isNumberInput ? max : undefined"
-                    :aria-valuemin="isNumberInput ? min : undefined"
                     @input="updateValue($event)"
                     @focus="onFocus"
                     @blur="onBlur"
@@ -98,8 +96,8 @@ export default defineComponent({
         styleSet: { type: [String, Object] as PropType<string | VsInputStyleSet>, default: '' },
         dense: { type: Boolean, default: false },
         type: { type: String as PropType<InputType>, default: InputType.Text },
-        max: { type: [Number, String], default: null },
-        min: { type: [Number, String], default: null },
+        max: { type: [Number, String], default: Number.MAX_SAFE_INTEGER },
+        min: { type: [Number, String], default: Number.MIN_SAFE_INTEGER },
         // v-model
         modelValue: { type: [String, Number] as PropType<InputValueType>, default: '' },
         modelModifiers: {

--- a/packages/vlossom/src/components/vs-input/VsInput.vue
+++ b/packages/vlossom/src/components/vs-input/VsInput.vue
@@ -243,7 +243,6 @@ export default defineComponent({
             computedColorScheme,
             computedStyleSet,
             InputType,
-            isNumberInput,
             inputValue,
             updateValue,
             inputRef,

--- a/packages/vlossom/src/components/vs-input/VsInput.vue
+++ b/packages/vlossom/src/components/vs-input/VsInput.vue
@@ -30,12 +30,10 @@
                     :name="name"
                     :disabled="disabled"
                     :readonly="readonly"
-                    :required="required"
+                    :aria-required="required"
                     :placeholder="placeholder"
-                    :max="isNumberInput ? max : undefined"
-                    :min="isNumberInput ? min : undefined"
-                    :maxlength="!isNumberInput ? max : undefined"
-                    :minlength="!isNumberInput ? min : undefined"
+                    :aria-valuemax="isNumberInput ? max : undefined"
+                    :aria-valuemin="isNumberInput ? min : undefined"
                     @input="updateValue($event)"
                     @focus="onFocus"
                     @blur="onBlur"
@@ -100,8 +98,8 @@ export default defineComponent({
         styleSet: { type: [String, Object] as PropType<string | VsInputStyleSet>, default: '' },
         dense: { type: Boolean, default: false },
         type: { type: String as PropType<InputType>, default: InputType.Text },
-        max: { type: [Number, String], default: Number.MAX_SAFE_INTEGER },
-        min: { type: [Number, String], default: Number.MIN_SAFE_INTEGER },
+        max: { type: [Number, String], default: null },
+        min: { type: [Number, String], default: null },
         // v-model
         modelValue: { type: [String, Number] as PropType<InputValueType>, default: '' },
         modelModifiers: {

--- a/packages/vlossom/src/components/vs-input/__tests__/vs-input.test.ts
+++ b/packages/vlossom/src/components/vs-input/__tests__/vs-input.test.ts
@@ -72,7 +72,7 @@ describe('vs-input', () => {
             expect(wrapper.find('input').element.value).toBe('test');
         });
 
-        it('type이 number가 아닐 때 modelValue의 타입이 string이 아니면 string 타입으로 가공해준다', async () => {
+        it('input type이 number가 아닐 때 modelValue의 타입이 string이 아니면 string 타입으로 가공해준다', async () => {
             // given
             const wrapper: ReturnType<typeof mountComponent> = mount(VsInput, {
                 props: {
@@ -92,7 +92,7 @@ describe('vs-input', () => {
             expect(updateModelValueEvent?.[0]).toEqual(['123']);
         });
 
-        it('type이 number 일 때 modelValue의 타입이 number가 아니면 number 타입으로 가공해준다', async () => {
+        it('input type이 number 일 때 modelValue의 타입이 number가 아니면 number 타입으로 가공해준다', async () => {
             // given
             const wrapper: ReturnType<typeof mountComponent> = mount(VsInput, {
                 props: {
@@ -113,7 +113,7 @@ describe('vs-input', () => {
             expect(updateModelValueEvent?.[0]).toEqual([123]);
         });
 
-        it('modelValue가 null이고 type이 number가 아니면 빈 문자열로 가공해준다', async () => {
+        it('modelValue가 null이고 input type이 number가 아니면 빈 문자열로 가공해준다', async () => {
             // given
             const wrapper: ReturnType<typeof mountComponent> = mount(VsInput, {
                 props: {
@@ -384,8 +384,8 @@ describe('vs-input', () => {
             // given
             const wrapper: ReturnType<typeof mountComponent> = mount(VsInput, {
                 slots: {
-                    'prepend-button': '<div class="prepend-button"></div>',
-                    'append-button': '<div class="append-button"></div>',
+                    'prepend-button': 'this is button content',
+                    'append-button': 'this is button content',
                 },
             });
 
@@ -420,7 +420,7 @@ describe('vs-input', () => {
             expect(wrapper.vm.computedMessages[0].text).toEqual('required');
         });
 
-        it('type이 number가 아닐 때 max 길이 체크가 가능하다', async () => {
+        it('input type이 number가 아닐 때 max 길이 체크가 가능하다', async () => {
             // given
             const wrapper: ReturnType<typeof mountComponent> = mount(VsInput, {
                 props: {
@@ -440,7 +440,7 @@ describe('vs-input', () => {
             expect(wrapper.vm.computedMessages[0].text).toEqual('max length: 3');
         });
 
-        it('type이 number가 아닐 때 min 길이 체크가 가능하다', async () => {
+        it('input type이 number가 아닐 때 min 길이 체크가 가능하다', async () => {
             // given
             const wrapper: ReturnType<typeof mountComponent> = mount(VsInput, {
                 props: {
@@ -460,7 +460,7 @@ describe('vs-input', () => {
             expect(wrapper.vm.computedMessages[0].text).toEqual('min length: 3');
         });
 
-        it('type이 number 일 때 max 값 체크가 가능하다', async () => {
+        it('input type이 number 일 때 max 값 체크가 가능하다', async () => {
             // given
             const wrapper: ReturnType<typeof mountComponent> = mount(VsInput, {
                 props: {
@@ -481,7 +481,7 @@ describe('vs-input', () => {
             expect(wrapper.vm.computedMessages[0].text).toEqual('max value: 3');
         });
 
-        it('type이 number 일 때 min 값 체크가 가능하다', async () => {
+        it('input type이 number 일 때 min 값 체크가 가능하다', async () => {
             // given
             const wrapper: ReturnType<typeof mountComponent> = mount(VsInput, {
                 props: {

--- a/packages/vlossom/src/components/vs-input/__tests__/vs-input.test.ts
+++ b/packages/vlossom/src/components/vs-input/__tests__/vs-input.test.ts
@@ -117,7 +117,6 @@ describe('vs-input', () => {
             // given
             const wrapper: ReturnType<typeof mountComponent> = mount(VsInput, {
                 props: {
-                    // @ts-expect-error: for null test
                     modelValue: null,
                     'onUpdate:modelValue': (e) => wrapper.setProps({ modelValue: e }),
                 },

--- a/packages/vlossom/src/components/vs-input/__tests__/vs-input.test.ts
+++ b/packages/vlossom/src/components/vs-input/__tests__/vs-input.test.ts
@@ -72,7 +72,7 @@ describe('vs-input', () => {
             expect(wrapper.find('input').element.value).toBe('test');
         });
 
-        it('type이 string 일 때 modelValue의 타입이 string이 아니면 string 타입으로 가공해준다', async () => {
+        it('type이 number가 아닐 때 modelValue의 타입이 string이 아니면 string 타입으로 가공해준다', async () => {
             // given
             const wrapper: ReturnType<typeof mountComponent> = mount(VsInput, {
                 props: {
@@ -113,7 +113,7 @@ describe('vs-input', () => {
             expect(updateModelValueEvent?.[0]).toEqual([123]);
         });
 
-        it('modelValue가 null이고 타입이 string이면 빈 문자열로 가공해준다', async () => {
+        it('modelValue가 null이고 type이 number가 아니면 빈 문자열로 가공해준다', async () => {
             // given
             const wrapper: ReturnType<typeof mountComponent> = mount(VsInput, {
                 props: {
@@ -129,25 +129,6 @@ describe('vs-input', () => {
             // then
             expect(wrapper.find('input').element.value).toBe('');
             expect(wrapper.props('modelValue')).toBe('');
-        });
-
-        it('modelValue가 null이고 타입이 number이면 0으로 가공해준다', async () => {
-            // given
-            const wrapper: ReturnType<typeof mountComponent> = mount(VsInput, {
-                props: {
-                    // @ts-expect-error: for null test
-                    modelValue: null,
-                    'onUpdate:modelValue': (e) => wrapper.setProps({ modelValue: e }),
-                    type: InputType.Number,
-                },
-            });
-
-            // when
-            await nextTick();
-
-            // then
-            expect(wrapper.find('input').element.value).toBe('0');
-            expect(wrapper.props('modelValue')).toBe(0);
         });
     });
 
@@ -211,7 +192,7 @@ describe('vs-input', () => {
     });
 
     describe('clear', () => {
-        it('input 영역을 mouse over 하면 clear 버튼이 나타난다', async () => {
+        it('value가 있으면 clear 버튼이 활성화된다', async () => {
             // given
             const wrapper: ReturnType<typeof mountComponent> = mount(VsInput, {
                 props: {
@@ -220,14 +201,13 @@ describe('vs-input', () => {
                 },
             });
 
-            // when
-            await wrapper.find('.vs-input').trigger('mouseover');
-
             // then
-            expect(wrapper.find('button').exists()).toBe(true);
+            const clearButton = wrapper.find<HTMLButtonElement>('button.clear-button');
+            expect(clearButton.element.disabled).toBeFalsy();
+            expect(clearButton.classes()).toContain('show');
         });
 
-        it('value가 없으면 input 영역을 mouse over 하여도 clear 버튼이 나타나지 않는다', async () => {
+        it('value가 없으면 clear 버튼이 활성화되지 않는다', async () => {
             // given
             const wrapper: ReturnType<typeof mountComponent> = mount(VsInput, {
                 props: {
@@ -240,7 +220,9 @@ describe('vs-input', () => {
             await wrapper.find('.vs-input').trigger('mouseover');
 
             // then
-            expect(wrapper.find('button').exists()).toBe(false);
+            const clearButton = wrapper.find<HTMLButtonElement>('button.clear-button');
+            expect(clearButton.element.disabled).toBeTruthy();
+            expect(clearButton.classes()).not.toContain('show');
         });
 
         it('clear 버튼을 누르면 input 값을 초기화 할 수 있다', async () => {
@@ -280,60 +262,86 @@ describe('vs-input', () => {
     });
 
     describe('prepend / append', () => {
-        it('prepend를 설정할 수 있다', async () => {
+        it('prepend button slot을 설정할 수 있다', async () => {
             // given
             const wrapper: ReturnType<typeof mountComponent> = mount(VsInput, {
                 slots: {
-                    'prepend-icon': '<div class="prepend-icon"></div>',
+                    'prepend-button': 'this is button content',
                 },
             });
 
             // then
-            expect(wrapper.find('button').exists()).toBe(true);
-            expect(wrapper.html()).toContain('prepend-icon');
+            expect(wrapper.find('button.prepend').exists()).toBe(true);
+            expect(wrapper.html()).toContain('this is button content');
         });
 
-        it('append를 설정할 수 있다', async () => {
+        it('append button slot을 설정할 수 있다', async () => {
             // given
             const wrapper: ReturnType<typeof mountComponent> = mount(VsInput, {
                 slots: {
-                    'append-icon': '<div class="append-icon"></div>',
+                    'append-button': 'this is button content',
                 },
             });
 
             // then
-            expect(wrapper.find('button').exists()).toBe(true);
-            expect(wrapper.html()).toContain('append-icon');
+            expect(wrapper.find('button.append').exists()).toBe(true);
+            expect(wrapper.html()).toContain('this is button content');
         });
 
-        it('prepend를 클릭하면 prepend 이벤트를 발생시킨다', async () => {
+        it('prepend button을 클릭하면 prepend 이벤트를 발생시킨다', async () => {
             // given
             const wrapper: ReturnType<typeof mountComponent> = mount(VsInput, {
                 slots: {
-                    'prepend-icon': '<div class="prepend-icon"></div>',
+                    'prepend-button': 'this is button content',
                 },
             });
 
             // when
-            await wrapper.find('button').trigger('click');
+            await wrapper.find('button.prepend').trigger('click');
 
             // then
             expect(wrapper.emitted('prepend')).toHaveLength(1);
         });
 
-        it('append를 클릭하면 append 이벤트를 발생시킨다', async () => {
+        it('append button을 클릭하면 append 이벤트를 발생시킨다', async () => {
             // given
             const wrapper: ReturnType<typeof mountComponent> = mount(VsInput, {
                 slots: {
-                    'append-icon': '<div class="append-icon"></div>',
+                    'append-button': 'this is button content',
                 },
             });
 
             // when
-            await wrapper.find('button').trigger('click');
+            await wrapper.find('button.append').trigger('click');
 
             // then
             expect(wrapper.emitted('append')).toHaveLength(1);
+        });
+
+        it('prepend content slot을 설정할 수 있다', async () => {
+            // given
+            const wrapper: ReturnType<typeof mountComponent> = mount(VsInput, {
+                slots: {
+                    'prepend-content': 'this is content',
+                },
+            });
+
+            // then
+            expect(wrapper.find('div.prepend').exists()).toBe(true);
+            expect(wrapper.html()).toContain('this is content');
+        });
+
+        it('append content slot을 설정할 수 있다', async () => {
+            // given
+            const wrapper: ReturnType<typeof mountComponent> = mount(VsInput, {
+                slots: {
+                    'append-content': 'this is content',
+                },
+            });
+
+            // then
+            expect(wrapper.find('div.append').exists()).toBe(true);
+            expect(wrapper.html()).toContain('this is content');
         });
     });
 
@@ -373,12 +381,12 @@ describe('vs-input', () => {
             expect(wrapper.emitted('enter')).toHaveLength(1);
         });
 
-        it('prepend와 append가 있을 경우 prepend, append 이벤트도 함께 발생시킨다', async () => {
+        it('prepend button과 append button이 있을 경우 prepend, append 이벤트도 함께 발생시킨다', async () => {
             // given
             const wrapper: ReturnType<typeof mountComponent> = mount(VsInput, {
                 slots: {
-                    'prepend-icon': '<div class="prepend-icon"></div>',
-                    'append-icon': '<div class="append-icon"></div>',
+                    'prepend-button': '<div class="prepend-button"></div>',
+                    'append-button': '<div class="append-button"></div>',
                 },
             });
 
@@ -413,7 +421,7 @@ describe('vs-input', () => {
             expect(wrapper.vm.computedMessages[0].text).toEqual('required');
         });
 
-        it('type이 string 일 때 max 체크가 가능하다', async () => {
+        it('type이 number가 아닐 때 max 길이 체크가 가능하다', async () => {
             // given
             const wrapper: ReturnType<typeof mountComponent> = mount(VsInput, {
                 props: {
@@ -433,7 +441,27 @@ describe('vs-input', () => {
             expect(wrapper.vm.computedMessages[0].text).toEqual('max length: 3');
         });
 
-        it('type이 number 일 때 max 체크가 가능하다', async () => {
+        it('type이 number가 아닐 때 min 길이 체크가 가능하다', async () => {
+            // given
+            const wrapper: ReturnType<typeof mountComponent> = mount(VsInput, {
+                props: {
+                    modelValue: 'test',
+                    'onUpdate:modelValue': (e) => wrapper.setProps({ modelValue: e }),
+                    min: 3,
+                },
+            });
+
+            // when
+            await nextTick();
+            await wrapper.find('input').setValue('te');
+
+            // then
+            expect(wrapper.vm.computedMessages).toHaveLength(1);
+            expect(wrapper.vm.computedMessages[0].state).toEqual(UIState.Error);
+            expect(wrapper.vm.computedMessages[0].text).toEqual('min length: 3');
+        });
+
+        it('type이 number 일 때 max 값 체크가 가능하다', async () => {
             // given
             const wrapper: ReturnType<typeof mountComponent> = mount(VsInput, {
                 props: {
@@ -454,27 +482,7 @@ describe('vs-input', () => {
             expect(wrapper.vm.computedMessages[0].text).toEqual('max value: 3');
         });
 
-        it('type이 string 일 때 min 체크가 가능하다', async () => {
-            // given
-            const wrapper: ReturnType<typeof mountComponent> = mount(VsInput, {
-                props: {
-                    modelValue: 'test',
-                    'onUpdate:modelValue': (e) => wrapper.setProps({ modelValue: e }),
-                    min: 3,
-                },
-            });
-
-            // when
-            await nextTick();
-            await wrapper.find('input').setValue('te');
-
-            // then
-            expect(wrapper.vm.computedMessages).toHaveLength(1);
-            expect(wrapper.vm.computedMessages[0].state).toEqual(UIState.Error);
-            expect(wrapper.vm.computedMessages[0].text).toEqual('min length: 3');
-        });
-
-        it('type이 number 일 때 min 체크가 가능하다', async () => {
+        it('type이 number 일 때 min 값 체크가 가능하다', async () => {
             // given
             const wrapper: ReturnType<typeof mountComponent> = mount(VsInput, {
                 props: {

--- a/packages/vlossom/src/components/vs-input/stories/VsInput.stories.ts
+++ b/packages/vlossom/src/components/vs-input/stories/VsInput.stories.ts
@@ -103,10 +103,20 @@ export const NoClear: Story = {
     },
 };
 
-export const NumberType: Story = {
-    args: {
-        type: 'number',
-    },
+export const Type: Story = {
+    render: () => ({
+        components: { VsInput },
+        setup() {
+            const types = Object.values(InputType);
+
+            return { types };
+        },
+        template: `
+            <div>
+                <vs-input v-for="type in types" :key="type" :type="type" :placeholder="type" style="marginBottom: 10px" />
+            </div>
+        `,
+    }),
 };
 
 export const Placeholder: Story = {
@@ -128,7 +138,7 @@ export const Required: Story = {
     },
 };
 
-export const Prepend: Story = {
+export const PrependButton: Story = {
     render: (args: any) => ({
         components: { VsInput },
         setup() {
@@ -136,8 +146,8 @@ export const Prepend: Story = {
         },
         template: `
             <vs-input v-bind="args">
-                <template #prepend-icon>
-                    <svg aria-label="edit" xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 -960 960 960" width="24">
+                <template #prepend-button>
+                    <svg aria-label="edit" xmlns="http://www.w3.org/2000/svg" height="20" viewBox="0 -960 960 960" width="20">
                         <path fill="currentColor" d="M200-200h57l391-391-57-57-391 391v57Zm-80 80v-170l528-527q12-11 26.5-17t30.5-6q16 0 31 6t26 18l55 56q12 11 17.5 26t5.5 30q0 16-5.5 30.5T817-647L290-120H120Zm640-584-56-56 56 56Zm-141 85-28-29 57 57-29-28Z"/>
                     </svg>
                 </template>
@@ -152,7 +162,7 @@ export const Prepend: Story = {
     },
 };
 
-export const Append: Story = {
+export const AppendButton: Story = {
     render: (args: any) => ({
         components: { VsInput, VsIcon },
         setup() {
@@ -160,8 +170,52 @@ export const Append: Story = {
         },
         template: `
             <vs-input v-bind="args">
-                <template #append-icon>
+                <template #append-button>
                     <vs-icon icon="check" />
+                </template>
+            </vs-input>
+        `,
+    }),
+    args: {
+        placeholder: 'email',
+    },
+    parameters: {
+        chromatic: chromaticParameters.theme,
+    },
+};
+
+export const PrependContent: Story = {
+    render: (args: any) => ({
+        components: { VsInput },
+        setup() {
+            return { args };
+        },
+        template: `
+            <vs-input v-bind="args">
+                <template #prepend-content>
+                    <div style="padding: 3px">prepend</div>
+                </template>
+            </vs-input>
+        `,
+    }),
+    args: {
+        placeholder: 'email',
+    },
+    parameters: {
+        chromatic: chromaticParameters.theme,
+    },
+};
+
+export const AppendContent: Story = {
+    render: (args: any) => ({
+        components: { VsInput, VsIcon },
+        setup() {
+            return { args };
+        },
+        template: `
+            <vs-input v-bind="args">
+                <template #append-content>
+                    <div style="padding: 3px">append</div>
                 </template>
             </vs-input>
         `,

--- a/packages/vlossom/src/components/vs-input/stories/VsInput.stories.ts
+++ b/packages/vlossom/src/components/vs-input/stories/VsInput.stories.ts
@@ -28,7 +28,7 @@ const meta: Meta<typeof VsInput> = {
         colorScheme,
         type: {
             control: 'radio',
-            options: [InputType.Text, InputType.Number],
+            options: Object.values(InputType),
         },
     },
 };

--- a/packages/vlossom/src/components/vs-input/types.ts
+++ b/packages/vlossom/src/components/vs-input/types.ts
@@ -1,5 +1,15 @@
 export type InputValueType = string | number | null;
 
+export enum InputType {
+    Email = 'email',
+    Number = 'number',
+    Password = 'password',
+    Search = 'search',
+    Tel = 'tel',
+    Text = 'text',
+    Url = 'url',
+}
+
 export interface VsInputStyleSet {
     appendBackgroundColor?: string;
     appendColor?: string;
@@ -12,14 +22,4 @@ export interface VsInputStyleSet {
     height?: string;
     prependBackgroundColor?: string;
     prependColor?: string;
-}
-
-export enum InputType {
-    Email = 'email',
-    Number = 'number',
-    Password = 'password',
-    Search = 'search',
-    Tel = 'tel',
-    Text = 'text',
-    Url = 'url',
 }

--- a/packages/vlossom/src/components/vs-input/types.ts
+++ b/packages/vlossom/src/components/vs-input/types.ts
@@ -1,4 +1,4 @@
-export type InputValueType = string | number;
+export type InputValueType = string | number | null;
 
 export interface VsInputStyleSet {
     appendBackgroundColor?: string;
@@ -15,6 +15,11 @@ export interface VsInputStyleSet {
 }
 
 export enum InputType {
-    Text = 'text',
+    Email = 'email',
     Number = 'number',
+    Password = 'password',
+    Search = 'search',
+    Tel = 'tel',
+    Text = 'text',
+    Url = 'url',
 }

--- a/packages/vlossom/src/components/vs-input/vs-input-rules.ts
+++ b/packages/vlossom/src/components/vs-input/vs-input-rules.ts
@@ -5,7 +5,7 @@ export function useVsInputRules(
     required: Ref<boolean>,
     max: Ref<number | string>,
     min: Ref<number | string>,
-    type: Ref<string>,
+    type: Ref<InputType>,
 ) {
     function requiredCheck(v: InputValueType) {
         if (required.value && v === '') {
@@ -22,12 +22,12 @@ export function useVsInputRules(
             return '';
         }
 
-        if (type.value === InputType.Text && typeof v === 'string' && v.length > limit) {
-            return 'max length: ' + max.value;
-        }
-
         if (type.value === InputType.Number && typeof v === 'number' && v > limit) {
             return 'max value: ' + max.value;
+        }
+
+        if (type.value !== InputType.Number && typeof v === 'string' && v.length > limit) {
+            return 'max length: ' + max.value;
         }
 
         return '';
@@ -40,12 +40,12 @@ export function useVsInputRules(
             return '';
         }
 
-        if (type.value === InputType.Text && typeof v === 'string' && v.length < limit) {
-            return 'min length: ' + min.value;
-        }
-
         if (type.value === InputType.Number && typeof v === 'number' && v < limit) {
             return 'min value: ' + min.value;
+        }
+
+        if (type.value !== InputType.Number && typeof v === 'string' && v.length < limit) {
+            return 'min length: ' + min.value;
         }
 
         return '';

--- a/packages/vlossom/src/components/vs-input/vs-input-rules.ts
+++ b/packages/vlossom/src/components/vs-input/vs-input-rules.ts
@@ -18,7 +18,7 @@ export function useVsInputRules(
     function maxCheck(v: InputValueType) {
         const limit = Number(max.value);
 
-        if (isNaN(limit) || limit > Number.MAX_SAFE_INTEGER) {
+        if (max.value === null || isNaN(limit) || limit > Number.MAX_SAFE_INTEGER) {
             return '';
         }
 
@@ -36,7 +36,7 @@ export function useVsInputRules(
     function minCheck(v: InputValueType) {
         const limit = Number(min.value);
 
-        if (isNaN(limit) || limit < Number.MIN_SAFE_INTEGER) {
+        if (min.value === null || isNaN(limit) || limit < Number.MIN_SAFE_INTEGER) {
             return '';
         }
 

--- a/packages/vlossom/src/components/vs-input/vs-input-rules.ts
+++ b/packages/vlossom/src/components/vs-input/vs-input-rules.ts
@@ -18,7 +18,7 @@ export function useVsInputRules(
     function maxCheck(v: InputValueType) {
         const limit = Number(max.value);
 
-        if (max.value === null || isNaN(limit) || limit > Number.MAX_SAFE_INTEGER) {
+        if (isNaN(limit) || limit > Number.MAX_SAFE_INTEGER) {
             return '';
         }
 
@@ -36,7 +36,7 @@ export function useVsInputRules(
     function minCheck(v: InputValueType) {
         const limit = Number(min.value);
 
-        if (min.value === null || isNaN(limit) || limit < Number.MIN_SAFE_INTEGER) {
+        if (isNaN(limit) || limit < Number.MIN_SAFE_INTEGER) {
             return '';
         }
 

--- a/packages/vlossom/src/components/vs-textarea/VsTextarea.vue
+++ b/packages/vlossom/src/components/vs-textarea/VsTextarea.vue
@@ -22,7 +22,7 @@
                 :name="name"
                 :disabled="disabled"
                 :readonly="readonly"
-                :required="required"
+                :aria-required="required"
                 :placeholder="placeholder"
                 @input="updateValue($event)"
                 @focus="onFocus"

--- a/packages/vlossom/src/nodes/vs-checkbox-node/VsCheckboxNode.vue
+++ b/packages/vlossom/src/nodes/vs-checkbox-node/VsCheckboxNode.vue
@@ -11,7 +11,7 @@
                 :name="name"
                 :value="convertToString(value)"
                 :checked="checked"
-                :required="required"
+                :aria-required="required"
                 @change="toggle"
                 @focus="onFocus"
                 @blur="onBlur"


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Feature (feat)

## Summary
vs-input의 prop type 종류를 여러 텍스트 입력 타입들로 확장 (text, tel, search, url, password, email, number)
prepend, append content slot 추가

## Description
content slot : password type 의 경우 visibility 토글 기능을 사용자 쪽에서 content slot을 통해 추가할 수 있습니다

<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
