### PR TITLE
fix(VsCheckbox, VsCheckboxSet): fix before-change input checked bug

### DIFF
--- a/packages/vlossom/playground/Playground.vue
+++ b/packages/vlossom/playground/Playground.vue
@@ -3,14 +3,40 @@
         <template #title>Vlossom Playground</template>
 
         Hello Vlossom!
+        <vs-button @click="checked = !checked">Toggle Checkbox</vs-button>
+        <vs-button @click="onClick">Show Toast</vs-button>
+        <vs-checkbox :before-change="checkConfirm" label="hello" check-label="world" />
+        <input type="checkbox" :checked="checked" />
     </vs-page>
 </template>
 
 <script lang="ts">
+import { ref } from 'vue';
+import { useVlossom } from './../src';
+
 export default {
     name: 'Playground',
     setup() {
-        return {};
+        const $vs = useVlossom();
+
+        const checked = ref(false);
+
+        function onClick() {
+            $vs.toast.show('Hello Vlossom!');
+        }
+
+        async function checkConfirm() {
+            const answer = await $vs.confirm.open('Are you sure?');
+
+            console.log(answer);
+            return answer;
+        }
+
+        return {
+            checkConfirm,
+            checked,
+            onClick,
+        };
     },
 };
 </script>

--- a/packages/vlossom/playground/Playground.vue
+++ b/packages/vlossom/playground/Playground.vue
@@ -3,40 +3,14 @@
         <template #title>Vlossom Playground</template>
 
         Hello Vlossom!
-        <vs-button @click="checked = !checked">Toggle Checkbox</vs-button>
-        <vs-button @click="onClick">Show Toast</vs-button>
-        <vs-checkbox :before-change="checkConfirm" label="hello" check-label="world" />
-        <input type="checkbox" :checked="checked" />
     </vs-page>
 </template>
 
 <script lang="ts">
-import { ref } from 'vue';
-import { useVlossom } from './../src';
-
 export default {
     name: 'Playground',
     setup() {
-        const $vs = useVlossom();
-
-        const checked = ref(false);
-
-        function onClick() {
-            $vs.toast.show('Hello Vlossom!');
-        }
-
-        async function checkConfirm() {
-            const answer = await $vs.confirm.open('Are you sure?');
-
-            console.log(answer);
-            return answer;
-        }
-
-        return {
-            checkConfirm,
-            checked,
-            onClick,
-        };
+        return {};
     },
 };
 </script>

--- a/packages/vlossom/src/components/vs-checkbox-set/VsCheckboxSet.vue
+++ b/packages/vlossom/src/components/vs-checkbox-set/VsCheckboxSet.vue
@@ -71,7 +71,7 @@ import VsWrapper from '@/components/vs-wrapper/VsWrapper.vue';
 import { VsCheckboxNode } from '@/nodes';
 
 import type { VsCheckboxSetStyleSet } from './types';
-import { VsCheckboxStyleSet } from '../vs-checkbox/types';
+import type { VsCheckboxStyleSet } from '@/components/vs-checkbox/types';
 
 const name = VsComponent.VsCheckboxSet;
 

--- a/packages/vlossom/src/components/vs-checkbox-set/VsCheckboxSet.vue
+++ b/packages/vlossom/src/components/vs-checkbox-set/VsCheckboxSet.vue
@@ -90,7 +90,10 @@ export default defineComponent({
         },
         vertical: { type: Boolean, default: false },
         // v-model
-        modelValue: { type: Array as PropType<any[]>, default: () => [] },
+        modelValue: {
+            type: Array as PropType<any[]>,
+            default: () => [],
+        },
     },
     emits: ['update:modelValue', 'update:changed', 'update:valid', 'change', 'focus', 'blur'],
     expose: ['clear', 'validate'],
