### PR TITLE
feat(scroll): add vlossom scroll bar style (chromatic-build)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
     "requires": true,
     "packages": {
         "": {
-            "name": "vlossom",
             "version": "0.0.1",
             "workspaces": [
                 "packages/*"

--- a/packages/vlossom/src/components/vs-block/VsBlock.scss
+++ b/packages/vlossom/src/components/vs-block/VsBlock.scss
@@ -3,11 +3,11 @@ $borderStyle: var(--vs-block-borderStyle, solid);
 $borderColor: var(--vs-block-borderColor, var(--vs-line-color));
 
 .vs-block {
-    border: var(--vs-block-border, $borderWidth $borderStyle $borderColor);
-    border-radius: var(--vs-block-borderRadius, 0.4rem);
-    overflow: hidden;
     position: relative;
     width: 100%;
+    overflow: auto;
+    border: var(--vs-block-border, $borderWidth $borderStyle $borderColor);
+    border-radius: var(--vs-block-borderRadius, 0.4rem);
 
     .block-header {
         background-color: var(--vs-block-headerBackgroundColor, var(--vs-comp-backgroundColor));

--- a/packages/vlossom/src/components/vs-drawer/VsDrawer.vue
+++ b/packages/vlossom/src/components/vs-drawer/VsDrawer.vue
@@ -110,11 +110,19 @@ export default defineComponent({
         watch(isOpen, (val) => {
             if (dimmed.value) {
                 if (val && !hasContainer.value) {
-                    document.body.style.overflow = 'hidden';
-                    document.body.style.paddingRight = '15px';
+                    if (document.body.scrollHeight > window.innerHeight) {
+                        document.body.style.overflow = 'hidden';
+                        document.body.style.paddingRight = '0.4rem';
+                    }
+
+                    if (document.body.scrollWidth > window.innerWidth) {
+                        document.body.style.overflow = 'hidden';
+                        document.body.style.paddingBottom = '0.4rem';
+                    }
                 } else {
                     document.body.style.overflow = '';
                     document.body.style.paddingRight = '';
+                    document.body.style.paddingBottom = '';
                 }
             }
 

--- a/packages/vlossom/src/components/vs-section/VsSection.scss
+++ b/packages/vlossom/src/components/vs-section/VsSection.scss
@@ -5,6 +5,7 @@
     color: var(--vs-section-fontColor, var(--vs-font-color));
     padding: var(--vs-section-padding, 2.8rem 3.2rem);
     position: relative;
+    overflow: auto;
 
     .section-title {
         margin: var(--vs-section-titleMargin, 0 0 1.2rem 0);

--- a/packages/vlossom/src/styles/base.scss
+++ b/packages/vlossom/src/styles/base.scss
@@ -1,12 +1,48 @@
 @import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css');
 
 body {
-    font-family: 'Pretendard Variable', Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto,
-        'Helvetica Neue', 'Segoe UI', 'Apple SD Gothic Neo', 'Noto Sans KR', 'Malgun Gothic', 'Apple Color Emoji',
-        'Segoe UI Emoji', 'Segoe UI Symbol', sans-serif;
+    font-family:
+        'Pretendard Variable',
+        Pretendard,
+        -apple-system,
+        BlinkMacSystemFont,
+        system-ui,
+        Roboto,
+        'Helvetica Neue',
+        'Segoe UI',
+        'Apple SD Gothic Neo',
+        'Noto Sans KR',
+        'Malgun Gothic',
+        'Apple Color Emoji',
+        'Segoe UI Emoji',
+        'Segoe UI Symbol',
+        sans-serif;
     font-weight: 400;
 }
 
 .vs-inline-gap:has(+ .vs-inline-gap) {
     margin-right: 0.3rem;
+}
+
+// vlossom scrollbar
+::-webkit- {
+    &scrollbar {
+        width: 0.4rem;
+    }
+
+    &scrollbar:horizontal {
+        height: 0.4rem;
+    }
+
+    &scrollbar-thumb {
+        border-radius: 8px;
+        background-color: rgba(#b9b9b9, 0.6);
+        &:hover {
+            background-color: rgba(#a1a1a1, 1);
+        }
+    }
+
+    &scrollbar-corner {
+        background-color: transparent;
+    }
 }


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Feature (feat)

## Summary
Vlossom scroll bar에 스타일을 입히는 작업입니다.

## Description
![image](https://github.com/pubg/vlossom/assets/28954218/004c4a7a-a63b-429f-bb0e-67e9334cf2f1)

- 브라우저마다 scroll style이 달라서 vlossom에서 스크롤 스타일을 아예 지정해버립니다
- color-scheme에 따라서 변경 가능한 부분도 있어서 나중에 개선해도 좋을 것 같습니다

<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
