### PR TITLE
fix(anchor-positioning-composable): recalculate placement

### DIFF
--- a/packages/vlossom/src/composables/__tests__/anchor-positioning-composable.test.ts
+++ b/packages/vlossom/src/composables/__tests__/anchor-positioning-composable.test.ts
@@ -1,21 +1,27 @@
 import { describe, expect, it, beforeEach } from 'vitest';
 import { mount } from '@vue/test-utils';
-import { defineComponent, nextTick, ref, Ref } from 'vue';
+import { defineComponent, nextTick, ref, type Ref } from 'vue';
 import { usePositioning, useOverlay } from '@/composables';
 
 describe('anchor-positioning-composable', () => {
-    describe('useDomAttach', async () => {
+    describe('usePositioning', async () => {
         // given
-        const attachment = document.createElement('div');
-        document.body.appendChild(attachment);
 
         const TargetComponent = defineComponent({
-            template: '<div ref="anchorRef">anchor</div>',
+            template: `
+                <div ref="anchorRef">anchor</div>
+                <div ref="attachmentRef">attachment</div>
+            `,
             setup() {
                 const anchorRef: Ref<HTMLElement | null> = ref(null);
+                const attachmentRef: Ref<HTMLElement | null> = ref(null);
 
-                const { isVisible, appear, disappear } = usePositioning(anchorRef as Ref<HTMLElement>, ref(attachment));
-                return { anchorRef, isVisible, appear, disappear };
+                const { isVisible, appear, disappear } = usePositioning(
+                    anchorRef as Ref<HTMLElement>,
+                    attachmentRef as Ref<HTMLElement>,
+                );
+
+                return { anchorRef, attachmentRef, isVisible, appear, disappear };
             },
         });
 
@@ -24,7 +30,6 @@ describe('anchor-positioning-composable', () => {
         it('appear 호출 시 isVisible이 true가 된다', async () => {
             // when
             wrapper.vm.appear();
-            await nextTick();
 
             // then
             expect(wrapper.vm.isVisible).toBe(true);
@@ -33,7 +38,6 @@ describe('anchor-positioning-composable', () => {
         it('disappear 호출 시 isVisible이 false가 된다', async () => {
             // when
             wrapper.vm.disappear();
-            await nextTick();
 
             // then
             expect(wrapper.vm.isVisible).toBe(false);
@@ -47,28 +51,14 @@ describe('anchor-positioning-composable', () => {
 
         it('useOverlay를 호출하면 #vs-overlay를 document에 추가한다', async () => {
             // given
-            const TargetComponent = defineComponent({
-                template: `
-                    <div ref="anchorRef">target</div>
-                    <Teleport to="vs-overlay">
-                        <div ref="attchmentRef">attachment</div>
-                    </Teleport>
-                `,
+            const Component = defineComponent({
+                template: '<div></div>',
                 setup() {
-                    const anchorRef: Ref<HTMLElement | null> = ref(null);
-                    const attachmentRef: Ref<HTMLElement | null> = ref(null);
-
                     useOverlay();
-
-                    const { isVisible, appear, disappear } = usePositioning(
-                        anchorRef as Ref<HTMLElement>,
-                        attachmentRef as Ref<HTMLElement>,
-                    );
-
-                    return { anchorRef, attachmentRef, isVisible, appear, disappear };
+                    return {};
                 },
             });
-            mount(TargetComponent);
+            mount(Component);
 
             // when
             await nextTick();

--- a/packages/vlossom/src/composables/anchor-positioning-composable.ts
+++ b/packages/vlossom/src/composables/anchor-positioning-composable.ts
@@ -44,13 +44,13 @@ export function usePositioning(anchor: Ref<HTMLElement>, attachment: Ref<HTMLEle
 
         // Change placements when there are no spaces in the viewport.
         if (placement === 'bottom' && bottom + attachmentHeight > window.innerHeight) {
-            computedPlacement.value = 'top';
+            computedPlacement.value = window.innerHeight - bottom < top ? 'top' : 'bottom';
         } else if (placement === 'top' && top - attachmentHeight < 0) {
-            computedPlacement.value = 'bottom';
+            computedPlacement.value = window.innerHeight - bottom > top ? 'bottom' : 'top';
         } else if (placement === 'left' && left - attachmentWidth < 0) {
-            computedPlacement.value = 'right';
+            computedPlacement.value = window.innerWidth - right > left ? 'right' : 'left';
         } else if (placement === 'right' && right + attachmentWidth > window.innerWidth) {
-            computedPlacement.value = 'left';
+            computedPlacement.value = window.innerWidth - right < left ? 'left' : 'right';
         } else {
             computedPlacement.value = placement;
         }


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary
anchor positioning composable에서 computed placement 계산 로직을 변경합니다

## Description
Fix 내용 :
기존 로직 상으로는 placement가 bottom이고 attachment가 viewport 범위를 넘어갈 때 위쪽 상황이 어떻든 무조건 top에 위치하게 됨
이럴 경우 위쪽보다 아래쪽 공간이 더 많은 경우엔 bottom에 위치시키는 것이 맞음

<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
