### PR TITLE
fix(VsTabs): remove scrobar-width css

### DIFF
--- a/packages/vlossom/src/components/vs-tabs/VsTabs.scss
+++ b/packages/vlossom/src/components/vs-tabs/VsTabs.scss
@@ -11,9 +11,21 @@ $fontWeight: var(--vs-tabs-fontWeight, 400);
         display: inline-flex;
         list-style: none;
         overflow-x: auto;
+        overflow-y: hidden;
+        position: relative;
 
         &.bottomLine {
-            border-bottom: 1px solid var(--vs-tabs-borderBottomColor, var(--vs-comp-border-color));
+            padding-bottom: 0.2rem;
+            &::after {
+                content: '';
+                position: absolute;
+                height: 1px;
+                width: var(--after-width, 100%);
+                left: 0;
+                right: 0;
+                top: var(--vs-tabs-height, 1.7rem);
+                background-color: var(--vs-tabs-borderBottomColor, var(--vs-comp-border-color));
+            }
         }
 
         .tab {

--- a/packages/vlossom/src/components/vs-tabs/VsTabs.scss
+++ b/packages/vlossom/src/components/vs-tabs/VsTabs.scss
@@ -11,7 +11,6 @@ $fontWeight: var(--vs-tabs-fontWeight, 400);
         display: inline-flex;
         list-style: none;
         overflow-x: auto;
-        scrollbar-width: thin;
 
         &.bottomLine {
             border-bottom: 1px solid var(--vs-tabs-borderBottomColor, var(--vs-comp-border-color));

--- a/packages/vlossom/src/components/vs-tabs/VsTabs.scss
+++ b/packages/vlossom/src/components/vs-tabs/VsTabs.scss
@@ -20,7 +20,7 @@ $fontWeight: var(--vs-tabs-fontWeight, 400);
                 content: '';
                 position: absolute;
                 height: 1px;
-                width: var(--after-width, 100%);
+                width: var(--scroll-width, 100%);
                 left: 0;
                 right: 0;
                 top: var(--vs-tabs-height, 1.7rem);

--- a/packages/vlossom/src/components/vs-tabs/VsTabs.scss
+++ b/packages/vlossom/src/components/vs-tabs/VsTabs.scss
@@ -6,63 +6,56 @@ $fontWeight: var(--vs-tabs-fontWeight, 400);
     overflow-x: hidden;
     user-select: none;
 
-    ul {
-        align-items: center;
-        display: inline-flex;
-        list-style: none;
+    .tabs-container {
         overflow-x: auto;
-        overflow-y: hidden;
-        position: relative;
+        padding-bottom: 0.2rem;
 
-        &.bottomLine {
-            padding-bottom: 0.2rem;
-            &::after {
-                content: '';
-                position: absolute;
-                height: 1px;
-                width: var(--scroll-width, 100%);
-                left: 0;
-                right: 0;
-                top: var(--vs-tabs-height, 1.7rem);
-                background-color: var(--vs-tabs-borderBottomColor, var(--vs-comp-border-color));
-            }
-        }
-
-        .tab {
+        ul {
             align-items: center;
-            background: transparent;
-            color: var(--vs-tabs-fontColor, var(--vs-comp-color));
-            cursor: pointer;
             display: inline-flex;
-            font-size: var(--vs-tabs-fontSize, 1rem);
-            font-weight: $fontWeight;
-            height: var(--vs-tabs-height, auto);
-            justify-content: center;
-            padding: var(--vs-tabs-padding, 0.2rem 1rem);
-            text-align: center;
-            transition: color 0.1s;
-            width: var(--vs-tabs-tabWidth, auto);
-            min-width: fit-content;
+            list-style: none;
+            flex-wrap: nowrap;
 
-            &:not(:last-child) {
-                margin-right: var(--vs-tabs-gap, 0.3rem);
+            &.bottomLine {
+                border-bottom: 1px solid var(--vs-tabs-borderBottomColor, var(--vs-comp-border-color));
             }
 
-            &:hover {
-                background-color: var(--vs-tabs-backgroundColor, var(--vs-light-backgroundColor));
-            }
+            .tab {
+                align-items: center;
+                background: transparent;
+                color: var(--vs-tabs-fontColor, var(--vs-comp-color));
+                cursor: pointer;
+                display: inline-flex;
+                font-size: var(--vs-tabs-fontSize, 1rem);
+                font-weight: $fontWeight;
+                height: var(--vs-tabs-height, auto);
+                justify-content: center;
+                padding: var(--vs-tabs-padding, 0.2rem 1rem);
+                text-align: center;
+                transition: color 0.1s;
+                width: var(--vs-tabs-tabWidth, auto);
+                min-width: fit-content;
 
-            &:focus {
-                outline: none;
-            }
+                &:not(:last-child) {
+                    margin-right: var(--vs-tabs-gap, 0.3rem);
+                }
 
-            &.primary {
-                border-bottom: 2px solid var(--vs-tabs-backgroundColor, var(--vs-comp-backgroundColor-primary));
-                font-weight: calc($fontWeight + 200);
-            }
+                &:hover {
+                    background-color: var(--vs-tabs-backgroundColor, var(--vs-light-backgroundColor));
+                }
 
-            &.disabled {
-                @include disabled;
+                &:focus {
+                    outline: none;
+                }
+
+                &.primary {
+                    border-bottom: 2px solid var(--vs-tabs-backgroundColor, var(--vs-comp-backgroundColor-primary));
+                    font-weight: calc($fontWeight + 200);
+                }
+
+                &.disabled {
+                    @include disabled;
+                }
             }
         }
     }

--- a/packages/vlossom/src/components/vs-tabs/VsTabs.vue
+++ b/packages/vlossom/src/components/vs-tabs/VsTabs.vue
@@ -11,24 +11,26 @@
             >
                 <vs-icon icon="goPrev" size="1.2rem" />
             </button>
-            <ul role="tablist" ref="tabsContainerRef" :class="{ bottomLine }">
-                <li
-                    v-for="(tab, index) in tabs"
-                    ref="tabRefs"
-                    :key="tab"
-                    :class="['tab', { primary: isSelected(index), disabled: isDisabled(index) }]"
-                    role="tab"
-                    :aria-selected="isSelected(index)"
-                    :aria-disabled="isDisabled(index)"
-                    :tabindex="isSelected(index) ? 0 : -1"
-                    @click.stop="selectTab(index)"
-                    @keydown.stop="handleKeydown"
-                >
-                    <slot :name="tab" :index="index">
-                        {{ tab }}
-                    </slot>
-                </li>
-            </ul>
+            <div class="tabs-container">
+                <ul role="tablist" ref="tabsContainerRef" :class="{ bottomLine }">
+                    <li
+                        v-for="(tab, index) in tabs"
+                        ref="tabRefs"
+                        :key="tab"
+                        :class="['tab', { primary: isSelected(index), disabled: isDisabled(index) }]"
+                        role="tab"
+                        :aria-selected="isSelected(index)"
+                        :aria-disabled="isDisabled(index)"
+                        :tabindex="isSelected(index) ? 0 : -1"
+                        @click.stop="selectTab(index)"
+                        @keydown.stop="handleKeydown"
+                    >
+                        <slot :name="tab" :index="index">
+                            {{ tab }}
+                        </slot>
+                    </li>
+                </ul>
+            </div>
             <button
                 v-if="showScrollButtons"
                 type="button"
@@ -44,18 +46,7 @@
 </template>
 
 <script lang="ts">
-import {
-    computed,
-    defineComponent,
-    toRefs,
-    ref,
-    watch,
-    onMounted,
-    onUpdated,
-    onUnmounted,
-    type Ref,
-    type PropType,
-} from 'vue';
+import { computed, defineComponent, toRefs, ref, watch, onMounted, onUnmounted, type Ref, type PropType } from 'vue';
 import { useColorScheme, useStyleSet, getResponsiveProps } from '@/composables';
 import { VsComponent, type ColorScheme } from '@/declaration';
 import { utils } from '@/utils';
@@ -248,22 +239,9 @@ export default defineComponent({
             scrollTo(targetIndex);
         }
 
-        function updateAfterWidth() {
-            if (!tabsContainerRef.value) {
-                return;
-            }
-            const scrollWidth = tabsContainerRef.value.scrollWidth;
-            tabsContainerRef.value?.style.setProperty('--scroll-width', `${scrollWidth}px`);
-        }
-
         onMounted(() => {
             calculateScrollCount();
             window.addEventListener('resize', calculateScrollCount);
-            updateAfterWidth();
-        });
-
-        onUpdated(() => {
-            updateAfterWidth();
         });
 
         onUnmounted(() => {

--- a/packages/vlossom/src/components/vs-tabs/VsTabs.vue
+++ b/packages/vlossom/src/components/vs-tabs/VsTabs.vue
@@ -253,7 +253,7 @@ export default defineComponent({
                 return;
             }
             const scrollWidth = tabsContainerRef.value.scrollWidth;
-            tabsContainerRef.value?.style.setProperty('--after-width', `${scrollWidth}px`);
+            tabsContainerRef.value?.style.setProperty('--scroll-width', `${scrollWidth}px`);
         }
 
         onMounted(() => {

--- a/packages/vlossom/src/components/vs-tabs/VsTabs.vue
+++ b/packages/vlossom/src/components/vs-tabs/VsTabs.vue
@@ -11,8 +11,8 @@
             >
                 <vs-icon icon="goPrev" size="1.2rem" />
             </button>
-            <div class="tabs-container">
-                <ul role="tablist" ref="tabsContainerRef" :class="{ bottomLine }">
+            <div class="tabs-container" ref="tabsContainerRef">
+                <ul role="tablist" :class="{ bottomLine }">
                     <li
                         v-for="(tab, index) in tabs"
                         ref="tabRefs"

--- a/packages/vlossom/src/components/vs-tabs/VsTabs.vue
+++ b/packages/vlossom/src/components/vs-tabs/VsTabs.vue
@@ -44,7 +44,18 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, toRefs, ref, watch, onMounted, onUnmounted, type Ref, type PropType } from 'vue';
+import {
+    computed,
+    defineComponent,
+    toRefs,
+    ref,
+    watch,
+    onMounted,
+    onUpdated,
+    onUnmounted,
+    type Ref,
+    type PropType,
+} from 'vue';
 import { useColorScheme, useStyleSet, getResponsiveProps } from '@/composables';
 import { VsComponent, type ColorScheme } from '@/declaration';
 import { utils } from '@/utils';
@@ -237,9 +248,22 @@ export default defineComponent({
             scrollTo(targetIndex);
         }
 
+        function updateAfterWidth() {
+            if (!tabsContainerRef.value) {
+                return;
+            }
+            const scrollWidth = tabsContainerRef.value.scrollWidth;
+            tabsContainerRef.value?.style.setProperty('--after-width', `${scrollWidth}px`);
+        }
+
         onMounted(() => {
             calculateScrollCount();
             window.addEventListener('resize', calculateScrollCount);
+            updateAfterWidth();
+        });
+
+        onUpdated(() => {
+            updateAfterWidth();
         });
 
         onUnmounted(() => {


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary
- 웨일브라우저에서 스크롤이 컨텐츠영역을 침범하는 현상이 발생하여, scrollbar-width 속성을 제거합니다.

- scrollbar 가 bottom-line 아래쪽으로 생기도록 하기 위해 tabs-container를 추가합니다.


