### PR TITLE
fix(VsFocusTrap): remove focuses on the first element

### DIFF
--- a/packages/vlossom/src/components/vs-file-input/VsFileInput.vue
+++ b/packages/vlossom/src/components/vs-file-input/VsFileInput.vue
@@ -50,6 +50,8 @@
                 <button
                     v-if="!noClear && hasValue && !readonly && !disabled"
                     class="clear-button"
+                    aria-hidden="true"
+                    tabindex="-1"
                     @click.stop="onClear()"
                 >
                     <vs-icon icon="close" :size="dense ? 16 : 20" />

--- a/packages/vlossom/src/components/vs-focus-trap/VsFocusTrap.vue
+++ b/packages/vlossom/src/components/vs-focus-trap/VsFocusTrap.vue
@@ -4,6 +4,7 @@ import {
     ref,
     toRefs,
     cloneVNode,
+    h,
     onMounted,
     onBeforeUnmount,
     computed,
@@ -23,6 +24,7 @@ export default defineComponent({
     setup(props, { slots }) {
         const { focusLock, initialFocusRef } = toRefs(props);
 
+        const focusTrapRef: Ref<HTMLElement | null> = ref(null);
         const wrapperRef: Ref<HTMLElement | ComponentPublicInstance | null> = ref(null);
 
         const wrapperElement = computed(() => {
@@ -80,7 +82,8 @@ export default defineComponent({
             }
 
             const focusables = wrapperElement.value.querySelectorAll<HTMLElement>(
-                'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+                `button:not([tabindex="-1"]), [href]:not([tabindex="-1"]), input:not([tabindex="-1"]),
+                select:not([tabindex="-1"]), textarea:not([tabindex="-1"]), [tabindex]:not([tabindex="-1"])`,
             );
             if (!focusables.length) {
                 return;
@@ -99,7 +102,7 @@ export default defineComponent({
                 if (initialFocusRef.value) {
                     initialFocusRef.value.focus();
                 } else {
-                    firstFocusable?.focus();
+                    focusTrapRef.value?.focus();
                 }
             });
         });
@@ -132,7 +135,10 @@ export default defineComponent({
                 }
             });
 
-            return cloneVNode(vNodes[0], { ref: wrapperRef });
+            return h('div', { class: 'vs-focus-trap' }, [
+                h('div', { tabindex: -1, ref: focusTrapRef }),
+                cloneVNode(vNodes[0], { ref: wrapperRef }),
+            ]);
         }
 
         return () => render();

--- a/packages/vlossom/src/components/vs-focus-trap/__tests__/vs-focus-trap.test.ts
+++ b/packages/vlossom/src/components/vs-focus-trap/__tests__/vs-focus-trap.test.ts
@@ -1,12 +1,23 @@
 import { describe, expect, it, beforeEach } from 'vitest';
 import { mount } from '@vue/test-utils';
-import { nextTick } from 'vue';
+import { nextTick, ref, defineComponent, Ref } from 'vue';
 import VsFocusTrap from '../VsFocusTrap.vue';
 
-const slot = `<div>
-    <input />
-    <button>close</button>
-</div>`;
+const Component = defineComponent({
+    template: `
+        <div>
+            <input />
+            <button ref="buttonRef">close</button>
+        </div>
+    `,
+    setup() {
+        const buttonRef: Ref<HTMLElement | null> = ref(null);
+
+        return {
+            buttonRef,
+        };
+    },
+});
 
 beforeEach(() => {
     document.body.innerHTML = '';
@@ -14,11 +25,11 @@ beforeEach(() => {
 
 describe('focus-trap', () => {
     describe('catch focus', () => {
-        it('mount 되고 나서 가장 첫번째 focusable 요소에 focus를 준다', async () => {
+        it('mount 되고 나서 vs-focus-trap 쪽으로 focus를 가져온다', async () => {
             // given
             const wrapper = mount(VsFocusTrap, {
                 slots: {
-                    default: slot,
+                    default: Component,
                 },
                 attachTo: document.body,
             });
@@ -26,14 +37,14 @@ describe('focus-trap', () => {
             await nextTick();
 
             // then
-            expect(wrapper.find('input').element).toBe(document.activeElement);
+            expect(wrapper.find('.vs-focus-trap>div[tabindex="-1"]').element).toBe(document.activeElement);
         });
 
         it('initial-focus-ref prop이 지정되어 있다면 mount 되고 나서 해당 요소에 focus를 준다', async () => {
             // given
             const wrapper = mount(VsFocusTrap, {
                 slots: {
-                    default: slot,
+                    default: Component,
                 },
                 attachTo: document.body,
             });
@@ -50,7 +61,7 @@ describe('focus-trap', () => {
             // given
             const wrapper = mount(VsFocusTrap, {
                 slots: {
-                    default: slot,
+                    default: Component,
                 },
                 attachTo: document.body,
             });
@@ -58,7 +69,8 @@ describe('focus-trap', () => {
             await nextTick();
 
             // when
-            wrapper.find('button').trigger('keydown.Tab');
+            await wrapper.find('button').element.focus();
+            await wrapper.find('button').trigger('keydown.Tab');
 
             // then
             expect(wrapper.find('input').element).toBe(document.activeElement);
@@ -68,7 +80,7 @@ describe('focus-trap', () => {
             // given
             const wrapper = mount(VsFocusTrap, {
                 slots: {
-                    default: slot,
+                    default: Component,
                 },
                 attachTo: document.body,
             });
@@ -76,7 +88,8 @@ describe('focus-trap', () => {
             await nextTick();
 
             // when
-            wrapper.find('input').trigger('keydown.Tab', {
+            await wrapper.find('input').element.focus();
+            await wrapper.find('input').trigger('keydown.Tab', {
                 shiftKey: true,
             });
 
@@ -90,7 +103,7 @@ describe('focus-trap', () => {
 
             const wrapper = mount(VsFocusTrap, {
                 slots: {
-                    default: slot,
+                    default: Component,
                 },
                 props: {
                     focusLock: false,
@@ -119,7 +132,7 @@ describe('focus-trap', () => {
 
             const wrapper = mount(VsFocusTrap, {
                 slots: {
-                    default: slot,
+                    default: Component,
                 },
                 attachTo: document.body,
             });

--- a/packages/vlossom/src/components/vs-focus-trap/__tests__/vs-focus-trap.test.ts
+++ b/packages/vlossom/src/components/vs-focus-trap/__tests__/vs-focus-trap.test.ts
@@ -25,7 +25,7 @@ beforeEach(() => {
 
 describe('focus-trap', () => {
     describe('catch focus', () => {
-        it('mount 되고 나서 vs-focus-trap 쪽으로 focus를 가져온다', async () => {
+        it('mount 되고 나서 vs-focus-trap이 감싸고 있는 영역으로 focus를 가져온다', async () => {
             // given
             const wrapper = mount(VsFocusTrap, {
                 slots: {

--- a/packages/vlossom/src/components/vs-input/VsInput.vue
+++ b/packages/vlossom/src/components/vs-input/VsInput.vue
@@ -51,7 +51,8 @@
                     class="clear-button"
                     :class="{ show: inputValue }"
                     :disabled="!inputValue"
-                    aria-label="clear"
+                    aria-hidden="true"
+                    tabindex="-1"
                     @click.stop="clearWithFocus()"
                 >
                     <vs-icon icon="close" :size="dense ? 16 : 20" />

--- a/packages/vlossom/src/components/vs-select/VsSelect.vue
+++ b/packages/vlossom/src/components/vs-select/VsSelect.vue
@@ -79,7 +79,8 @@
                     v-if="!noClear && selectedOptions.length && !readonly && !disabled"
                     type="button"
                     class="clear-button"
-                    aria-label="clear"
+                    aria-hidden="true"
+                    tabindex="-1"
                     @click.stop="onClear()"
                 >
                     <vs-icon icon="close" :size="dense ? 16 : 20" />

--- a/packages/vlossom/src/components/vs-select/__tests__/vs-select.test.ts
+++ b/packages/vlossom/src/components/vs-select/__tests__/vs-select.test.ts
@@ -813,7 +813,7 @@ describe('vs-select', () => {
 
             // when
             await wrapper.find('input').trigger('mouseover');
-            await wrapper.find('button[aria-label="clear"').trigger('click');
+            await wrapper.find('button.clear-button').trigger('click');
 
             // then
             expect(wrapper.vm.computedMessages).toHaveLength(1);


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary
focus trap이 감싸고 있는 영역으로 keyboard navigation focus를 가져오는 방식을 변경합니다

## Description
기존에는 첫번째 focusable 요소에 focus를 줬지만 이 방식은 스크롤링 이슈가 발생할 수 있어 수정합니다


<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
