### PR TITLE
refactor(VsTable): move useTableExpand to VsTableBody

### DIFF
--- a/packages/vlossom/src/components/vs-table/VsTable.vue
+++ b/packages/vlossom/src/components/vs-table/VsTable.vue
@@ -121,8 +121,8 @@ export default defineComponent({
         const hasExpand = computed(() => !!slots['expand']);
         const tableBodyRef: Ref<typeof VsTableBody | null> = ref(null);
 
-        const expand = () => {
-            return tableBodyRef.value?.expand();
+        const expand = (index: number) => {
+            return tableBodyRef.value?.expand(index);
         };
 
         return {

--- a/packages/vlossom/src/components/vs-table/VsTableBodyRow.vue
+++ b/packages/vlossom/src/components/vs-table/VsTableBodyRow.vue
@@ -29,7 +29,7 @@
             <button
                 v-if="isExpandableRow"
                 type="button"
-                @click.stop="onToggleExpand(item.id)"
+                @click.stop="emitToggleExpand(item.id)"
                 :disabled="loading"
                 :class="{ expanded }"
                 :aria-label="`expand ${item.id}`"
@@ -108,17 +108,17 @@ export default defineComponent({
             return !Object.keys(item.value.data).length;
         });
 
-        function onToggleExpand(id: string) {
+        function emitToggleExpand(id: string) {
             emit('toggleExpand', id);
         }
 
         return {
             isDummyRow,
+            isExpandableRow,
             getRowData,
             getHeader,
             getTableData,
-            onToggleExpand,
-            isExpandableRow,
+            emitToggleExpand,
         };
     },
 });

--- a/packages/vlossom/src/components/vs-table/composables/useTableExpand.ts
+++ b/packages/vlossom/src/components/vs-table/composables/useTableExpand.ts
@@ -1,7 +1,11 @@
 import { Ref, ref } from 'vue';
 
-export default function useTableExpand(expandable: Ref<boolean>) {
+export function useTableExpand(expandable: Ref<boolean>) {
     const expandedIds: Ref<string[]> = ref([]);
+
+    function isExpanded(id: string): boolean {
+        return expandedIds.value.includes(id);
+    }
 
     function toggleExpand(id: string) {
         if (!expandable.value) {
@@ -18,7 +22,7 @@ export default function useTableExpand(expandable: Ref<boolean>) {
     }
 
     return {
-        expandedIds,
+        isExpanded,
         toggleExpand,
     };
 }


### PR DESCRIPTION
## Type of PR (check all applicable)
-  [x] Refactor (refactor)

## Summary
- useTableExpand를 VsTableBody에서 사용하는 구조로 수정하였습니다




