### PR TITLE
feat(VsAccordion): change open model binding

### DIFF
--- a/packages/vlossom/src/components/vs-accordion/VsAccordion.vue
+++ b/packages/vlossom/src/components/vs-accordion/VsAccordion.vue
@@ -25,30 +25,31 @@ export default defineComponent({
         ...getResponsiveProps(),
         colorScheme: { type: String as PropType<ColorScheme> },
         styleSet: { type: [String, Object] as PropType<string | VsAccordionStyleSet> },
-        // v-model
         open: { type: Boolean, default: false },
+        // v-model
+        modelValue: { type: Boolean, default: false },
     },
-    emits: ['update:open', 'toggle'],
+    emits: ['update:modelValue', 'toggle'],
     setup(props, { emit }) {
-        const { colorScheme, styleSet, open: modelOpen } = toRefs(props);
+        const { colorScheme, styleSet, open, modelValue } = toRefs(props);
 
         const { computedColorScheme } = useColorScheme(name, colorScheme);
 
         const { computedStyleSet } = useStyleSet<VsAccordionStyleSet>(name, styleSet);
 
-        const isOpen = ref(modelOpen.value);
+        const isOpen = ref(open.value || modelValue.value);
 
         function onToggle(event: Event) {
-            const { open } = event.target as HTMLDetailsElement;
-            isOpen.value = open;
+            const element = event.target as HTMLDetailsElement;
+            isOpen.value = element.open;
         }
 
-        watch(modelOpen, (o) => {
+        watch(modelValue, (o) => {
             isOpen.value = o;
         });
 
         watch(isOpen, (o) => {
-            emit('update:open', o);
+            emit('update:modelValue', o);
             emit('toggle', o);
         });
 

--- a/packages/vlossom/src/components/vs-accordion/__tests__/vs-accordion.test.ts
+++ b/packages/vlossom/src/components/vs-accordion/__tests__/vs-accordion.test.ts
@@ -23,35 +23,53 @@ describe('vs-accordion', () => {
         expect(wrapper.find('.accordion-content').html()).toContain(contents);
     });
 
-    describe('open', () => {
-        it('open 상태를 전달해서 accordion을 열어둘 수 있다', () => {
-            // given
-            const wrapper: ReturnType<typeof mountComponent> = mount(VsAccordion, {
-                props: {
-                    open: true,
-                },
-            });
-
-            // then;
-            expect(wrapper.find('details').attributes('open')).exist;
+    it('open 상태를 전달해서 accordion을 열어둘 수 있다', () => {
+        // given
+        const wrapper: ReturnType<typeof mountComponent> = mount(VsAccordion, {
+            props: {
+                open: true,
+            },
         });
 
-        it('v-model:open으로 open 상태를 바인딩 할 수 있다', async () => {
+        // then;
+        expect(wrapper.find('details').attributes('open')).exist;
+    });
+
+    describe('v-model', () => {
+        it('v-model binding으로 accordion을 열 수 있다', async () => {
             // given
             const wrapper: ReturnType<typeof mountComponent> = mount(VsAccordion, {
                 props: {
-                    open: false,
-                    'onUpdate:open': (open: boolean) => wrapper.setProps({ open }),
+                    modelValue: false,
+                    'onUpdate:modelValue': (v: boolean) => wrapper.setProps({ modelValue: v }),
                 },
             });
 
             // when
-            await wrapper.setProps({ open: true });
+            await wrapper.setProps({ modelValue: true });
 
             // then;
             expect(wrapper.find('details').attributes('open')).exist;
-            expect(wrapper.emitted('update:open')).toEqual([[true]]);
+            expect(wrapper.emitted('update:modelValue')).toEqual([[true]]);
             expect(wrapper.emitted('toggle')).toEqual([[true]]);
+        });
+
+        it('v-model binding으로 accordion을 닫을 수 있다', async () => {
+            // given
+            const wrapper: ReturnType<typeof mountComponent> = mount(VsAccordion, {
+                props: {
+                    modelValue: true,
+                    'onUpdate:modelValue': (v: boolean) => wrapper.setProps({ modelValue: v }),
+                },
+            });
+
+            // when
+            await wrapper.setProps({ modelValue: false });
+
+            // then;
+            expect(wrapper.find('details').attributes('open')).not.exist;
+            expect(wrapper.emitted('update:modelValue')).toEqual([[false]]);
+            expect(wrapper.emitted('toggle')).toEqual([[false]]);
         });
     });
 });


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Feature (feat)

## Summary
vs-accordion의 v-model binding 방식을 바꿉니다

## Description
- open props를 초기 open에만 영향을 주는 prop으로 변경
- v-model:open을 v-model로 변경

<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
