### PR TITLE
feat(VsTable): add header on mobile view

### DIFF
--- a/packages/vlossom/src/components/vs-table/VsTable.scss
+++ b/packages/vlossom/src/components/vs-table/VsTable.scss
@@ -185,14 +185,25 @@
 
 @media screen and (max-width: 576px) {
     .vs-table .table-wrap {
-        table thead {
-            display: none;
+        margin-bottom: 2rem;
+
+        table thead tr {
+            grid-template-columns: none !important;
+            th:not(:first-child) {
+                display: none;
+            }
+            th:first-child {
+                color: transparent;
+                height: 3.2rem;
+            }
+            margin-bottom: 0.8rem;
+            border: 1px solid var(--vs-line-color);
         }
 
         table tbody tr {
             display: flex !important;
             flex-direction: column;
-            margin: 1rem 0 0 0;
+            margin: 0.8rem 0 0 0;
             border: 1px solid var(--vs-line-color);
 
             &:first-of-type {

--- a/packages/vlossom/src/components/vs-table/VsTable.scss
+++ b/packages/vlossom/src/components/vs-table/VsTable.scss
@@ -13,7 +13,7 @@
             padding-bottom: 1rem;
             font-weight: bold;
             font-size: 1.2rem;
-            color: var(--vs-font-color); 
+            color: var(--vs-font-color);
         }
 
         tr {
@@ -212,6 +212,7 @@
             }
             margin-bottom: 0.8rem;
             border: 1px solid var(--vs-line-color);
+        }
 
         table {
             display: flex;


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Feature (feat)

## Summary
- mobile view에서 테이블이 여러 개 있을 때 다른 테이블과 시각적으로 구분하기 어려운 문제가 있어, 모바일에서도 테이블 헤더가 보이도록 추가하였습니다.
- mobile view에서도 select all을 누를 수 있도록 헤더에 추가하였습니다.
