### PR TITLE
feat(props): rename props (noMsg, mobile-full, column)

### DIFF
--- a/packages/vlossom/src/components/vs-checkbox-set/VsCheckboxSet.scss
+++ b/packages/vlossom/src/components/vs-checkbox-set/VsCheckboxSet.scss
@@ -2,7 +2,7 @@
     display: flex;
     align-items: center;
 
-    &.column {
+    &.vertical {
         flex-direction: column;
         align-items: flex-start;
     }

--- a/packages/vlossom/src/components/vs-checkbox-set/VsCheckboxSet.vue
+++ b/packages/vlossom/src/components/vs-checkbox-set/VsCheckboxSet.vue
@@ -4,7 +4,7 @@
             :label="label"
             :messages="computedMessages"
             :no-label="noLabel"
-            :no-msg="noMsg"
+            :no-message="noMessage"
             :required="required"
             :shake="shake"
             :state="state"
@@ -46,7 +46,7 @@
                 </vs-check-node>
             </div>
 
-            <template #messages v-if="!noMsg">
+            <template #messages v-if="!noMessage">
                 <slot name="messages" />
             </template>
         </vs-input-wrapper>

--- a/packages/vlossom/src/components/vs-checkbox-set/VsCheckboxSet.vue
+++ b/packages/vlossom/src/components/vs-checkbox-set/VsCheckboxSet.vue
@@ -14,7 +14,7 @@
                 <slot name="label" />
             </template>
 
-            <div :class="['vs-checkbox-set', { column }]" :style="checkboxSetStyleSet">
+            <div :class="['vs-checkbox-set', { vertical }]" :style="checkboxSetStyleSet">
                 <vs-check-node
                     v-for="(option, index) in options"
                     :key="getOptionValue(option)"
@@ -88,7 +88,7 @@ export default defineComponent({
             type: Function as PropType<(checked: boolean, target: any) => Promise<boolean> | null>,
             default: null,
         },
-        column: { type: Boolean, default: false },
+        vertical: { type: Boolean, default: false },
         // v-model
         modelValue: { type: Array as PropType<any[]>, default: () => [] },
     },

--- a/packages/vlossom/src/components/vs-checkbox-set/stories/VsCheckboxSet.stories.ts
+++ b/packages/vlossom/src/components/vs-checkbox-set/stories/VsCheckboxSet.stories.ts
@@ -99,9 +99,9 @@ export const Required: Story = {
     },
 };
 
