### PR TITLE
feat(VsTable): set td overflow-x as auto on mobile view

### DIFF
--- a/packages/vlossom/src/components/vs-table/VsTable.scss
+++ b/packages/vlossom/src/components/vs-table/VsTable.scss
@@ -185,6 +185,11 @@
 
 @media screen and (max-width: 576px) {
     .vs-table .table-wrap {
+        table {
+            display: flex;
+            flex-direction: column;
+        }
+
         table thead {
             display: none;
         }
@@ -204,13 +209,14 @@
                 justify-content: space-between;
                 padding: 0.8rem 1.2rem !important;
                 border-top: 1px dashed var(--vs-line-color);
+                overflow-x: auto;
 
                 &::before {
                     content: attr(data-label);
                     color: var(--vs-comp-color);
                     display: block;
                     line-height: 3rem;
-                    margin-right: 1.8rem;
+                    margin-right: 1.4rem;
                     font-size: 1.1rem;
                     font-weight: 700;
                 }


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Feature (feat)

## Summary
- 모바일뷰 컨텐츠 넘치는 문제 수정
    - table display를 flex 로 지정, 수직방향으로 배치
    - td 에 overflow-x auto 지정하여 컨텐츠가 길어지면 스크롤 발생하게 함 

## Description

다음 이슈를 해결합니다
- vs-text-wrap을 item으로 넣었을 때 table 너비가 넘치는 이슈


## Screenshot

![image](https://github.com/pubg/vlossom/assets/134579071/f4c41e28-7ed3-423e-a98c-e1f292a28bd0)


![image](https://github.com/pubg/vlossom/assets/134579071/61001761-f9dc-4ff7-9a6a-7b175833f30f)
