### PR TITLE
feat(VsTextWrap): set mobile width as fit-content

### DIFF
--- a/packages/vlossom/src/components/vs-text-wrap/VsTextWrap.scss
+++ b/packages/vlossom/src/components/vs-text-wrap/VsTextWrap.scss
@@ -13,7 +13,6 @@
         overflow: hidden;
         text-overflow: ellipsis;
         word-wrap: break-word;
-        white-space: nowrap;
         -webkit-line-clamp: 1;
     }
 
@@ -35,5 +34,11 @@
 
     .text-wrap-contents + .text-wrap-buttons {
         margin-left: 0.6rem;
+    }
+}
+
+@media screen and (max-width: 768px) {
+    .text-wrap > .text-wrap-contents {
+        width: fit-content !important;
     }
 }


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Feature (feat)

## Summary
현상 : width를 뷰포트 사이즈보다 크게 지정하는 경우에 너비가 인라인 스타일로 지정되는데, 그러면 텍스트가 길어져서 좌우 스크롤이 발생하게 됩니다.

수정방안 : 줄바꿈을 허용하고 모바일 사이즈에서 너비가 fit-content 로 변경되도록 했습니다


## Description
vs-text-wrap을 table item으로 넣었을 때 table 너비가 넘치는 이슈 해결

