### PR TITLE
feat(Vlossom): add radius ratio on vlossom options

### DIFF
--- a/packages/vlossom/src/components/vs-accordion/VsAccordion.scss
+++ b/packages/vlossom/src/components/vs-accordion/VsAccordion.scss
@@ -7,7 +7,7 @@ $titleColor: var(--vs-accordion-titleFontColor, var(--vs-comp-font));
         box-sizing: border-box;
         overflow: hidden;
         border: var(--vs-accordion-border, 1px solid var(--vs-line-color));
-        border-radius: var(--vs-accordion-borderRadius, 0.4rem);
+        border-radius: var(--vs-accordion-borderRadius, calc(var(--vs-radius-ratio) * 0.4rem));
 
         summary {
             position: relative;

--- a/packages/vlossom/src/components/vs-avatar/VsAvatar.scss
+++ b/packages/vlossom/src/components/vs-avatar/VsAvatar.scss
@@ -4,7 +4,7 @@
     justify-content: center;
     align-items: center;
     border: var(--vs-avatar-border, 0.1rem solid var(--vs-line-color));
-    border-radius: var(--vs-avatar-borderRadius, 0.4rem);
+    border-radius: var(--vs-avatar-borderRadius, calc(var(--vs-radius-ratio) * 0.4rem));
     width: var(--vs-avatar-width, 3rem);
     height: var(--vs-avatar-height, 3rem);
     background-color: var(--vs-avatar-backgroundColor, var(--vs-comp-bg));

--- a/packages/vlossom/src/components/vs-block/VsBlock.scss
+++ b/packages/vlossom/src/components/vs-block/VsBlock.scss
@@ -4,7 +4,7 @@ $borderColor: var(--vs-block-borderColor, var(--vs-line-color));
 
 .vs-block {
     border: var(--vs-block-border, $borderWidth $borderStyle $borderColor);
-    border-radius: var(--vs-block-borderRadius, 0.4rem);
+    border-radius: var(--vs-block-borderRadius, calc(var(--vs-radius-ratio) * 0.5rem));
     overflow: hidden;
     position: relative;
     width: 100%;

--- a/packages/vlossom/src/components/vs-button/VsButton.scss
+++ b/packages/vlossom/src/components/vs-button/VsButton.scss
@@ -7,7 +7,7 @@
     max-height: var(--vs-button-maxHeight, 3rem);
     padding: var(--vs-button-padding, 0.4rem 1rem);
     border: 1px solid var(--vs-line-color);
-    border-radius: var(--vs-button-borderRadius, 0.4rem);
+    border-radius: var(--vs-button-borderRadius, var(--vs-border-radius, 0.4rem));
     cursor: pointer;
     font-size: var(--vs-button-fontSize, 0.9rem);
     font-weight: var(--vs-button-fontWeight, 500);

--- a/packages/vlossom/src/components/vs-button/VsButton.scss
+++ b/packages/vlossom/src/components/vs-button/VsButton.scss
@@ -7,7 +7,7 @@
     max-height: var(--vs-button-maxHeight, 3rem);
     padding: var(--vs-button-padding, 0.4rem 1rem);
     border: 1px solid var(--vs-line-color);
-    border-radius: var(--vs-button-borderRadius, var(--vs-border-radius, 0.4rem));
+    border-radius: var(--vs-button-borderRadius, calc(var(--vs-radius-ratio) * 0.4rem));
     cursor: pointer;
     font-size: var(--vs-button-fontSize, 0.9rem);
     font-weight: var(--vs-button-fontWeight, 500);
@@ -80,14 +80,14 @@
 .vs-button {
     &.dense {
         padding: var(--vs-button-padding, 0.2rem 0.8rem);
-        border-radius: var(--vs-button-borderRadius, 0.4rem);
+        border-radius: var(--vs-button-borderRadius, calc(var(--vs-radius-ratio) * 0.3rem));
         font-size: var(--vs-button-fontSize, 0.8rem);
         max-height: var(--vs-button-maxHeight, 2.4rem);
     }
 
     &.large {
         padding: var(--vs-button-padding, 0.6rem 1.4rem);
-        border-radius: var(--vs-button-borderRadius, 0.6rem);
+        border-radius: var(--vs-button-borderRadius, calc(var(--vs-radius-ratio) * 0.6rem));
         font-size: var(--vs-button-fontSize, 1.2rem);
         max-height: var(--vs-button-maxHeight, 3.7rem);
     }

--- a/packages/vlossom/src/components/vs-file-input/VsFileInput.scss
+++ b/packages/vlossom/src/components/vs-file-input/VsFileInput.scss
@@ -8,7 +8,7 @@ $borderColor: var(--vs-file-input-borderColor, var(--vs-line-color));
     position: relative;
     background-color: var(--vs-file-input-backgroundColor, var(--vs-no-color));
     border: $borderWidth $borderStyle $borderColor;
-    border-radius: var(--vs-file-input-borderRadius, 0.4rem);
+    border-radius: var(--vs-file-input-borderRadius, calc(var(--vs-radius-ratio) * 0.4rem));
     height: var(--vs-file-input-height, 2.5rem);
     outline: none;
     font-size: var(--vs-file-input-fontSize, 1rem);
@@ -29,7 +29,8 @@ $borderColor: var(--vs-file-input-borderColor, var(--vs-line-color));
 
         .attach-file-icon {
             width: 2.5rem;
-            border-radius: var(--vs-file-input-borderRadius, 0.4rem) 0 0 var(--vs-file-input-borderRadius, 0.4rem);
+            border-radius: var(--vs-file-input-borderRadius, calc(var(--vs-radius-ratio) * 0.4rem)) 0 0
+                var(--vs-file-input-borderRadius, calc(var(--vs-radius-ratio) * 0.4rem));
             background-color: var(--vs-file-input-prependBackgroundColor, var(--vs-line-color));
             color: var(--vs-file-input-prependColor, var(--vs-primary-comp-bg));
             display: flex;

--- a/packages/vlossom/src/components/vs-input/VsInput.scss
+++ b/packages/vlossom/src/components/vs-input/VsInput.scss
@@ -8,7 +8,7 @@
     background-color: var(--vs-input-backgroundColor, var(--vs-no-color));
     box-sizing: border-box;
     border: var(--vs-input-border, solid 1px var(--vs-line-color));
-    border-radius: var(--vs-input-borderRadius, 0.4rem);
+    border-radius: var(--vs-input-borderRadius, calc(var(--vs-radius-ratio) * 0.4rem));
     height: var(--vs-input-height, 2.5rem);
 
     input {

--- a/packages/vlossom/src/components/vs-modal/VsModal.scss
+++ b/packages/vlossom/src/components/vs-modal/VsModal.scss
@@ -30,7 +30,7 @@ $sizes: xs, sm, md, lg, xl;
         min-height: var(--vs-modal-height-xs);
         max-width: 100%;
         max-height: 100%;
-        border-radius: var(--vs-modal-borderRadius, 0.6rem);
+        border-radius: var(--vs-modal-borderRadius, calc(var(--vs-radius-ratio) * 0.6rem));
 
         // size
         @each $size in $sizes {

--- a/packages/vlossom/src/components/vs-pagination/VsPagination.scss
+++ b/packages/vlossom/src/components/vs-pagination/VsPagination.scss
@@ -19,7 +19,7 @@
         height: var(--vs-pagination-buttonHeight, 2rem);
         line-height: var(--vs-pagination-buttonHeight, 2rem);
         margin: var(--vs-pagination-gap, 0.2rem);
-        border-radius: var(--vs-pagination-borderRadius, 0.4rem);
+        border-radius: var(--vs-pagination-borderRadius, calc(var(--vs-radius-ratio) * 0.4rem));
         background-color: var(--vs-pagination-backgroundColor, var(--vs-comp-bg));
         color: var(--vs-pagination-fontColor, var(--vs-comp-font));
         border: 1px solid var(--vs-line-color);

--- a/packages/vlossom/src/components/vs-progress/VsProgress.scss
+++ b/packages/vlossom/src/components/vs-progress/VsProgress.scss
@@ -10,7 +10,7 @@ progress[value] {
         overflow: hidden;
         background-color: var(--vs-progress-barColor, var(--vs-comp-bg));
         border: 1px solid var(--vs-progress-borderColor, var(--vs-line-color));
-        border-radius: var(--vs-progress-borderRadius, 0.4rem);
+        border-radius: var(--vs-progress-borderRadius, calc(var(--vs-radius-ratio) * 0.4rem));
     }
 
     &::-webkit-progress-value {

--- a/packages/vlossom/src/components/vs-section/VsSection.scss
+++ b/packages/vlossom/src/components/vs-section/VsSection.scss
@@ -1,6 +1,6 @@
 .vs-section {
     background-color: var(--vs-section-backgroundColor, var(--vs-area-bg));
-    border-radius: var(--vs-section-borderRadius, 0.4rem);
+    border-radius: var(--vs-section-borderRadius, calc(var(--vs-radius-ratio) * 0.6rem));
     box-shadow: var(--vs-section-boxShadow, var(--vs-area-shadow));
     color: var(--vs-section-fontColor, var(--vs-font-color));
     padding: var(--vs-section-padding, 2rem);

--- a/packages/vlossom/src/components/vs-select/VsSelect.scss
+++ b/packages/vlossom/src/components/vs-select/VsSelect.scss
@@ -4,8 +4,8 @@
     display: flex;
     background-color: var(--vs-select-backgroundColor, var(--vs-no-color));
     border: var(--vs-select-border, solid 0.0625rem var(--vs-line-color));
-    border-radius: var(--vs-select-borderRadius, 0.4rem);
     min-height: var(--vs-select-height, 2.6rem);
+    border-radius: var(--vs-select-borderRadius, calc(var(--vs-radius-ratio) * 0.4rem));
     font-size: var(--vs-select-fontSize, 1rem);
 
     .multiple-chips {
@@ -96,7 +96,7 @@
     z-index: 900;
     background-color: var(--vs-select-backgroundColor, var(--vs-no-color));
     border: var(--vs-select-border, solid 0.0625rem var(--vs-line-color));
-    border-radius: var(--vs-select-borderRadius, 0.4rem);
+    border-radius: var(--vs-select-borderRadius, calc(var(--vs-radius-ratio) * 0.4rem));
     overflow: hidden;
 
     .options {

--- a/packages/vlossom/src/components/vs-table/VsTable.scss
+++ b/packages/vlossom/src/components/vs-table/VsTable.scss
@@ -94,7 +94,7 @@
                         justify-content: center;
                         width: 1.6rem;
                         height: 1.6rem;
-                        border-radius: 0.2rem;
+                        border-radius: calc(var(--vs-radius-ratio) * 0.2rem);
                         background-color: var(--vs-comp-bg);
 
                         i {
@@ -134,7 +134,7 @@
                 .skeleton {
                     width: 95%;
                     height: 60%;
-                    border-radius: 0.4rem;
+                    border-radius: calc(var(--vs-radius-ratio) * 0.4rem);
                     background-color: var(--vs-gray-200);
                     animation: skeleton-loading 0.6s infinite alternate;
                 }

--- a/packages/vlossom/src/components/vs-textarea/VsTextarea.scss
+++ b/packages/vlossom/src/components/vs-textarea/VsTextarea.scss
@@ -10,7 +10,7 @@
     color: var(--vs-textarea-fontColor, var(--vs-comp-font));
     font-size: var(--vs-textarea-fontSize, 1rem);
     border: var(--vs-textarea-border, solid 1px var(--vs-line-color));
-    border-radius: var(--vs-textarea-borderRadius, 0.4rem);
+    border-radius: var(--vs-textarea-borderRadius, calc(var(--vs-radius-ratio) * 0.4rem));
     padding: 0.6rem;
     outline: none;
     resize: vertical;

--- a/packages/vlossom/src/components/vs-toast/VsToastView.scss
+++ b/packages/vlossom/src/components/vs-toast/VsToastView.scss
@@ -26,7 +26,7 @@
     box-shadow: 0 0.4rem 0.3rem 0 rgba(#000, 0.3);
     display: flex;
     justify-content: center;
-    border-radius: 0.4rem;
+    border-radius: calc(var(--vs-radius-ratio) * 0.5rem);
     color: #fff;
     font-size: 1.1rem;
     margin: 0.4rem 0;

--- a/packages/vlossom/src/components/vs-tooltip/VsTooltip.scss
+++ b/packages/vlossom/src/components/vs-tooltip/VsTooltip.scss
@@ -12,7 +12,7 @@
         position: relative;
         padding: var(--vs-tooltip-padding, 0.8rem);
         font-size: var(--vs-tooltip-fontSize, 1rem);
-        border-radius: var(--vs-tooltip-borderRadius, 0.35rem);
+        border-radius: var(--vs-tooltip-borderRadius, calc(var(--vs-radius-ratio) * 0.3rem));
         background-color: var(--vs-tooltip-backgroundColor, var(--vs-area-bg));
         box-shadow: inset 0px 0px 0px var(--vs-tooltip-borderWidth, 0.15rem)
             var(--vs-tooltip-borderColor, var(--vs-primary-comp-bg));

--- a/packages/vlossom/src/components/vs-value-tag/VsValueTag.scss
+++ b/packages/vlossom/src/components/vs-value-tag/VsValueTag.scss
@@ -2,7 +2,8 @@
     display: flex;
     align-items: center;
     border: 1px solid var(--vs-line-color);
-    border-radius: var(--vs-value-tag-borderRadius, 0.2rem);
+    border-radius: var(--vs-value-tag-borderRadius, calc(var(--vs-radius-ratio) * 0.2rem));
+    overflow: hidden;
     font-size: var(--vs-value-tag-fontSize, 1rem);
     font-weight: var(--vs-value-tag-fontWeight, 400);
     width: var(--vs-value-tag-width, 100%);

--- a/packages/vlossom/src/declaration/types.ts
+++ b/packages/vlossom/src/declaration/types.ts
@@ -83,7 +83,7 @@ export interface VlossomOptions {
     components?: VsComponent[];
     colorScheme?: GlobalColorScheme;
     styleSet?: StyleSet;
-    borderRadius?: string;
+    radiusRatio?: number;
     detectOSTheme?: boolean;
 }
 

--- a/packages/vlossom/src/declaration/types.ts
+++ b/packages/vlossom/src/declaration/types.ts
@@ -83,6 +83,7 @@ export interface VlossomOptions {
     components?: VsComponent[];
     colorScheme?: GlobalColorScheme;
     styleSet?: StyleSet;
+    borderRadius?: string;
     detectOSTheme?: boolean;
 }
 

--- a/packages/vlossom/src/nodes/vs-checkbox-node/VsCheckboxNode.scss
+++ b/packages/vlossom/src/nodes/vs-checkbox-node/VsCheckboxNode.scss
@@ -17,7 +17,7 @@ $checkbox-selected-label-color: var(--vs-checkbox-selectedLabelFontColor, $check
         display: flex;
         align-items: center;
         color: $checkbox-color;
-        border-radius: var(--vs-checkbox-borderRadius, 0.2rem);
+        border-radius: var(--vs-checkbox-borderRadius, calc(var(--vs-radius-ratio) * 0.2rem));
         overflow: hidden;
 
         .check-icon {

--- a/packages/vlossom/src/stores/__tests__/option-store.test.ts
+++ b/packages/vlossom/src/stores/__tests__/option-store.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { OptionStore } from '../option-store';
 import { VsComponent } from '@/declaration';
 
@@ -15,7 +15,7 @@ describe('option store', () => {
             theme: 'light',
             globalColorScheme: {},
             styleSets: {},
-            globalBorderRadius: '0.4rem',
+            globalRadiusRatio: 1,
         });
     });
 
@@ -168,38 +168,60 @@ describe('option store', () => {
         });
     });
 
-    describe('globalBorderRadius', () => {
-        it('globalBorderRadius를 설정할 수 있다', () => {
+    describe('globalRadiusRatio', () => {
+        it('globalRadiusRatio를 설정할 수 있다', () => {
             // given
             const store = new OptionStore();
+            const setPropertySpy = vi.spyOn(document.documentElement.style, 'setProperty').mockImplementation(() => {});
 
             // when
-            store.setGlobalBorderRadius('0.5rem');
+            store.setGlobalRadiusRatio(0.5);
 
             // then
-            expect(store.getState().globalBorderRadius).toEqual('0.5rem');
+            expect(store.getState().globalRadiusRatio).toEqual(0.5);
+            expect(setPropertySpy).toBeCalledWith('--vs-radius-ratio', '0.5');
         });
 
-        it('globalBorderRadius를 설정할 수 있다 (기본값)', () => {
+        it('globalRadiusRatio가 0보다 작으면 radius ratio를 설정하지 않는다', () => {
             // given
             const store = new OptionStore();
+            const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+            const setPropertySpy = vi.spyOn(document.documentElement.style, 'setProperty').mockImplementation(() => {});
 
             // when
-            store.setGlobalBorderRadius();
+            store.setGlobalRadiusRatio(-1);
 
             // then
-            expect(store.getState().globalBorderRadius).toEqual('0.4rem');
+            expect(consoleErrorSpy).toBeCalled();
+            expect(setPropertySpy).not.toBeCalled();
         });
 
-        it('globalBorderRadius를 설정할 때 document에도 반영된다', () => {
+        it('globalRadiusRatio가 1보다 크면 radius ratio를 설정하지 않는다', () => {
             // given
             const store = new OptionStore();
+            const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+            const setPropertySpy = vi.spyOn(document.documentElement.style, 'setProperty').mockImplementation(() => {});
 
             // when
-            store.setGlobalBorderRadius('0.5rem');
+            store.setGlobalRadiusRatio(2);
 
             // then
-            expect(document.documentElement.style.getPropertyValue('--vs-border-radius')).toEqual('0.5rem');
+            expect(consoleErrorSpy).toBeCalled();
+            expect(setPropertySpy).not.toBeCalled();
+        });
+
+        it('globalRadiusRatio가 NaN이면 radius ratio를 설정하지 않는다', () => {
+            // given
+            const store = new OptionStore();
+            const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+            const setPropertySpy = vi.spyOn(document.documentElement.style, 'setProperty').mockImplementation(() => {});
+
+            // when
+            store.setGlobalRadiusRatio(NaN);
+
+            // then
+            expect(consoleErrorSpy).toBeCalled();
+            expect(setPropertySpy).not.toBeCalled();
         });
     });
 });

--- a/packages/vlossom/src/stores/__tests__/option-store.test.ts
+++ b/packages/vlossom/src/stores/__tests__/option-store.test.ts
@@ -15,6 +15,7 @@ describe('option store', () => {
             theme: 'light',
             globalColorScheme: {},
             styleSets: {},
+            globalBorderRadius: '0.4rem',
         });
     });
 
@@ -164,6 +165,41 @@ describe('option store', () => {
                 // then
                 expect(result).toBeUndefined();
             });
+        });
+    });
+
+    describe('globalBorderRadius', () => {
+        it('globalBorderRadius를 설정할 수 있다', () => {
+            // given
+            const store = new OptionStore();
+
+            // when
+            store.setGlobalBorderRadius('0.5rem');
+
+            // then
+            expect(store.getState().globalBorderRadius).toEqual('0.5rem');
+        });
+
+        it('globalBorderRadius를 설정할 수 있다 (기본값)', () => {
+            // given
+            const store = new OptionStore();
+
+            // when
+            store.setGlobalBorderRadius();
+
+            // then
+            expect(store.getState().globalBorderRadius).toEqual('0.4rem');
+        });
+
+        it('globalBorderRadius를 설정할 때 document에도 반영된다', () => {
+            // given
+            const store = new OptionStore();
+
+            // when
+            store.setGlobalBorderRadius('0.5rem');
+
+            // then
+            expect(document.documentElement.style.getPropertyValue('--vs-border-radius')).toEqual('0.5rem');
         });
     });
 });

--- a/packages/vlossom/src/stores/option-store.ts
+++ b/packages/vlossom/src/stores/option-store.ts
@@ -7,6 +7,7 @@ interface OptionStoreState {
     theme: 'light' | 'dark';
     globalColorScheme: GlobalColorScheme;
     styleSets: StyleSet;
+    globalBorderRadius: string;
 }
 
 export class OptionStore {
@@ -14,6 +15,7 @@ export class OptionStore {
         theme: 'light',
         globalColorScheme: {},
         styleSets: {},
+        globalBorderRadius: '0.4rem',
     });
 
     getState() {
@@ -30,6 +32,12 @@ export class OptionStore {
 
     getGlobalColorScheme(component: VsComponent) {
         return this.state.globalColorScheme[component] || this.state.globalColorScheme.default;
+    }
+
+    setGlobalBorderRadius(borderRadius: string = '0.4rem') {
+        this.state.globalBorderRadius = borderRadius;
+
+        document.documentElement.style.setProperty('--vs-border-radius', borderRadius);
     }
 
     registerStyleSet(styleSet: StyleSet) {

--- a/packages/vlossom/src/stores/option-store.ts
+++ b/packages/vlossom/src/stores/option-store.ts
@@ -1,5 +1,6 @@
 import { reactive } from 'vue';
 import { VsComponent } from '@/declaration';
+import { utils } from '@/utils';
 
 import type { GlobalColorScheme, StyleSet } from '@/declaration';
 
@@ -7,7 +8,7 @@ interface OptionStoreState {
     theme: 'light' | 'dark';
     globalColorScheme: GlobalColorScheme;
     styleSets: StyleSet;
-    globalBorderRadius: string;
+    globalRadiusRatio: number;
 }
 
 export class OptionStore {
@@ -15,7 +16,7 @@ export class OptionStore {
         theme: 'light',
         globalColorScheme: {},
         styleSets: {},
-        globalBorderRadius: '0.4rem',
+        globalRadiusRatio: 1,
     });
 
     getState() {
@@ -34,10 +35,14 @@ export class OptionStore {
         return this.state.globalColorScheme[component] || this.state.globalColorScheme.default;
     }
 
-    setGlobalBorderRadius(borderRadius: string = '0.4rem') {
-        this.state.globalBorderRadius = borderRadius;
+    setGlobalRadiusRatio(radiusRatio: number) {
+        if (isNaN(radiusRatio) || radiusRatio < 0 || radiusRatio > 1) {
+            utils.log.error('VlossomOptions', 'The radius ratio must be between 0 and 1');
+            return;
+        }
 
-        document.documentElement.style.setProperty('--vs-border-radius', borderRadius);
+        this.state.globalRadiusRatio = radiusRatio;
+        document.documentElement.style.setProperty('--vs-radius-ratio', radiusRatio.toString());
     }
 
     registerStyleSet(styleSet: StyleSet) {

--- a/packages/vlossom/src/styles/variables.scss
+++ b/packages/vlossom/src/styles/variables.scss
@@ -10,6 +10,7 @@ $variables: (
     drawer-width-md: 32%,
     drawer-width-lg: 60%,
     drawer-width-xl: 80%,
+
     // modal
     modal-height-xs: 20%,
     modal-height-sm: 32%,

--- a/packages/vlossom/src/vlossom-framework.ts
+++ b/packages/vlossom/src/vlossom-framework.ts
@@ -7,12 +7,12 @@ import type { ToastPlugin, ConfirmPlugin } from './plugins';
 
 export class Vlossom {
     constructor(options?: VlossomOptions) {
-        const { colorScheme = {}, styleSet = {}, theme = 'light', borderRadius } = options || {};
+        const { colorScheme = {}, styleSet = {}, theme = 'light', radiusRatio = 1 } = options || {};
 
         this.theme = (this.getDefaultTheme(options) as 'light' | 'dark') || theme;
         store.option.setGlobalColorScheme(colorScheme);
         store.option.registerStyleSet(styleSet);
-        store.option.setGlobalBorderRadius(borderRadius);
+        store.option.setGlobalRadiusRatio(radiusRatio);
 
         if (options?.detectOSTheme) {
             const mediaQueryList = window.matchMedia('(prefers-color-scheme: dark)');
@@ -57,12 +57,12 @@ export class Vlossom {
         return store.option.getState().styleSets;
     }
 
-    get borderRadius() {
-        return store.option.getState().globalBorderRadius;
+    get radiusRatio() {
+        return store.option.getState().globalRadiusRatio;
     }
 
-    set borderRadius(radius: string) {
-        store.option.setGlobalBorderRadius(radius);
+    set radiusRatio(radiusRatio: number) {
+        store.option.setGlobalRadiusRatio(radiusRatio);
     }
 
     toggleTheme() {

--- a/packages/vlossom/src/vlossom-framework.ts
+++ b/packages/vlossom/src/vlossom-framework.ts
@@ -7,11 +7,12 @@ import type { ToastPlugin, ConfirmPlugin } from './plugins';
 
 export class Vlossom {
     constructor(options?: VlossomOptions) {
-        const { colorScheme = {}, styleSet = {}, theme = 'light' } = options || {};
+        const { colorScheme = {}, styleSet = {}, theme = 'light', borderRadius } = options || {};
 
         this.theme = (this.getDefaultTheme(options) as 'light' | 'dark') || theme;
         store.option.setGlobalColorScheme(colorScheme);
         store.option.registerStyleSet(styleSet);
+        store.option.setGlobalBorderRadius(borderRadius);
 
         if (options?.detectOSTheme) {
             const mediaQueryList = window.matchMedia('(prefers-color-scheme: dark)');
@@ -44,12 +45,24 @@ export class Vlossom {
         document.body.classList.toggle('vs-dark', value === 'dark');
     }
 
-    get globalColorScheme() {
+    get colorScheme() {
         return store.option.getState().globalColorScheme;
+    }
+
+    set colorScheme(colorScheme) {
+        store.option.setGlobalColorScheme(colorScheme);
     }
 
     get styleSets() {
         return store.option.getState().styleSets;
+    }
+
+    get borderRadius() {
+        return store.option.getState().globalBorderRadius;
+    }
+
+    set borderRadius(radius: string) {
+        store.option.setGlobalBorderRadius(radius);
     }
 
     toggleTheme() {


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Feature (feat)

## Summary
border-radius를 global option으로 조절할 수 있는 radius ratio를 추가합니다

## Description
- VlossomOptions에 radiusRatio option을 추가합니다
- radiusRatio는 0과 1사이의 값을 가집니다
- 각 컴포넌트에 적용된 border-radius에 radiusRatio를 곱해서 값을 조정합니다

<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
