### PR TITLE
fix(VsDrawer): initialize body overflow when closing drawer

### DIFF
--- a/packages/vlossom/src/components/vs-drawer/VsDrawer.vue
+++ b/packages/vlossom/src/components/vs-drawer/VsDrawer.vue
@@ -38,6 +38,7 @@ import {
     ref,
     toRefs,
     watch,
+    onMounted,
     computed,
     type PropType,
     getCurrentInstance,
@@ -140,6 +141,11 @@ export default defineComponent({
         });
 
         const isOpen = ref(modelValue.value);
+        const originalOverflow = ref('');
+
+        onMounted(() => {
+            originalOverflow.value = document.body.style.overflow;
+        });
 
         watch(
             modelValue,
@@ -154,15 +160,21 @@ export default defineComponent({
             (val) => {
                 if (dimmed.value) {
                     if (val && position.value === 'fixed') {
-                        if (document.body.scrollHeight > window.innerHeight) {
-                            document.body.style.overflow = 'hidden';
-                            document.body.style.paddingRight = '0.4rem';
-                        }
+                        setTimeout(() => {
+                            if (document.body.scrollHeight > window.innerHeight) {
+                                document.body.style.overflow = 'hidden';
+                                document.body.style.paddingRight = '0.4rem';
+                            }
 
-                        if (document.body.scrollWidth > window.innerWidth) {
-                            document.body.style.overflow = 'hidden';
-                            document.body.style.paddingBottom = '0.4rem';
-                        }
+                            if (document.body.scrollWidth > window.innerWidth) {
+                                document.body.style.overflow = 'hidden';
+                                document.body.style.paddingBottom = '0.4rem';
+                            }
+                        });
+                    } else {
+                        document.body.style.overflow = originalOverflow.value;
+                        document.body.style.paddingRight = '0';
+                        document.body.style.paddingBottom = '0';
                     }
                 }
 

--- a/packages/vlossom/src/components/vs-drawer/VsDrawer.vue
+++ b/packages/vlossom/src/components/vs-drawer/VsDrawer.vue
@@ -158,8 +158,8 @@ export default defineComponent({
         watch(
             isOpen,
             (val) => {
-                if (dimmed.value) {
-                    if (val && position.value === 'fixed') {
+                if (dimmed.value && position.value === 'fixed') {
+                    if (val) {
                         setTimeout(() => {
                             if (document.body.scrollHeight > window.innerHeight) {
                                 document.body.style.overflow = 'hidden';


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary
- fixed 인 drawer 를 열었다가 닫았을 때 상하 스크롤이 동작하지 않는 버그를 수정합니다.
- dimmed drawer에 대해서만 발생하는 버그입니다.

## Description
- drawer가 닫히면(isOpen = false) 스크롤이 가능해지도록 overflow 를 초기화합니다. 
- 최초 마운트 후에 document.body.scrollHeight 가 제대로 감지되지 않습니다. 약간의 시간차이 (순서차이)가 발생합니다. 
   - setTimeout 을 0초로 걸어주면 감지됩니다.
   - nextTick 을 걸어보았지만 감지되지 않았습니다.