-export const Column: Story = {
+export const Vertical: Story = {
     args: {
-        column: true,
+        vertical: true,
     },
 };
 

--- a/packages/vlossom/src/components/vs-checkbox/VsCheckbox.vue
+++ b/packages/vlossom/src/components/vs-checkbox/VsCheckbox.vue
@@ -5,7 +5,7 @@
             :label="label"
             :messages="computedMessages"
             :no-label="noLabel"
-            :no-msg="noMsg"
+            :no-message="noMessage"
             :required="required"
             :shake="shake"
             :state="state"
@@ -37,7 +37,7 @@
                 </template>
             </vs-check-node>
 
-            <template #messages v-if="!noMsg">
+            <template #messages v-if="!noMessage">
                 <slot name="messages" />
             </template>
         </vs-input-wrapper>

--- a/packages/vlossom/src/components/vs-divider/VsDivider.scss
+++ b/packages/vlossom/src/components/vs-divider/VsDivider.scss
@@ -30,7 +30,7 @@
 }
 
 @media screen and (max-width: 768px) {
-    .vs-divider.vertical.mobile-full {
+    .vs-divider.vertical.responsive {
         @include vs-divider-horizontal;
         margin: 0;
     }

--- a/packages/vlossom/src/components/vs-divider/VsDivider.vue
+++ b/packages/vlossom/src/components/vs-divider/VsDivider.vue
@@ -16,10 +16,10 @@ export default defineComponent({
         colorScheme: { type: String as PropType<ColorScheme> },
         styleSet: { type: [String, Object] as PropType<string | VsDividerStyleSet> },
         vertical: { type: Boolean, default: false },
-        mobileFull: { type: Boolean, default: false },
+        responsive: { type: Boolean, default: false },
     },
     setup(props) {
-        const { colorScheme, styleSet, mobileFull, vertical } = toRefs(props);
+        const { colorScheme, styleSet, responsive, vertical } = toRefs(props);
 
         const { computedColorScheme } = useColorScheme(name, colorScheme);
 
@@ -28,7 +28,7 @@ export default defineComponent({
         const classObj = computed(() => ({
             horizontal: !vertical.value,
             vertical: vertical.value,
-            'mobile-full': mobileFull.value,
+            responsive: responsive.value,
         }));
 
         return {

--- a/packages/vlossom/src/components/vs-divider/__tests__/vs-divider.test.ts
+++ b/packages/vlossom/src/components/vs-divider/__tests__/vs-divider.test.ts
@@ -45,19 +45,19 @@ describe('vs-divider', () => {
         });
     });
 
-    describe('mobile-full', () => {
-        it('vertical과 mobile-full props를 설정하면 각각의 class를 가진다.', () => {
+    describe('responsive', () => {
+        it('vertical과 responsive props를 설정하면 각각의 class를 가진다.', () => {
             //given
             const wrapper = mount(VsDivider, {
                 props: {
                     vertical: true,
-                    mobileFull: true,
+                    responsive: true,
                 },
             });
 
             //then
             expect(wrapper.classes('vertical')).toBe(true);
-            expect(wrapper.classes('mobile-full')).toBe(true);
+            expect(wrapper.classes('responsive')).toBe(true);
         });
     });
 });

--- a/packages/vlossom/src/components/vs-divider/stories/VsDivider.stories.ts
+++ b/packages/vlossom/src/components/vs-divider/stories/VsDivider.stories.ts
@@ -73,7 +73,7 @@ export const Vertical: Story = {
 export const VerticalWithMobileFull: Story = {
     args: {
         vertical: true,
-        mobileFull: true,
+        responsive: true,
     },
     render: (args: any) => ({
         components: { VsDivider },

--- a/packages/vlossom/src/components/vs-file-input/VsFileInput.vue
+++ b/packages/vlossom/src/components/vs-file-input/VsFileInput.vue
@@ -5,7 +5,7 @@
             :label="label"
             :messages="computedMessages"
             :no-label="noLabel"
-            :no-msg="noMsg"
+            :no-message="noMessage"
             :required="required"
             :shake="shake"
             :state="state"
@@ -59,7 +59,7 @@
                 </button>
             </div>
 
-            <template #messages v-if="!noMsg">
+            <template #messages v-if="!noMessage">
                 <slot name="messages" />
             </template>
         </vs-input-wrapper>

--- a/packages/vlossom/src/components/vs-input-wrapper/VsInputWrapper.vue
+++ b/packages/vlossom/src/components/vs-input-wrapper/VsInputWrapper.vue
@@ -17,7 +17,7 @@
         </component>
 
         <slot name="messages">
-            <div class="vs-messages" v-if="!noMsg">
+            <div class="vs-messages" v-if="!noMessage">
                 <vs-message v-for="(message, index) in messages" :key="`${index}-${message.text}`" :message="message" />
             </div>
         </slot>
@@ -39,7 +39,7 @@ export default defineComponent({
         label: { type: String, default: '' },
         messages: { type: Array as PropType<StateMessage[]>, default: () => [] },
         noLabel: { type: Boolean, default: false },
-        noMsg: { type: Boolean, default: false },
+        noMessage: { type: Boolean, default: false },
         required: { type: Boolean, default: false },
         shake: { type: Boolean, default: false },
         state: { type: String as PropType<UIState>, default: UIState.Idle },

--- a/packages/vlossom/src/components/vs-input-wrapper/__tests__/vs-input-wrapper.test.ts
+++ b/packages/vlossom/src/components/vs-input-wrapper/__tests__/vs-input-wrapper.test.ts
@@ -75,11 +75,11 @@ describe('vs-input-wrapper', () => {
     });
 
     describe('messages', () => {
-        it('noMsg props가 전달되면 message 영역이 보이지 않는다', () => {
+        it('noMessage props가 전달되면 message 영역이 보이지 않는다', () => {
             // given
             const wrapper = mount(VsInputWrapper, {
                 props: {
-                    noMsg: true,
+                    noMessage: true,
                 },
             });
 

--- a/packages/vlossom/src/components/vs-input/VsInput.vue
+++ b/packages/vlossom/src/components/vs-input/VsInput.vue
@@ -5,7 +5,7 @@
             :label="label"
             :messages="computedMessages"
             :no-label="noLabel"
-            :no-msg="noMsg"
+            :no-message="noMessage"
             :required="required"
             :shake="shake"
             :state="state"
@@ -71,7 +71,7 @@
                 </button>
             </div>
 
-            <template #messages v-if="!noMsg">
+            <template #messages v-if="!noMessage">
                 <slot name="messages" />
             </template>
         </vs-input-wrapper>

--- a/packages/vlossom/src/components/vs-radio-set/VsRadioSet.scss
+++ b/packages/vlossom/src/components/vs-radio-set/VsRadioSet.scss
@@ -2,7 +2,7 @@
     display: flex;
     align-items: center;
 
-    &.column {
+    &.vertical {
         flex-direction: column;
         align-items: flex-start;
     }

--- a/packages/vlossom/src/components/vs-radio-set/VsRadioSet.vue
+++ b/packages/vlossom/src/components/vs-radio-set/VsRadioSet.vue
@@ -4,7 +4,7 @@
             :label="label"
             :messages="computedMessages"
             :no-label="noLabel"
-            :no-msg="noMsg"
+            :no-message="noMessage"
             :required="required"
             :shake="shake"
             :state="state"
@@ -46,7 +46,7 @@
                 </vs-check-node>
             </div>
 
-            <template #messages v-if="!noMsg">
+            <template #messages v-if="!noMessage">
                 <slot name="messages" />
             </template>
         </vs-input-wrapper>

--- a/packages/vlossom/src/components/vs-radio-set/VsRadioSet.vue
+++ b/packages/vlossom/src/components/vs-radio-set/VsRadioSet.vue
@@ -14,7 +14,7 @@
                 <slot name="label" />
             </template>
 
-            <div :class="['vs-radio-set', { column }]" :style="radioSetStyleSet">
+            <div :class="['vs-radio-set', { vertical }]" :style="radioSetStyleSet">
                 <vs-check-node
                     v-for="(option, index) in options"
                     :key="getOptionValue(option)"
@@ -87,8 +87,8 @@ export default defineComponent({
             type: Function as PropType<(option: any) => Promise<boolean> | null>,
             default: null,
         },
-        column: { type: Boolean, default: false },
         name: { type: String, required: true },
+        vertical: { type: Boolean, default: false },
         // v-model
         modelValue: { type: null, default: null },
     },

--- a/packages/vlossom/src/components/vs-radio-set/stories/VsRadioSet.stories.ts
+++ b/packages/vlossom/src/components/vs-radio-set/stories/VsRadioSet.stories.ts
@@ -106,9 +106,9 @@ export const Readonly: Story = {
     },
 };
 
-export const Column: Story = {
+export const Vertical: Story = {
     args: {
-        column: true,
+        vertical: true,
     },
 };
 

--- a/packages/vlossom/src/components/vs-radio/VsRadio.vue
+++ b/packages/vlossom/src/components/vs-radio/VsRadio.vue
@@ -5,7 +5,7 @@
             :label="label"
             :messages="computedMessages"
             :no-label="noLabel"
-            :no-msg="noMsg"
+            :no-message="noMessage"
             :required="required"
             :shake="shake"
             :state="state"
@@ -36,7 +36,7 @@
                 </template>
             </vs-check-node>
 
-            <template #messages v-if="!noMsg">
+            <template #messages v-if="!noMessage">
                 <slot name="messages" />
             </template>
         </vs-input-wrapper>

--- a/packages/vlossom/src/components/vs-radio/stories/VsRadio.stories.ts
+++ b/packages/vlossom/src/components/vs-radio/stories/VsRadio.stories.ts
@@ -30,7 +30,7 @@ const meta: Meta<typeof VsRadio> = {
     args: {
         radioLabel: 'Radio Input',
         noLabel: true,
-        noMsg: true,
+        noMessage: true,
         name: 'test',
         radioValue: 'test',
     },
@@ -101,7 +101,7 @@ export const Label: Story = {
 export const Messages: Story = {
     args: {
         messages: [{ state: UIState.Info, text: 'This is info message' }],
-        noMsg: false,
+        noMessage: false,
     },
 };
 

--- a/packages/vlossom/src/components/vs-section/__tests__/vs-section.test.ts
+++ b/packages/vlossom/src/components/vs-section/__tests__/vs-section.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { mount } from '@vue/test-utils';
-import { VsSection } from '@/components';
+import VsSection from '@/components/vs-section/VsSection.vue';
 
 describe('vs-section', () => {
     it('title slot을 설정하지 않으면 section-title 영역이 없다', () => {

--- a/packages/vlossom/src/components/vs-select/VsSelect.vue
+++ b/packages/vlossom/src/components/vs-select/VsSelect.vue
@@ -5,7 +5,7 @@
             :label="label"
             :messages="computedMessages"
             :no-label="noLabel"
-            :no-msg="noMsg"
+            :no-message="noMessage"
             :required="required"
             :shake="shake"
             :state="state"
@@ -175,7 +175,7 @@
                 </Teleport>
             </div>
 
-            <template #messages v-if="!noMsg">
+            <template #messages v-if="!noMessage">
                 <slot name="messages" />
             </template>
         </vs-input-wrapper>

--- a/packages/vlossom/src/components/vs-select/VsSelect.vue
+++ b/packages/vlossom/src/components/vs-select/VsSelect.vue
@@ -204,7 +204,7 @@ import { utils } from '@/utils';
 import { logUtil } from '@/utils/log';
 import VsChip from '@/components/vs-chip/VsChip.vue';
 
-import type { VsChipStyleSet } from '@/components';
+import type { VsChipStyleSet } from '@/components/vs-chip/types';
 
 const name = VsComponent.VsSelect;
 export default defineComponent({

--- a/packages/vlossom/src/components/vs-stepper/__tests__/vs-stepper.test.ts
+++ b/packages/vlossom/src/components/vs-stepper/__tests__/vs-stepper.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
-import { VsStepper } from '@/components';
+import VsStepper from '@/components/vs-stepper/VsStepper.vue';
 
 function mountComponent() {
     return mount(VsStepper);

--- a/packages/vlossom/src/components/vs-switch/VsSwitch.vue
+++ b/packages/vlossom/src/components/vs-switch/VsSwitch.vue
@@ -5,7 +5,7 @@
             :label="label"
             :messages="computedMessages"
             :no-label="noLabel"
-            :no-msg="noMsg"
+            :no-message="noMessage"
             :required="required"
             :shake="shake"
             :state="state"
@@ -55,6 +55,10 @@
                 :checked="isChecked"
                 @change="toggle()"
             />
+
+            <template #messages v-if="!noMessage">
+                <slot name="messages" />
+            </template>
         </vs-input-wrapper>
     </vs-wrapper>
 </template>

--- a/packages/vlossom/src/components/vs-textarea/VsTextarea.vue
+++ b/packages/vlossom/src/components/vs-textarea/VsTextarea.vue
@@ -5,7 +5,7 @@
             :label="label"
             :messages="computedMessages"
             :no-label="noLabel"
-            :no-msg="noMsg"
+            :no-message="noMessage"
             :required="required"
             :shake="shake"
             :state="state"
@@ -32,7 +32,7 @@
                 @change.stop
             />
 
-            <template #messages v-if="!noMsg">
+            <template #messages v-if="!noMessage">
                 <slot name="messages" />
             </template>
         </vs-input-wrapper>

--- a/packages/vlossom/src/components/vs-tooltip/VsTooltip.vue
+++ b/packages/vlossom/src/components/vs-tooltip/VsTooltip.vue
@@ -10,7 +10,7 @@
             <slot />
         </div>
 
-        <teleport to="#vs-overlay" v-if="computedShow || isVisible">
+        <Teleport to="#vs-overlay" v-if="computedShow || isVisible">
             <div
                 ref="tooltipRef"
                 :class="['tooltip', `vs-${computedColorScheme}`, `placement-${computedPlacement}`, `align-${align}`]"
@@ -21,7 +21,7 @@
                     <slot name="tooltip" />
                 </div>
             </div>
-        </teleport>
+        </Teleport>
     </div>
 </template>
 

--- a/packages/vlossom/src/composables/__tests__/__snapshots__/input-composable.test.ts.snap
+++ b/packages/vlossom/src/composables/__tests__/__snapshots__/input-composable.test.ts.snap
@@ -30,7 +30,7 @@ exports[`getInputProps > input component에 필요한 props들을 가져올 수 
     "default": false,
     "type": [Function],
   },
-  "noMsg": {
+  "noMessage": {
     "default": false,
     "type": [Function],
   },
@@ -87,7 +87,7 @@ exports[`getInputProps > input props 중 제외할 props를 정할 수 있다 1`
     "default": false,
     "type": [Function],
   },
-  "noMsg": {
+  "noMessage": {
     "default": false,
     "type": [Function],
   },

--- a/packages/vlossom/src/composables/input-composable.ts
+++ b/packages/vlossom/src/composables/input-composable.ts
@@ -12,7 +12,7 @@ interface VsInputProps<T> {
     name: { type: StringConstructor; default: string };
     noClear: { type: BooleanConstructor; default: boolean };
     noLabel: { type: BooleanConstructor; default: boolean };
-    noMsg: { type: BooleanConstructor; default: boolean };
+    noMessage: { type: BooleanConstructor; default: boolean };
     placeholder: { type: StringConstructor; default: string };
     readonly: { type: BooleanConstructor; default: boolean };
     required: { type: BooleanConstructor; default: boolean };
@@ -37,7 +37,7 @@ export function getInputProps<T = unknown, K extends Array<keyof VsInputProps<T>
             name: { type: String, default: '' },
             noClear: { type: Boolean, default: false },
             noLabel: { type: Boolean, default: false },
-            noMsg: { type: Boolean, default: false },
+            noMessage: { type: Boolean, default: false },
             placeholder: { type: String, default: '' },
             readonly: { type: Boolean, default: false },
             required: { type: Boolean, default: false },


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Refactor (refactor)

## Summary
props 이름 변경을 위한 MR입니다

## Description
- noMsg -> noMessage
- teleport -> Teleport
- mobile-full -> response (vs-divider)
- column -> vertical (vs-checkbox-set, vs-radio-set)
- fix circular dependencies

<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
