### PR TITLE
feat(VsTable): set table-data overflow-x as auto

### DIFF
--- a/packages/vlossom/src/components/vs-table/VsTable.scss
+++ b/packages/vlossom/src/components/vs-table/VsTable.scss
@@ -24,6 +24,7 @@
                     align-items: center;
                     width: 100%;
                     height: 100%;
+                    overflow-x: auto;
                 }
             }
         }


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Feature (feat)

## Summary
- table-data 에 overflow-x: auto 지정하여 컨텐츠가 nowrap인 경우에 스크롤발생하도록 함

## Description

다음 이슈를 해결합니다
- 컨텐츠 overflow 상황에서 어떻게 처리할 것인지 고민

## Screenshot
![image](https://github.com/pubg/vlossom/assets/134579071/2e39d81b-0cfe-444d-aec7-d8c14f170f1d)
