### PR TITLE
fix(VsPagination): fix the position of page-button when overflox-x occurs

### DIFF
--- a/packages/vlossom/src/components/vs-pagination/VsPagination.scss
+++ b/packages/vlossom/src/components/vs-pagination/VsPagination.scss
@@ -2,12 +2,9 @@
     position: relative;
     display: flex;
     justify-content: center;
-    align-items: center;
 
     .page-buttons {
         display: flex;
-        align-items: center;
-        justify-content: center;
         overflow-x: auto;
     }
 


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Feature (feat)

## Summary
- x축 overflow 발생 시 scroll bar가 생기면서 page button들이 right, left control button보다 위로 밀려 올라가는 버그를 수정합니다.
