### PR TITLE
fix(objectUtil): apply isPlainObject on typeof object

### DIFF
--- a/packages/vlossom/src/composables/input-option-composable.ts
+++ b/packages/vlossom/src/composables/input-option-composable.ts
@@ -19,7 +19,7 @@ export function useInputOption(
     multiple = ref(false),
 ) {
     function getOptionLabel(option: any) {
-        if (typeof option === 'object') {
+        if (utils.object.isPlainObject(option)) {
             if (optionLabel.value) {
                 const label = _.at(option, [optionLabel.value])[0];
 
@@ -40,7 +40,7 @@ export function useInputOption(
     }
 
     function getOptionValue(option: any) {
-        if (typeof option === 'object' && optionValue.value) {
+        if (utils.object.isPlainObject(option) && optionValue.value) {
             const value = _.at(option, [optionValue.value])[0];
 
             if (!value) {

--- a/packages/vlossom/src/composables/responsive-composable.ts
+++ b/packages/vlossom/src/composables/responsive-composable.ts
@@ -1,4 +1,5 @@
 import { ComputedRef, PropType, Ref, computed } from 'vue';
+import { utils } from '@/utils';
 
 import type { Breakpoints } from '@/declaration';
 
@@ -13,7 +14,7 @@ export function useResponsive(width: Ref<string | Breakpoints | null>, grid: Ref
     const responsiveClasses: ComputedRef<string[]> = computed(() => {
         const classes: string[] = ['vs-responsive'];
 
-        if (width.value && typeof width.value === 'object') {
+        if (width.value && utils.object.isPlainObject(width.value)) {
             const { sm, md, lg, xl } = width.value;
             const widthClasses = [
                 ...(sm ? ['vs-width-sm'] : []),
@@ -39,7 +40,7 @@ export function useResponsive(width: Ref<string | Breakpoints | null>, grid: Ref
     const responsiveStyles: ComputedRef<Record<string, string>> = computed(() => {
         const styles: Record<string, string> = {};
 
-        if (width.value && typeof width.value === 'object') {
+        if (width.value && utils.object.isPlainObject(width.value)) {
             const { base, sm, md, lg, xl } = width.value;
             const widthStyles = {
                 ...(base && { ['--vs-width-base']: base?.toString() }),

--- a/packages/vlossom/src/utils/__tests__/object.test.ts
+++ b/packages/vlossom/src/utils/__tests__/object.test.ts
@@ -47,4 +47,31 @@ describe('object util', () => {
             expect(result2).toBe(false);
         });
     });
+
+    describe('isPlainObject', () => {
+        const { isPlainObject } = objectUtil;
+
+        it('객체가 plain object인지 확인할 수 있다', () => {
+            // given
+            const plainObject = { a: 1 };
+            const notPlainObject = new Map();
+            const array = [1, 2, 3];
+            class Foo {
+                a = 1;
+            }
+            const instance = new Foo();
+
+            // when
+            const result1 = isPlainObject(plainObject);
+            const result2 = isPlainObject(notPlainObject);
+            const result3 = isPlainObject(array);
+            const result4 = isPlainObject(instance);
+
+            // then
+            expect(result1).toBe(true);
+            expect(result2).toBe(false);
+            expect(result3).toBe(false);
+            expect(result4).toBe(false);
+        });
+    });
 });

--- a/packages/vlossom/src/utils/object.ts
+++ b/packages/vlossom/src/utils/object.ts
@@ -8,4 +8,8 @@ export const objectUtil = {
     isUniq(array: any[]): boolean {
         return _.uniq(array).length === array.length;
     },
+
+    isPlainObject(value: any): value is Record<string, any> {
+        return _.isPlainObject(value);
+    },
 };


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary
typeof object 검증 로직 보완

## Description
- isPlainObject util 함수 추가
- `typeof`를 이용해서 'object'를 검증하는 코드가 plain object를 기대했으나 array나 function도 들어갈 수 있는 여지가 있어서 isPlainObject로 object 여부를 판단하도록 코드 수정

<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
