### PR TITLE
fix(VsButton): modify loading icon position absolute

### DIFF
--- a/packages/vlossom/src/components/vs-button/VsButton.scss
+++ b/packages/vlossom/src/components/vs-button/VsButton.scss
@@ -40,7 +40,7 @@
         opacity: 0;
         width: 120%;
         height: 100%;
-        background: #ffffff;
+        background: var(--vs-white);
         transition: all 0.4s ease-out;
         pointer-events: none;
     }
@@ -119,21 +119,43 @@
 
 // loading
 .vs-button {
-    @keyframes rotate {
-        0% {
-            transform: rotate(0deg);
-        }
-        100% {
-            transform: rotate(360deg);
-        }
+    .content {
+        visibility: visible;
+    }
+
+    .loading-icon {
+        visibility: hidden;
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        line-height: 1;
+        font-size: 0;
     }
 
     &.loading {
         pointer-events: none;
 
-        .loading-icon {
-            animation: rotate 2s linear infinite;
+        .content {
+            visibility: hidden;
         }
+
+        .loading-icon {
+            visibility: visible;
+        }
+    }
+
+    .rotate-ani {
+        animation: rotate 2s linear infinite;
+    }
+}
+
+@keyframes rotate {
+    0% {
+        transform: rotate(0deg);
+    }
+    100% {
+        transform: rotate(360deg);
     }
 }
 

--- a/packages/vlossom/src/components/vs-button/VsButton.scss
+++ b/packages/vlossom/src/components/vs-button/VsButton.scss
@@ -131,6 +131,10 @@
         transform: translate(-50%, -50%);
         line-height: 1;
         font-size: 0;
+        
+        .vs-icon {
+            animation: rotate 2s linear infinite;
+        }
     }
 
     &.loading {
@@ -143,10 +147,6 @@
         .loading-icon {
             visibility: visible;
         }
-    }
-
-    .rotate-ani {
-        animation: rotate 2s linear infinite;
     }
 }
 

--- a/packages/vlossom/src/components/vs-button/VsButton.scss
+++ b/packages/vlossom/src/components/vs-button/VsButton.scss
@@ -143,7 +143,7 @@
         .loading-icon {
             visibility: visible;
 
-            .vs-icon {
+            .rotate {
                 animation: rotate 2s linear infinite;
             }
         }

--- a/packages/vlossom/src/components/vs-button/VsButton.scss
+++ b/packages/vlossom/src/components/vs-button/VsButton.scss
@@ -131,10 +131,6 @@
         transform: translate(-50%, -50%);
         line-height: 1;
         font-size: 0;
-        
-        .vs-icon {
-            animation: rotate 2s linear infinite;
-        }
     }
 
     &.loading {
@@ -146,6 +142,10 @@
 
         .loading-icon {
             visibility: visible;
+
+            .vs-icon {
+                animation: rotate 2s linear infinite;
+            }
         }
     }
 }

--- a/packages/vlossom/src/components/vs-button/VsButton.vue
+++ b/packages/vlossom/src/components/vs-button/VsButton.vue
@@ -11,7 +11,7 @@
         </span>
 
         <span class="loading-icon">
-            <vs-icon icon="rotateRight" class="rotate-ani" :size="dense ? 15 : 20" />
+            <vs-icon icon="rotateRight" :size="dense ? 15 : 20" />
         </span>
     </button>
 </template>

--- a/packages/vlossom/src/components/vs-button/VsButton.vue
+++ b/packages/vlossom/src/components/vs-button/VsButton.vue
@@ -6,11 +6,13 @@
         :disabled="disabled"
         :aria-label="loading ? 'loading' : undefined"
     >
-        <span v-if="!loading" class="content">
+        <span class="content">
             <slot />
         </span>
 
-        <vs-icon v-if="loading" class="loading-icon" icon="rotateRight" :size="dense ? 20 : 24" />
+        <span class="loading-icon">
+            <vs-icon icon="rotateRight" class="rotate-ani" :size="dense ? 15 : 20" />
+        </span>
     </button>
 </template>
 

--- a/packages/vlossom/src/components/vs-button/VsButton.vue
+++ b/packages/vlossom/src/components/vs-button/VsButton.vue
@@ -11,7 +11,7 @@
         </span>
 
         <span class="loading-icon">
-            <vs-icon icon="rotateRight" :size="dense ? 15 : 20" />
+            <vs-icon class="rotate" icon="rotateRight" :size="dense ? 15 : 20" />
         </span>
     </button>
 </template>


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x]  Fix Bug (fix)

## Summary
- loading = true일 때 loading-icon 크기에 맞춰 vs-button 크기가 작아지는 이슈를 수정합니다.

수정 전
<img width="511" alt="image" src="https://github.com/pubg/vlossom/assets/109822768/ac95021b-6fec-48a9-a168-742c46a1e74c">


수정 후
<img width="532" alt="image" src="https://github.com/pubg/vlossom/assets/109822768/967af7e3-b30c-4cac-a21e-2a8340b542eb">