@@ -149,6 +152,11 @@ export default defineComponent({
             messages,
             rules: allRules,
             callbacks: {
+                onMounted: () => {
+                    if (!inputValue.value) {
+                        inputValue.value = [];
+                    }
+                },
                 onClear: () => {
                     inputValue.value = [];
                 },
@@ -160,11 +168,12 @@ export default defineComponent({
         }
 
         async function onToggle(option: any, checked: boolean) {
-            const beforeChangeFn = beforeChange.value;
             const targetOptionValue = getOptionValue(option);
             const toValue = checked
                 ? [...inputValue.value, targetOptionValue]
                 : inputValue.value.filter((v: any) => !utils.object.isEqual(v, targetOptionValue));
+
+            const beforeChangeFn = beforeChange.value;
             if (beforeChangeFn) {
                 const result = await beforeChangeFn(inputValue.value, toValue, option);
                 if (!result) {

--- a/packages/vlossom/src/components/vs-checkbox-set/__tests__/vs-checkbox-set.test.ts
+++ b/packages/vlossom/src/components/vs-checkbox-set/__tests__/vs-checkbox-set.test.ts
@@ -112,6 +112,7 @@ describe('vs-checkbox-set', () => {
 
                 // when
                 await wrapper.find('input[value="B"]').trigger('click');
+                await nextTick();
 
                 // then
                 const updateModelValueEvent = wrapper.emitted('update:modelValue');
@@ -131,6 +132,7 @@ describe('vs-checkbox-set', () => {
 
                 // when
                 await wrapper.setProps({ modelValue: ['B'] });
+                await nextTick();
 
                 // then
                 const checked = wrapper.findAll('input').filter((e) => e.element.checked);
@@ -178,6 +180,7 @@ describe('vs-checkbox-set', () => {
 
                 // when
                 await wrapper.find('input[value="b"]').trigger('click');
+                await nextTick();
 
                 // then
                 const updateModelValueEvent = wrapper.emitted('update:modelValue');
@@ -197,6 +200,7 @@ describe('vs-checkbox-set', () => {
 
                 // when
                 await wrapper.setProps({ modelValue: ['b'] });
+                await nextTick();
 
                 // then
                 const checked = wrapper.findAll('input').filter((e) => e.element.checked);

--- a/packages/vlossom/src/components/vs-checkbox-set/__tests__/vs-checkbox-set.test.ts
+++ b/packages/vlossom/src/components/vs-checkbox-set/__tests__/vs-checkbox-set.test.ts
@@ -111,7 +111,7 @@ describe('vs-checkbox-set', () => {
                 });
 
                 // when
-                await wrapper.find('input[value="B"]').setValue(true);
+                await wrapper.find('input[value="B"]').trigger('click');
 
                 // then
                 const updateModelValueEvent = wrapper.emitted('update:modelValue');
@@ -177,7 +177,7 @@ describe('vs-checkbox-set', () => {
                 });
 
                 // when
-                await wrapper.find('input[value="b"]').setValue(true);
+                await wrapper.find('input[value="b"]').trigger('click');
 
                 // then
                 const updateModelValueEvent = wrapper.emitted('update:modelValue');
@@ -241,7 +241,7 @@ describe('vs-checkbox-set', () => {
 
             // when
             await nextTick();
-            await wrapper.find('input[value="A"]').setValue(false);
+            await wrapper.find('input[value="A"]').trigger('click');
 
             // then
             expect(wrapper.vm.computedMessages).toHaveLength(1);
@@ -278,7 +278,7 @@ describe('vs-checkbox-set', () => {
 
             // when
             await nextTick();
-            await wrapper.find('input[value="A"]').setValue(false);
+            await wrapper.find('input[value="A"]').trigger('click');
 
             // then
             expect(wrapper.vm.validate()).toBe(false);
@@ -303,7 +303,7 @@ describe('vs-checkbox-set', () => {
             });
 
             // when
-            await wrapper.find('input[value="B"]').setValue(true);
+            await wrapper.find('input[value="B"]').trigger('click');
 
             // then
             expect(beforeChange).toHaveBeenCalledWith(['A'], ['A', 'B'], 'B');
@@ -321,7 +321,7 @@ describe('vs-checkbox-set', () => {
             });
 
             // when
-            await wrapper.find('input[value="B"]').setValue(true);
+            await wrapper.find('input[value="B"]').trigger('click');
 
             // then
             const updateModelValueEvent = wrapper.emitted('update:modelValue');
@@ -341,7 +341,7 @@ describe('vs-checkbox-set', () => {
             });
 
             // when
-            await wrapper.find('input[value="B"]').setValue(true);
+            await wrapper.find('input[value="B"]').trigger('click');
 
             // then
             const updateModelValueEvent = wrapper.emitted('update:modelValue');

--- a/packages/vlossom/src/components/vs-checkbox/VsCheckbox.vue
+++ b/packages/vlossom/src/components/vs-checkbox/VsCheckbox.vue
@@ -116,7 +116,7 @@ export default defineComponent({
             getInitialValue,
             getClearedValue,
             getUpdatedValue,
-        } = useValueMatcher(multiple, modelValue, inputValue, trueValue, falseValue);
+        } = useValueMatcher(multiple, inputValue, trueValue, falseValue);
 
         function requiredCheck() {
             return required.value && !isChecked.value ? 'required' : '';
@@ -142,8 +142,12 @@ export default defineComponent({
         });
 
         async function onToggle(c: boolean) {
+            console.log('🚀 ~ onToggle ~ c:', c);
             const beforeChangeFn = beforeChange.value;
+
             const toValue = getUpdatedValue(c, inputValue.value);
+            console.log('🚀 ~ onToggle ~ toValue:', toValue);
+
             if (beforeChangeFn) {
                 const result = await beforeChangeFn(inputValue.value, toValue);
                 if (!result) {

--- a/packages/vlossom/src/components/vs-checkbox/VsCheckbox.vue
+++ b/packages/vlossom/src/components/vs-checkbox/VsCheckbox.vue
@@ -142,12 +142,9 @@ export default defineComponent({
         });
 
         async function onToggle(c: boolean) {
-            console.log('🚀 ~ onToggle ~ c:', c);
-            const beforeChangeFn = beforeChange.value;
-
             const toValue = getUpdatedValue(c, inputValue.value);
-            console.log('🚀 ~ onToggle ~ toValue:', toValue);
 
+            const beforeChangeFn = beforeChange.value;
             if (beforeChangeFn) {
                 const result = await beforeChangeFn(inputValue.value, toValue);
                 if (!result) {

--- a/packages/vlossom/src/components/vs-checkbox/__tests__/vs-checkbox.test.ts
+++ b/packages/vlossom/src/components/vs-checkbox/__tests__/vs-checkbox.test.ts
@@ -20,6 +20,7 @@ describe('vs-checkbox', () => {
 
             // then
             expect(wrapper.find('input').element.checked).toBe(true);
+            expect(wrapper.vm.isChecked).toBe(true);
         });
 
         it('modelValue를 업데이트 할 수 있다', async () => {
@@ -32,12 +33,13 @@ describe('vs-checkbox', () => {
             });
 
             // when
-            await wrapper.find('input').setValue(true);
+            await wrapper.find('input').trigger('click');
 
             // then
             const updateModelValueEvent = wrapper.emitted('update:modelValue');
             expect(updateModelValueEvent).toHaveLength(1);
             expect(updateModelValueEvent?.[0][0]).toEqual(true);
+            expect(wrapper.find('input').element.checked).toBe(true);
         });
 
         it('modelValue를 바꿔서 checkbox 값을 업데이트 할 수 있다', async () => {
@@ -54,6 +56,7 @@ describe('vs-checkbox', () => {
 
             // then
             expect(wrapper.find('input').element.checked).toBe(true);
+            expect(wrapper.vm.isChecked).toBe(true);
         });
 
         it('modelValue가 null이면 false로 가공해준다', async () => {
@@ -88,6 +91,7 @@ describe('vs-checkbox', () => {
 
             // then
             expect(wrapper.find('input').element.checked).toBe(true);
+            expect(wrapper.vm.isChecked).toBe(true);
         });
 
         it('checkbox를 true로 업데이트하면 modelValue를 true-value 값으로 업데이트 한다', async () => {
@@ -102,7 +106,7 @@ describe('vs-checkbox', () => {
             });
 
             // when
-            await wrapper.find('input').setValue(true);
+            await wrapper.find('input').trigger('click');
 
             // then
             const updateModelValueEvent = wrapper.emitted('update:modelValue');
@@ -122,12 +126,13 @@ describe('vs-checkbox', () => {
             });
 
             // when
-            await wrapper.find('input').setValue(false);
+            await wrapper.find('input').trigger('click');
 
             // then
             const updateModelValueEvent = wrapper.emitted('update:modelValue');
             expect(updateModelValueEvent).toHaveLength(1);
             expect(updateModelValueEvent?.[0][0]).toEqual('B');
+            expect(wrapper.find('input').element.checked).toBe(false);
         });
 
         it('object 타입 true-value, false-value를 설정할 수 있다', () => {
@@ -143,6 +148,7 @@ describe('vs-checkbox', () => {
 
             // then
             expect(wrapper.find('input').element.checked).toBe(true);
+            expect(wrapper.vm.isChecked).toBe(true);
         });
     });
 
@@ -161,6 +167,7 @@ describe('vs-checkbox', () => {
 
                 // then
                 expect(wrapper.find('input').element.checked).toBe(true);
+                expect(wrapper.vm.isChecked).toBe(true);
             });
 
             it('인풋 값을 true로 업데이트하면 true-value가 modelValue배열에 포함된다', async () => {
@@ -175,12 +182,13 @@ describe('vs-checkbox', () => {
                 });
 
                 // when
-                await wrapper.find('input').setValue(true);
+                await wrapper.find('input').trigger('click');
 
                 // then
                 const updateModelValueEvent = wrapper.emitted('update:modelValue');
                 expect(updateModelValueEvent).toHaveLength(1);
                 expect(updateModelValueEvent?.[0][0]).toEqual(['A']);
+                expect(wrapper.find('input').element.checked).toBe(true);
             });
         });
 
@@ -212,12 +220,13 @@ describe('vs-checkbox', () => {
                 });
 
                 // when
-                await wrapper.find('input').setValue(true);
+                await wrapper.find('input').trigger('click');
 
                 // then
                 const updateModelValueEvent = wrapper.emitted('update:modelValue');
                 expect(updateModelValueEvent).toHaveLength(1);
                 expect(updateModelValueEvent?.[0][0]).toEqual('A');
+                expect(wrapper.find('input').element.checked).toBe(true);
             });
         });
 
@@ -237,9 +246,10 @@ describe('vs-checkbox', () => {
 
             // then
             expect(wrapper.find('input').element.checked).toBe(true);
+            expect(wrapper.vm.isChecked).toBe(true);
         });
 
-        it('object array 타입으로 modelValue의 초깃값을 설정할 수 있다', () => {
+        it('object array 타입으로 modelValue의 초깃값을 설정할 수 있다', async () => {
             // given
             const wrapper: ReturnType<typeof mountComponent> = mount(VsCheckbox, {
                 props: {
@@ -250,8 +260,11 @@ describe('vs-checkbox', () => {
                 },
             });
 
+            await nextTick();
+
             // then
             expect(wrapper.find('input').element.checked).toBe(true);
+            expect(wrapper.vm.isChecked).toBe(true);
         });
 
         it('object array 타입으로 modelValue 를 업데이트 할 수 있다', async () => {
@@ -266,7 +279,7 @@ describe('vs-checkbox', () => {
             });
 
             // when
-            await wrapper.find('input').setValue(true);
+            await wrapper.find('input').trigger('click');
 
             // then
             const updateModelValueEvent = wrapper.emitted('update:modelValue');
@@ -290,6 +303,7 @@ describe('vs-checkbox', () => {
 
             // then
             expect(wrapper.find('input').element.checked).toBe(true);
+            expect(wrapper.vm.isChecked).toBe(true);
         });
     });
 
@@ -311,7 +325,7 @@ describe('vs-checkbox', () => {
                 await nextTick();
 
                 // then
-                expect(wrapper.find('input').element.checked).toBe(false);
+                expect(wrapper.vm.isChecked).toBe(false);
                 expect(wrapper.props('modelValue')).toEqual(['B']);
             });
         });
@@ -332,6 +346,7 @@ describe('vs-checkbox', () => {
 
                 // then
                 expect(wrapper.find('input').element.checked).toBe(false);
+                expect(wrapper.vm.isChecked).toBe(false);
                 expect(wrapper.props('modelValue')).toBe(false);
             });
         });
@@ -350,7 +365,7 @@ describe('vs-checkbox', () => {
 
             // when
             await nextTick();
-            await wrapper.find('input').setValue(false);
+            await wrapper.find('input').trigger('click');
 
             // then
             expect(wrapper.vm.computedMessages).toHaveLength(1);
@@ -405,7 +420,7 @@ describe('vs-checkbox', () => {
             });
 
             // when
-            await wrapper.find('input').setValue('A');
+            await wrapper.find('input').trigger('click');
 
             // then
             expect(beforeChange).toHaveBeenCalledWith('B', 'A');
@@ -422,7 +437,7 @@ describe('vs-checkbox', () => {
             });
 
             // when
-            await wrapper.find('input').setValue(true);
+            await wrapper.find('input').trigger('click');
 
             // then
             const updateModelValueEvent = wrapper.emitted('update:modelValue');
@@ -441,7 +456,7 @@ describe('vs-checkbox', () => {
             });
 
             // when
-            await wrapper.find('input').setValue(true);
+            await wrapper.find('input').trigger('click');
 
             // then
             const updateModelValueEvent = wrapper.emitted('update:modelValue');

--- a/packages/vlossom/src/components/vs-notice/VsNotice.vue
+++ b/packages/vlossom/src/components/vs-notice/VsNotice.vue
@@ -24,7 +24,7 @@ import { PropType, defineComponent, ref, toRefs, watch, computed } from 'vue';
 import { useColorScheme, useStyleSet } from '@/composables';
 import { VsComponent, type ColorScheme } from '@/declaration';
 import { VsIcon } from '@/icons';
-import VsDivider from '../vs-divider/VsDivider.vue';
+import VsDivider from '@/components/vs-divider/VsDivider.vue';
 
 import type { VsNoticeStyleSet } from './types';
 

--- a/packages/vlossom/src/components/vs-radio-set/VsRadioSet.vue
+++ b/packages/vlossom/src/components/vs-radio-set/VsRadioSet.vue
@@ -71,7 +71,7 @@ import VsWrapper from '@/components/vs-wrapper/VsWrapper.vue';
 import { VsRadioNode } from '@/nodes';
 
 import type { VsRadioSetStyleSet } from './types';
-import type { VsRadioStyleSet } from './../vs-radio/types';
+import type { VsRadioStyleSet } from '@/components/vs-radio/types';
 
 export default defineComponent({
     name: VsComponent.VsRadioSet,

--- a/packages/vlossom/src/components/vs-radio-set/VsRadioSet.vue
+++ b/packages/vlossom/src/components/vs-radio-set/VsRadioSet.vue
@@ -82,10 +82,6 @@ export default defineComponent({
         ...getResponsiveProps(),
         colorScheme: { type: String as PropType<ColorScheme> },
         styleSet: { type: [String, Object] as PropType<string | VsRadioSetStyleSet> },
-        beforeChange: {
-            type: Function as PropType<(from: any, to: any, option: any) => Promise<boolean> | null>,
-            default: null,
-        },
         name: { type: String, required: true },
         vertical: { type: Boolean, default: false },
         // v-model
@@ -97,7 +93,6 @@ export default defineComponent({
         const {
             colorScheme,
             styleSet,
-            beforeChange,
             disabled,
             label,
             modelValue,
@@ -157,16 +152,7 @@ export default defineComponent({
 
         async function onToggle(option: any) {
             // radio change event value is always true
-            const beforeChangeFn = beforeChange.value;
-            const toValue = getOptionValue(option);
-            if (beforeChangeFn) {
-                const result = await beforeChangeFn(inputValue.value, toValue, option);
-                if (!result) {
-                    return;
-                }
-            }
-
-            inputValue.value = toValue;
+            inputValue.value = getOptionValue(option);
         }
 
         function onFocus(option: any, e: FocusEvent) {

--- a/packages/vlossom/src/components/vs-radio-set/__tests__/vs-radio-set.test.ts
+++ b/packages/vlossom/src/components/vs-radio-set/__tests__/vs-radio-set.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import { mount } from '@vue/test-utils';
 import { nextTick } from 'vue';
 import VsRadioSet from './../VsRadioSet.vue';
@@ -323,69 +323,6 @@ describe('vs-radio-set', () => {
                 expect(wrapper.vm.computedMessages).toHaveLength(1);
                 expect(wrapper.html()).toContain('required');
             });
-        });
-    });
-
-    describe('before change', () => {
-        it('beforeChange 함수에 from, to 인자가 전달된다 ', async () => {
-            // given
-            const beforeChange = vi.fn().mockResolvedValue(true);
-            const wrapper: ReturnType<typeof mountComponent> = mount(VsRadioSet, {
-                props: {
-                    name: 'radio',
-                    modelValue: 'A',
-                    'onUpdate:modelValue': (e) => wrapper.setProps({ modelValue: e }),
-                    options: ['A', 'B', 'C'],
-                    beforeChange,
-                },
-            });
-
-            // when
-            await wrapper.find('input[value="C"]').trigger('change');
-
-            // then
-            expect(beforeChange).toHaveBeenCalledWith('A', 'C', 'C');
-        });
-
-        it('beforeChange 함수가 Promise<true>를 리턴하면 값이 업데이트 된다', async () => {
-            // given
-            const wrapper: ReturnType<typeof mountComponent> = mount(VsRadioSet, {
-                props: {
-                    name: 'test',
-                    modelValue: 'A',
-                    'onUpdate:modelValue': (e) => wrapper.setProps({ modelValue: e }),
-                    options: ['A', 'B', 'C'],
-                    beforeChange: () => Promise.resolve(true),
-                },
-            });
-
-            // when
-            await wrapper.find('input[value="B"]').setValue(true);
-
-            // then
-            const updateModelValueEvent = wrapper.emitted('update:modelValue');
-            expect(updateModelValueEvent).toHaveLength(1);
-            expect(updateModelValueEvent?.[0]).toEqual(['B']);
-        });
-
-        it('beforeChange 함수가 Promise<false>를 리턴하면 값이 업데이트 되지 않는다', async () => {
-            // given
-            const wrapper: ReturnType<typeof mountComponent> = mount(VsRadioSet, {
-                props: {
-                    name: 'test',
-                    modelValue: 'A',
-                    'onUpdate:modelValue': (e) => wrapper.setProps({ modelValue: e }),
-                    options: ['A', 'B', 'C'],
-                    beforeChange: () => Promise.resolve(false),
-                },
-            });
-
-            // when
-            await wrapper.find('input[value="B"]').setValue(true);
-
-            // then
-            const updateModelValueEvent = wrapper.emitted('update:modelValue');
-            expect(updateModelValueEvent).toBeUndefined();
         });
     });
 

--- a/packages/vlossom/src/components/vs-radio-set/stories/VsRadioSet.stories.ts
+++ b/packages/vlossom/src/components/vs-radio-set/stories/VsRadioSet.stories.ts
@@ -7,7 +7,6 @@ import {
     getStateTemplate,
 } from '@/storybook';
 import { UIState } from '@/declaration';
-import { useVlossom } from '@/vlossom-framework';
 import VsContainer from '@/components/vs-container/VsContainer.vue';
 import VsRadioSet from '../VsRadioSet.vue';
 
@@ -110,15 +109,6 @@ export const Readonly: Story = {
 export const Vertical: Story = {
     args: {
         vertical: true,
-    },
-};
-
-export const BeforeChange: Story = {
-    args: {
-        beforeChange: async () => {
-            const $vs = useVlossom();
-            return await $vs.confirm.open('Are you sure?');
-        },
     },
 };
 

--- a/packages/vlossom/src/components/vs-radio/VsRadio.vue
+++ b/packages/vlossom/src/components/vs-radio/VsRadio.vue
@@ -64,10 +64,6 @@ export default defineComponent({
         colorScheme: { type: String as PropType<ColorScheme> },
         styleSet: { type: [String, Object] as PropType<string | VsRadioStyleSet> },
         ariaLabel: { type: String, default: '' },
-        beforeChange: {
-            type: Function as PropType<(from: any, to: any) => Promise<boolean> | null>,
-            default: null,
-        },
         checked: { type: Boolean, default: false },
         name: { type: String, required: true },
         radioLabel: { type: String, default: '' },
@@ -78,19 +74,8 @@ export default defineComponent({
     emits: ['update:modelValue', 'update:changed', 'update:valid', 'change', 'focus', 'blur'],
     expose: ['clear', 'validate'],
     setup(props, context) {
-        const {
-            beforeChange,
-            checked,
-            colorScheme,
-            label,
-            messages,
-            modelValue,
-            name,
-            radioValue,
-            required,
-            rules,
-            styleSet,
-        } = toRefs(props);
+        const { checked, colorScheme, label, messages, modelValue, name, radioValue, required, rules, styleSet } =
+            toRefs(props);
 
         const { emit } = context;
 
@@ -132,16 +117,7 @@ export default defineComponent({
 
         async function onToggle() {
             // radio change event value is always true
-            const beforeChangeFn = beforeChange.value;
-            const toValue = radioValue.value;
-            if (beforeChangeFn) {
-                const result = await beforeChangeFn(inputValue.value, toValue);
-                if (!result) {
-                    return;
-                }
-            }
-
-            inputValue.value = toValue;
+            inputValue.value = radioValue.value;
         }
 
         function onFocus(e: FocusEvent) {

--- a/packages/vlossom/src/components/vs-radio/__tests__/vs-radio.test.ts
+++ b/packages/vlossom/src/components/vs-radio/__tests__/vs-radio.test.ts
@@ -338,24 +338,4 @@ describe('vs-radio (multiple inputs)', () => {
         expect(radio2.vm.computedMessages).toHaveLength(1);
         expect(radio2.html()).toContain('required');
     });
-
-    it('beforeChange 함수에 from, to 인자가 전달된다 ', async () => {
-        // given
-        const beforeChange = vi.fn().mockResolvedValue(true);
-        const radio3: ReturnType<typeof mountComponent> = mount(VsRadio, {
-            props: {
-                name: 'radio',
-                radioValue: 'C',
-                modelValue: 'A',
-                'onUpdate:modelValue': (e) => radio3.setProps({ modelValue: e }),
-                beforeChange,
-            },
-        });
-
-        // when
-        await radio3.find('input').trigger('change');
-
-        // then
-        expect(beforeChange).toHaveBeenCalledWith('A', 'C');
-    });
 });

--- a/packages/vlossom/src/components/vs-radio/stories/VsRadio.stories.ts
+++ b/packages/vlossom/src/components/vs-radio/stories/VsRadio.stories.ts
@@ -7,7 +7,6 @@ import {
     getStateTemplate,
 } from '@/storybook';
 import { UIState } from '@/declaration';
-import { useVlossom } from '@/vlossom-framework';
 import VsContainer from '@/components/vs-container/VsContainer.vue';
 import VsRadio from './../VsRadio.vue';
 
@@ -116,15 +115,6 @@ export const Required: Story = {
     args: {
         label: 'Label',
         required: true,
-    },
-};
-
-export const BeforeChange: Story = {
-    args: {
-        beforeChange: async () => {
-            const $vs = useVlossom();
-            return await $vs.confirm.open('Are you sure?');
-        },
     },
 };
 

--- a/packages/vlossom/src/components/vs-switch/VsSwitch.vue
+++ b/packages/vlossom/src/components/vs-switch/VsSwitch.vue
@@ -163,8 +163,9 @@ export default defineComponent({
                 return;
             }
 
-            const beforeChangeFn = beforeChange.value;
             const toValue = getUpdatedValue(!isChecked.value, inputValue.value);
+
+            const beforeChangeFn = beforeChange.value;
             if (beforeChangeFn) {
                 const result = await beforeChangeFn(inputValue.value, toValue);
                 if (!result) {

--- a/packages/vlossom/src/components/vs-switch/VsSwitch.vue
+++ b/packages/vlossom/src/components/vs-switch/VsSwitch.vue
@@ -137,7 +137,7 @@ export default defineComponent({
             getInitialValue,
             getClearedValue,
             getUpdatedValue,
-        } = useValueMatcher(multiple, modelValue, inputValue, trueValue, falseValue);
+        } = useValueMatcher(multiple, inputValue, trueValue, falseValue);
 
         function requiredCheck() {
             return required.value && !isChecked.value ? 'required' : '';

--- a/packages/vlossom/src/components/vs-table/__tests__/vs-table.test.ts
+++ b/packages/vlossom/src/components/vs-table/__tests__/vs-table.test.ts
@@ -107,7 +107,7 @@ describe('VsTable', () => {
 
             // when
             const selectAllCheckBox = wrapper.find('.select-all').find('input');
-            await selectAllCheckBox.setValue(true);
+            await selectAllCheckBox.trigger('click');
             await nextTick();
 
             // then
@@ -151,7 +151,7 @@ describe('VsTable', () => {
 
             // when
             const firstItemCheckbox = wrapper.findComponent({ name: 'VsTableBodyRow' }).find('input[type="checkbox"]');
-            await firstItemCheckbox.setValue(true);
+            await firstItemCheckbox.trigger('click');
             await nextTick();
 
             // then

--- a/packages/vlossom/src/composables/__tests__/value-matcher-composable.test.ts
+++ b/packages/vlossom/src/composables/__tests__/value-matcher-composable.test.ts
@@ -8,13 +8,12 @@ describe('value-matcher-composable', () => {
             it('inputValue 중 하나라도 trueValue와 일치하면 true를 반환한다 ', () => {
                 // given
                 const multiple = ref(true);
-                const modelValue = ref([1, 2, 3]);
                 const inputValue = ref([1, 2, 3]);
                 const trueValue = ref(1);
                 const falseValue = ref('falseValue');
 
                 // when
-                const { isMatched } = useValueMatcher(multiple, modelValue, inputValue, trueValue, falseValue);
+                const { isMatched } = useValueMatcher(multiple, inputValue, trueValue, falseValue);
 
                 // then
                 expect(isMatched.value).toBe(true);
@@ -23,13 +22,12 @@ describe('value-matcher-composable', () => {
             it('inputValue 중 일치하는 요소가 없으면 false를 반환한다 ', () => {
                 // given
                 const multiple = ref(true);
-                const modelValue = ref([1, 2, 3]);
                 const inputValue = ref([1, 2, 3]);
                 const trueValue = ref(4);
                 const falseValue = ref('falseValue');
 
                 // when
-                const { isMatched } = useValueMatcher(multiple, modelValue, inputValue, trueValue, falseValue);
+                const { isMatched } = useValueMatcher(multiple, inputValue, trueValue, falseValue);
 
                 // then
                 expect(isMatched.value).toBe(false);
@@ -40,13 +38,12 @@ describe('value-matcher-composable', () => {
             it('inputValue 와 trueValue 가 같은 경우, true를 반환한다', () => {
                 // given
                 const multiple = ref(false);
-                const modelValue = ref([1, 2, 3]);
                 const inputValue = ref([1, 2, 3]);
                 const trueValue = ref([1, 2, 3]);
                 const falseValue = ref('falseValue');
 
                 // when
-                const { isMatched } = useValueMatcher(multiple, modelValue, inputValue, trueValue, falseValue);
+                const { isMatched } = useValueMatcher(multiple, inputValue, trueValue, falseValue);
 
                 // then
                 expect(isMatched.value).toBe(true);
@@ -55,13 +52,12 @@ describe('value-matcher-composable', () => {
             it('inputValue 와 trueValue 가 다른 경우, false를 반환한다', () => {
                 // given
                 const multiple = ref(false);
-                const modelValue = ref([1, 2, 3]);
                 const inputValue = ref([1, 2, 3]);
                 const trueValue = ref(1);
                 const falseValue = ref('falseValue');
 
                 // when
-                const { isMatched } = useValueMatcher(multiple, modelValue, inputValue, trueValue, falseValue);
+                const { isMatched } = useValueMatcher(multiple, inputValue, trueValue, falseValue);
 
                 // then
                 expect(isMatched.value).toBe(false);
@@ -71,13 +67,12 @@ describe('value-matcher-composable', () => {
             it('inputValue 와 trueValue 가 같은 경우, true를 반환한다', () => {
                 // given
                 const multiple = ref(true);
-                const modelValue = ref(1);
                 const inputValue = ref(1);
                 const trueValue = ref(1);
                 const falseValue = ref('falseValue');
 
                 // when
-                const { isMatched } = useValueMatcher(multiple, modelValue, inputValue, trueValue, falseValue);
+                const { isMatched } = useValueMatcher(multiple, inputValue, trueValue, falseValue);
 
                 // then
                 expect(isMatched.value).toBe(true);
@@ -86,13 +81,12 @@ describe('value-matcher-composable', () => {
             it('inputValue 와 trueValue 가 다른 경우, false를 반환한다', () => {
                 // given
                 const multiple = ref(true);
-                const modelValue = ref(1);
                 const inputValue = ref(1);
                 const trueValue = ref([1, 2, 3]);
                 const falseValue = ref('falseValue');
 
                 // when
-                const { isMatched } = useValueMatcher(multiple, modelValue, inputValue, trueValue, falseValue);
+                const { isMatched } = useValueMatcher(multiple, inputValue, trueValue, falseValue);
 
                 // then
                 expect(isMatched.value).toBe(false);
@@ -105,13 +99,12 @@ describe('value-matcher-composable', () => {
             it('inputValue를 그대로 반환한다', () => {
                 // given
                 const multiple = ref(true);
-                const modelValue = ref([1, 2, 3]);
                 const inputValue = ref([1, 2, 3]);
                 const trueValue = ref(1);
                 const falseValue = ref('falseValue');
 
                 // when
-                const { getInitialValue } = useValueMatcher(multiple, modelValue, inputValue, trueValue, falseValue);
+                const { getInitialValue } = useValueMatcher(multiple, inputValue, trueValue, falseValue);
 
                 // then
                 expect(getInitialValue()).toEqual([1, 2, 3]);
@@ -122,13 +115,12 @@ describe('value-matcher-composable', () => {
             it('modelValue가 trueValue와 같으면 trueValue를 반환한다', () => {
                 // given
                 const multiple = ref(false);
-                const modelValue = ref([1, 2, 3]);
                 const inputValue = ref([1, 2, 3]);
                 const trueValue = ref([1, 2, 3]);
                 const falseValue = ref('falseValue');
 
                 // when
-                const { getInitialValue } = useValueMatcher(multiple, modelValue, inputValue, trueValue, falseValue);
+                const { getInitialValue } = useValueMatcher(multiple, inputValue, trueValue, falseValue);
 
                 // then
                 expect(getInitialValue()).toEqual([1, 2, 3]);
@@ -137,13 +129,12 @@ describe('value-matcher-composable', () => {
             it('modelValue가 trueValue와 다르면 falseValue를 반환한다', () => {
                 // given
                 const multiple = ref(false);
-                const modelValue = ref([1, 2, 3]);
                 const inputValue = ref([1, 2, 3]);
                 const trueValue = ref(1);
                 const falseValue = ref('falseValue');
 
                 // when
-                const { getInitialValue } = useValueMatcher(multiple, modelValue, inputValue, trueValue, falseValue);
+                const { getInitialValue } = useValueMatcher(multiple, inputValue, trueValue, falseValue);
 
                 // then
                 expect(getInitialValue()).toBe('falseValue');
@@ -154,13 +145,12 @@ describe('value-matcher-composable', () => {
             it('modelValue가 trueValue와 같으면 trueValue를 반환한다', () => {
                 // given
                 const multiple = ref(true);
-                const modelValue = ref(1);
                 const inputValue = ref(1);
                 const trueValue = ref(1);
                 const falseValue = ref('falseValue');
 
                 // when
-                const { getInitialValue } = useValueMatcher(multiple, modelValue, inputValue, trueValue, falseValue);
+                const { getInitialValue } = useValueMatcher(multiple, inputValue, trueValue, falseValue);
 
                 // then
                 expect(getInitialValue()).toBe(1);
@@ -169,13 +159,12 @@ describe('value-matcher-composable', () => {
             it('modelValue가 trueValue와 다르면 falseValue를 반환한다', () => {
                 // given
                 const multiple = ref(true);
-                const modelValue = ref(0);
                 const inputValue = ref(0);
                 const trueValue = ref(1);
                 const falseValue = ref('falseValue');
 
                 // when
-                const { getInitialValue } = useValueMatcher(multiple, modelValue, inputValue, trueValue, falseValue);
+                const { getInitialValue } = useValueMatcher(multiple, inputValue, trueValue, falseValue);
 
                 // then
                 expect(getInitialValue()).toBe('falseValue');
@@ -188,13 +177,12 @@ describe('value-matcher-composable', () => {
             it('trueValue와 같은 값들을 제거한 배열을 반환한다', () => {
                 // given
                 const multiple = ref(true);
-                const modelValue = ref([1, 2, 3]);
                 const inputValue = ref([1, 2, 3]);
                 const trueValue = ref(1);
                 const falseValue = ref('falseValue');
 
                 // when
-                const { getClearedValue } = useValueMatcher(multiple, modelValue, inputValue, trueValue, falseValue);
+                const { getClearedValue } = useValueMatcher(multiple, inputValue, trueValue, falseValue);
 
                 // then
                 expect(getClearedValue()).toEqual([2, 3]);
@@ -205,13 +193,12 @@ describe('value-matcher-composable', () => {
             it('falseValue를 반환한다', () => {
                 // given
                 const multiple = ref(false);
-                const modelValue = ref([1, 2, 3]);
                 const inputValue = ref([1, 2, 3]);
                 const trueValue = ref(1);
                 const falseValue = ref('falseValue');
 
                 // when
-                const { getClearedValue } = useValueMatcher(multiple, modelValue, inputValue, trueValue, falseValue);
+                const { getClearedValue } = useValueMatcher(multiple, inputValue, trueValue, falseValue);
 
                 // then
                 expect(getClearedValue()).toBe('falseValue');
@@ -222,13 +209,12 @@ describe('value-matcher-composable', () => {
             it('falseValue를 반환한다', () => {
                 // given
                 const multiple = ref(true);
-                const modelValue = ref(1);
                 const inputValue = ref(1);
                 const trueValue = ref(1);
                 const falseValue = ref('falseValue');
 
                 // when
-                const { getClearedValue } = useValueMatcher(multiple, modelValue, inputValue, trueValue, falseValue);
+                const { getClearedValue } = useValueMatcher(multiple, inputValue, trueValue, falseValue);
 
                 // then
                 expect(getClearedValue()).toBe('falseValue');
@@ -243,13 +229,12 @@ describe('value-matcher-composable', () => {
                 const value = [1, 2, 3];
 
                 const multiple = ref(true);
-                const modelValue = ref(value);
                 const inputValue = ref(value);
                 const trueValue = ref(1);
                 const falseValue = ref('falseValue');
 
                 // when
-                const { getUpdatedValue } = useValueMatcher(multiple, modelValue, inputValue, trueValue, falseValue);
+                const { getUpdatedValue } = useValueMatcher(multiple, inputValue, trueValue, falseValue);
 
                 // then
                 expect(getUpdatedValue(true, value)).toEqual([1, 2, 3, 1]);
@@ -263,13 +248,12 @@ describe('value-matcher-composable', () => {
                 const value = 0;
 
                 const multiple = ref(false);
-                const modelValue = ref(value);
                 const inputValue = ref(value);
                 const trueValue = ref(1);
                 const falseValue = ref('falseValue');
 
                 // when
-                const { getUpdatedValue } = useValueMatcher(multiple, modelValue, inputValue, trueValue, falseValue);
+                const { getUpdatedValue } = useValueMatcher(multiple, inputValue, trueValue, falseValue);
 
                 // then
                 expect(getUpdatedValue(true, value)).toBe(1);
@@ -282,13 +266,12 @@ describe('value-matcher-composable', () => {
                 const value = 0;
 
                 const multiple = ref(true);
-                const modelValue = ref(value);
                 const inputValue = ref(value);
                 const trueValue = ref(1);
                 const falseValue = ref('falseValue');
 
                 // when
-                const { getUpdatedValue } = useValueMatcher(multiple, modelValue, inputValue, trueValue, falseValue);
+                const { getUpdatedValue } = useValueMatcher(multiple, inputValue, trueValue, falseValue);
 
                 // then
                 expect(getUpdatedValue(true, value)).toBe(1);

--- a/packages/vlossom/src/composables/value-matcher-composable.ts
+++ b/packages/vlossom/src/composables/value-matcher-composable.ts
@@ -3,12 +3,11 @@ import { utils } from '@/utils';
 
 export function useValueMatcher(
     multiple: Ref<boolean>,
-    modelValue: Ref<any>,
     inputValue: Ref<any>,
     trueValue: Ref<any>,
     falseValue: Ref<any>,
 ) {
-    const isArrayValue = computed(() => Array.isArray(modelValue.value));
+    const isArrayValue = computed(() => Array.isArray(inputValue.value));
     const isMultipleValue = computed(() => multiple.value && isArrayValue.value);
 
     const isMatched: ComputedRef<boolean> = computed(() => {
@@ -23,7 +22,7 @@ export function useValueMatcher(
         if (isMultipleValue.value) {
             return inputValue.value;
         }
-        return utils.object.isEqual(modelValue.value, trueValue.value) ? trueValue.value : falseValue.value;
+        return utils.object.isEqual(inputValue.value, trueValue.value) ? trueValue.value : falseValue.value;
     }
 
     function getClearedValue() {

--- a/packages/vlossom/src/index.ts
+++ b/packages/vlossom/src/index.ts
@@ -11,4 +11,6 @@ export * from './vlossom-framework';
 export * from './components';
 export * from './composables';
 export * from './declaration';
+export * from './icons';
+export * from './nodes';
 export * from './utils';

--- a/packages/vlossom/src/nodes/vs-checkbox-node/VsCheckboxNode.scss
+++ b/packages/vlossom/src/nodes/vs-checkbox-node/VsCheckboxNode.scss
@@ -29,7 +29,7 @@ $checkbox-selected-label-color: var(--vs-checkbox-selectedLabelFontColor, $check
             position: absolute;
             top: 0;
             left: 0;
-            opacity: 0;
+            opacity: 1;
             width: 100%;
             height: 100%;
             cursor: pointer;

--- a/packages/vlossom/src/nodes/vs-checkbox-node/VsCheckboxNode.scss
+++ b/packages/vlossom/src/nodes/vs-checkbox-node/VsCheckboxNode.scss
@@ -29,7 +29,7 @@ $checkbox-selected-label-color: var(--vs-checkbox-selectedLabelFontColor, $check
             position: absolute;
             top: 0;
             left: 0;
-            opacity: 1;
+            opacity: 0;
             width: 100%;
             height: 100%;
             cursor: pointer;
@@ -52,7 +52,6 @@ $checkbox-selected-label-color: var(--vs-checkbox-selectedLabelFontColor, $check
 
     &.checked {
         .checkbox-label {
-            font-weight: var(--vs-checkbox-selectedLabelFontWeight, 500);
             color: $checkbox-selected-label-color;
         }
     }

--- a/packages/vlossom/src/nodes/vs-checkbox-node/VsCheckboxNode.vue
+++ b/packages/vlossom/src/nodes/vs-checkbox-node/VsCheckboxNode.vue
@@ -3,6 +3,7 @@
         <div class="checkbox-wrap">
             <vs-icon class="check-icon" :icon="icon" />
             <input
+                ref="checkboxRef"
                 type="checkbox"
                 :class="['checkbox-input', boxGlowByState]"
                 :aria-label="ariaLabel"
@@ -12,9 +13,9 @@
                 :value="convertToString(value)"
                 :checked="checked"
                 :aria-required="required"
-                @change="toggle"
-                @focus="onFocus"
-                @blur="onBlur"
+                @click.prevent.stop="onClick"
+                @focus.stop="onFocus"
+                @blur.stop="onBlur"
             />
         </div>
         <label v-if="label || $slots['label']" :for="id" :class="['checkbox-label', textGlowByState]">
@@ -24,11 +25,12 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, PropType, toRefs } from 'vue';
+import { computed, defineComponent, PropType, Ref, ref, toRefs, watch } from 'vue';
 import { ColorScheme, UIState } from '@/declaration';
 import { useStateClass } from '@/composables';
 import { utils } from '@/utils';
 import { VsIcon } from '@/icons';
+import { nextTick } from 'process';
 
 export default defineComponent({
     name: 'VsCheckboxNode',
@@ -54,6 +56,8 @@ export default defineComponent({
 
         const { boxGlowByState, textGlowByState } = useStateClass(state);
 
+        const checkboxRef: Ref<HTMLInputElement | null> = ref(null);
+
         const classObj = computed(() => ({
             checked: checked.value,
             disabled: disabled.value,
@@ -72,9 +76,9 @@ export default defineComponent({
             return 'checkboxUnchecked';
         });
 
-        function toggle(event: Event) {
+        function onClick(event: Event) {
             emit('change', event);
-            emit('toggle', (event.target as HTMLInputElement).checked);
+            emit('toggle', !checked.value);
         }
 
         function onFocus(event: FocusEvent) {
@@ -85,10 +89,23 @@ export default defineComponent({
             emit('blur', event);
         }
 
+        watch(
+            checked,
+            (value) => {
+                nextTick(() => {
+                    if (checkboxRef.value) {
+                        checkboxRef.value.checked = value;
+                    }
+                });
+            },
+            { immediate: true },
+        );
+
         return {
+            checkboxRef,
             classObj,
             icon,
-            toggle,
+            onClick,
             onFocus,
             onBlur,
             convertToString: utils.string.convertToString,

--- a/packages/vlossom/src/nodes/vs-checkbox-node/VsCheckboxNode.vue
+++ b/packages/vlossom/src/nodes/vs-checkbox-node/VsCheckboxNode.vue
@@ -25,12 +25,11 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, PropType, Ref, ref, toRefs, watch } from 'vue';
+import { computed, defineComponent, nextTick, PropType, Ref, ref, toRefs, watch } from 'vue';
 import { ColorScheme, UIState } from '@/declaration';
 import { useStateClass } from '@/composables';
 import { utils } from '@/utils';
 import { VsIcon } from '@/icons';
-import { nextTick } from 'process';
 
 export default defineComponent({
     name: 'VsCheckboxNode',

--- a/packages/vlossom/src/nodes/vs-checkbox-node/__tests__/vs-checkbox-node.test.ts
+++ b/packages/vlossom/src/nodes/vs-checkbox-node/__tests__/vs-checkbox-node.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { mount } from '@vue/test-utils';
 import VsCheckboxNode from './../VsCheckboxNode.vue';
+import { nextTick } from 'vue';
 
 function mountComponent() {
     return mount(VsCheckboxNode);
@@ -18,6 +19,7 @@ describe('vs-checkbox-node', () => {
             });
 
             // then
+            expect(wrapper.find('input').element.checked).toBe(false);
             expect(wrapper.vm.icon).toBe('checkboxUnchecked');
         });
 
@@ -31,6 +33,7 @@ describe('vs-checkbox-node', () => {
             });
 
             // then
+            expect(wrapper.find('input').element.checked).toBe(true);
             expect(wrapper.vm.icon).toBe('checkboxChecked');
         });
 
@@ -45,6 +48,7 @@ describe('vs-checkbox-node', () => {
             });
 
             // then
+            expect(wrapper.find('input').element.checked).toBe(false);
             expect(wrapper.vm.icon).toBe('checkboxIndeterminate');
         });
 
@@ -59,6 +63,7 @@ describe('vs-checkbox-node', () => {
             });
 
             // then
+            expect(wrapper.find('input').element.checked).toBe(true);
             expect(wrapper.vm.icon).toBe('checkboxChecked');
         });
     });
@@ -123,12 +128,12 @@ describe('vs-checkbox-node', () => {
             });
 
             // when
-            await wrapper.find('input').trigger('change');
+            await wrapper.find('input').trigger('click');
 
             // then
             expect(wrapper.emitted('change')).toHaveLength(1);
             expect(wrapper.emitted('toggle')).toHaveLength(1);
-            expect(wrapper.emitted('toggle')).toEqual([[true]]);
+            expect(wrapper.emitted('toggle')).toEqual([[false]]);
         });
 
         it('focus 이벤트를 발생시킬 수 있다', async () => {

--- a/packages/vlossom/src/nodes/vs-checkbox-node/__tests__/vs-checkbox-node.test.ts
+++ b/packages/vlossom/src/nodes/vs-checkbox-node/__tests__/vs-checkbox-node.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { mount } from '@vue/test-utils';
 import VsCheckboxNode from './../VsCheckboxNode.vue';
-import { nextTick } from 'vue';
 
 function mountComponent() {
     return mount(VsCheckboxNode);

--- a/packages/vlossom/src/nodes/vs-checkbox-node/types.ts
+++ b/packages/vlossom/src/nodes/vs-checkbox-node/types.ts
@@ -6,5 +6,4 @@ export interface VsCheckboxNodeStyleSet {
     labelFontColor?: string;
     labelFontSize?: string;
     selectedLabelFontColor?: string;
-    selectedLabelFontWeight?: string | number;
 }

--- a/packages/vlossom/src/nodes/vs-radio-node/VsRadioNode.scss
+++ b/packages/vlossom/src/nodes/vs-radio-node/VsRadioNode.scss
@@ -22,7 +22,6 @@ $radio-selected-inset-box-shadow: inset 0 0 0 calc($radio-size / 3) $radio-color
             opacity: 0;
 
             &:checked + .radio-label {
-                font-weight: var(--vs-radio-selectedLabelFontWeight, 500);
                 color: $radio-selected-label-color;
 
                 &:before {

--- a/packages/vlossom/src/nodes/vs-radio-node/types.ts
+++ b/packages/vlossom/src/nodes/vs-radio-node/types.ts
@@ -6,5 +6,4 @@ export interface VsRadioNodeStyleSet {
     radioColor?: string;
     radioSize?: string;
     selectedLabelFontColor?: string;
-    selectedLabelFontWeight?: string | number;
 }

--- a/packages/vlossom/src/vlossom-framework.ts
+++ b/packages/vlossom/src/vlossom-framework.ts
@@ -33,6 +33,10 @@ export class Vlossom {
         return '';
     }
 
+    get store() {
+        return store;
+    }
+
     get theme() {
         return store.option.getState().theme;
     }


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary
checkbox의 before-change bug를 수정하고, radio에서는 before-change를 제거합니다

## Description
- checkbox node input에 preventDefault를 걸어서 checkbox의 checked를 native가 아니라 직접 컨트롤 하도록 변경합니다
- radio before-change는 버그 요소가 많고, 사용 빈도가 낮을 것으로 예상되어 제거합니다
- 
<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
