### PR TITLE
feat(input-component): add error state on invalid input

### DIFF
--- a/packages/vlossom/src/components/vs-checkbox-set/VsCheckboxSet.vue
+++ b/packages/vlossom/src/components/vs-checkbox-set/VsCheckboxSet.vue
@@ -29,7 +29,7 @@
                     :name="name"
                     :readonly="readonly"
                     :required="required"
-                    :state="state"
+                    :state="computedState"
                     :value="getOptionValue(option)"
                     @toggle="onToggle(option, $event)"
                     @focus="onFocus(option, $event)"
@@ -112,6 +112,7 @@ export default defineComponent({
             readonly,
             required,
             rules,
+            state,
         } = toRefs(props);
 
         const checkboxRefs: Ref<HTMLInputElement[]> = ref([]);
@@ -150,25 +151,32 @@ export default defineComponent({
 
         const allRules = computed(() => [...rules.value, requiredCheck]);
 
-        const { computedMessages, shake, validate, clear, id } = useInput(inputValue, modelValue, context, label, {
-            messages,
-            rules: allRules,
-            callbacks: {
-                onMounted: () => {
-                    if (!inputValue.value) {
+        const { computedMessages, computedState, shake, validate, clear, id } = useInput(
+            inputValue,
+            modelValue,
+            context,
+            label,
+            {
+                messages,
+                rules: allRules,
+                state,
+                callbacks: {
+                    onMounted: () => {
+                        if (!inputValue.value) {
+                            inputValue.value = [];
+                        }
+                    },
+                    onChange: () => {
+                        if (!inputValue.value) {
+                            inputValue.value = [];
+                        }
+                    },
+                    onClear: () => {
                         inputValue.value = [];
-                    }
-                },
-                onChange: () => {
-                    if (!inputValue.value) {
-                        inputValue.value = [];
-                    }
-                },
-                onClear: () => {
-                    inputValue.value = [];
+                    },
                 },
             },
-        });
+        );
 
         function isChecked(option: any) {
             if (!inputValue.value) {
@@ -218,6 +226,7 @@ export default defineComponent({
             optionIds,
             classObj,
             computedColorScheme,
+            computedState,
             checkboxStyleSet,
             checkboxSetStyleSet,
             isChecked,

--- a/packages/vlossom/src/components/vs-checkbox/VsCheckbox.vue
+++ b/packages/vlossom/src/components/vs-checkbox/VsCheckbox.vue
@@ -27,7 +27,7 @@
                 :name="name"
                 :readonly="readonly"
                 :required="required"
-                :state="state"
+                :state="computedState"
                 :value="trueValue"
                 @toggle="onToggle"
                 @focus="onFocus"
@@ -97,6 +97,7 @@ export default defineComponent({
             messages,
             required,
             rules,
+            state,
             trueValue,
             falseValue,
             multiple,
@@ -125,27 +126,34 @@ export default defineComponent({
 
         const allRules = computed(() => [...rules.value, requiredCheck]);
 
-        const { computedMessages, shake, validate, clear, id } = useInput(inputValue, modelValue, context, label, {
-            messages,
-            rules: allRules,
-            callbacks: {
-                onMounted: () => {
-                    if (checked.value) {
-                        inputValue.value = getUpdatedValue(true);
-                    } else {
-                        inputValue.value = getInitialValue();
-                    }
-                },
-                onChange: () => {
-                    if (inputValue.value === undefined || inputValue.value === null) {
+        const { computedMessages, computedState, shake, validate, clear, id } = useInput(
+            inputValue,
+            modelValue,
+            context,
+            label,
+            {
+                messages,
+                rules: allRules,
+                state,
+                callbacks: {
+                    onMounted: () => {
+                        if (checked.value) {
+                            inputValue.value = getUpdatedValue(true);
+                        } else {
+                            inputValue.value = getInitialValue();
+                        }
+                    },
+                    onChange: () => {
+                        if (inputValue.value === undefined || inputValue.value === null) {
+                            inputValue.value = getClearedValue();
+                        }
+                    },
+                    onClear: () => {
                         inputValue.value = getClearedValue();
-                    }
-                },
-                onClear: () => {
-                    inputValue.value = getClearedValue();
+                    },
                 },
             },
-        });
+        );
 
         async function onToggle(c: boolean) {
             const toValue = getUpdatedValue(c);
@@ -182,6 +190,7 @@ export default defineComponent({
             checkboxRef,
             isChecked,
             computedColorScheme,
+            computedState,
             computedStyleSet,
             inputValue,
             computedMessages,

--- a/packages/vlossom/src/components/vs-file-input/VsFileInput.vue
+++ b/packages/vlossom/src/components/vs-file-input/VsFileInput.vue
@@ -118,8 +118,6 @@ export default defineComponent({
 
         const { computedStyleSet } = useStyleSet<VsFileInputStyleSet>(name, styleSet);
 
-        const { stateClasses } = useStateClass(state);
-
         const classObj = computed(() => ({
             dense: dense.value,
             disabled: disabled.value,
@@ -186,15 +184,24 @@ export default defineComponent({
             }
         }
 
-        const { computedMessages, shake, validate, clear, id } = useInput(inputValue, modelValue, context, label, {
-            messages,
-            rules: allRules,
-            callbacks: {
-                onMounted: correctEmptyValue,
-                onChange: correctEmptyValue,
-                onClear,
+        const { computedMessages, computedState, shake, validate, clear, id } = useInput(
+            inputValue,
+            modelValue,
+            context,
+            label,
+            {
+                messages,
+                rules: allRules,
+                state,
+                callbacks: {
+                    onMounted: correctEmptyValue,
+                    onChange: correctEmptyValue,
+                    onClear,
+                },
             },
-        });
+        );
+
+        const { stateClasses } = useStateClass(computedState);
 
         function updateValue(event: Event) {
             const target = event.target as HTMLInputElement;

--- a/packages/vlossom/src/components/vs-input/VsInput.vue
+++ b/packages/vlossom/src/components/vs-input/VsInput.vue
@@ -76,7 +76,7 @@ import {
     useStringModifier,
     useStateClass,
 } from '@/composables';
-import { VsComponent, type ColorScheme, StringModifiers } from '@/declaration';
+import { VsComponent, StringModifiers, type ColorScheme } from '@/declaration';
 import { useVsInputRules } from './vs-input-rules';
 import VsInputWrapper from '@/components/vs-input-wrapper/VsInputWrapper.vue';
 import VsWrapper from '@/components/vs-wrapper/VsWrapper.vue';
@@ -147,8 +147,6 @@ export default defineComponent({
 
         const { computedStyleSet } = useStyleSet<VsInputStyleSet>(name, styleSet);
 
-        const { stateClasses } = useStateClass(state);
-
         const { modifyStringValue } = useStringModifier(modelModifiers);
 
         const { requiredCheck, maxCheck, minCheck } = useVsInputRules(required, max, min, type);
@@ -178,19 +176,28 @@ export default defineComponent({
             inputValue.value = null;
         }
 
-        const { computedMessages, shake, validate, clear, id } = useInput(inputValue, modelValue, context, label, {
-            messages,
-            rules: allRules,
-            callbacks: {
-                onMounted: () => {
-                    inputValue.value = convertValue(inputValue.value);
+        const { computedMessages, computedState, shake, validate, clear, id } = useInput(
+            inputValue,
+            modelValue,
+            context,
+            label,
+            {
+                messages,
+                rules: allRules,
+                state,
+                callbacks: {
+                    onMounted: () => {
+                        inputValue.value = convertValue(inputValue.value);
+                    },
+                    onChange: () => {
+                        inputValue.value = convertValue(inputValue.value);
+                    },
+                    onClear,
                 },
-                onChange: () => {
-                    inputValue.value = convertValue(inputValue.value);
-                },
-                onClear,
             },
-        });
+        );
+
+        const { stateClasses } = useStateClass(computedState);
 
         function updateValue(event: Event) {
             const target = event.target as HTMLInputElement;

--- a/packages/vlossom/src/components/vs-message/VsMessage.scss
+++ b/packages/vlossom/src/components/vs-message/VsMessage.scss
@@ -2,11 +2,11 @@
     display: flex;
     align-items: center;
     color: var(--vs-primary-comp-bg);
-    font-size: 0.9rem;
+    font-size: 0.8rem;
 
     .message-icon {
         position: relative;
         top: 0.05rem;
-        margin-right: 0.3rem;
+        margin-right: 0.2rem;
     }
 }

--- a/packages/vlossom/src/components/vs-message/VsMessage.vue
+++ b/packages/vlossom/src/components/vs-message/VsMessage.vue
@@ -1,6 +1,6 @@
 <template>
     <div :class="['vs-message', colorClass]">
-        <vs-icon class="message-icon" :icon="icon" size="1rem" />
+        <vs-icon class="message-icon" :icon="icon" size="0.9rem" />
         <span class="message-text">{{ message.text }}</span>
     </div>
 </template>

--- a/packages/vlossom/src/components/vs-radio-set/VsRadioSet.vue
+++ b/packages/vlossom/src/components/vs-radio-set/VsRadioSet.vue
@@ -29,7 +29,7 @@
                     :name="name"
                     :readonly="readonly"
                     :required="required"
-                    :state="state"
+                    :state="computedState"
                     :value="getOptionValue(option)"
                     @toggle="onToggle(option)"
                     @focus="onFocus(option, $event)"
@@ -104,6 +104,7 @@ export default defineComponent({
             readonly,
             required,
             rules,
+            state,
         } = toRefs(props);
 
         const radioRefs: Ref<HTMLInputElement[]> = ref([]);
@@ -143,15 +144,22 @@ export default defineComponent({
 
         const allRules = computed(() => [...rules.value, requiredCheck]);
 
-        const { computedMessages, shake, validate, clear, id } = useInput(inputValue, modelValue, context, label, {
-            messages,
-            rules: allRules,
-            callbacks: {
-                onClear: () => {
-                    inputValue.value = null;
+        const { computedMessages, computedState, shake, validate, clear, id } = useInput(
+            inputValue,
+            modelValue,
+            context,
+            label,
+            {
+                messages,
+                rules: allRules,
+                state,
+                callbacks: {
+                    onClear: () => {
+                        inputValue.value = null;
+                    },
                 },
             },
-        });
+        );
 
         async function onToggle(option: any) {
             // radio change event value is always true
@@ -182,6 +190,7 @@ export default defineComponent({
             optionIds,
             classObj,
             computedColorScheme,
+            computedState,
             radioStyleSet,
             radioSetStyleSet,
             isChecked,

--- a/packages/vlossom/src/components/vs-radio/VsRadio.vue
+++ b/packages/vlossom/src/components/vs-radio/VsRadio.vue
@@ -26,7 +26,7 @@
                 :name="name"
                 :readonly="readonly"
                 :required="required"
-                :state="state"
+                :state="computedState"
                 :value="radioValue"
                 @toggle="onToggle"
                 @focus="onFocus"
@@ -74,8 +74,19 @@ export default defineComponent({
     emits: ['update:modelValue', 'update:changed', 'update:valid', 'change', 'focus', 'blur'],
     expose: ['clear', 'validate', 'focus', 'blur'],
     setup(props, context) {
-        const { checked, colorScheme, label, messages, modelValue, name, radioValue, required, rules, styleSet } =
-            toRefs(props);
+        const {
+            checked,
+            colorScheme,
+            label,
+            messages,
+            modelValue,
+            name,
+            radioValue,
+            required,
+            rules,
+            state,
+            styleSet,
+        } = toRefs(props);
 
         const radioRef: Ref<HTMLInputElement | null> = ref(null);
 
@@ -103,20 +114,27 @@ export default defineComponent({
 
         const allRules = computed(() => [...rules.value, requiredCheck]);
 
-        const { computedMessages, shake, validate, clear, id } = useInput(inputValue, modelValue, context, label, {
-            messages,
-            rules: allRules,
-            callbacks: {
-                onMounted: () => {
-                    if (checked.value) {
-                        inputValue.value = radioValue.value;
-                    }
-                },
-                onClear: () => {
-                    inputValue.value = null;
+        const { computedMessages, computedState, shake, validate, clear, id } = useInput(
+            inputValue,
+            modelValue,
+            context,
+            label,
+            {
+                messages,
+                rules: allRules,
+                state,
+                callbacks: {
+                    onMounted: () => {
+                        if (checked.value) {
+                            inputValue.value = radioValue.value;
+                        }
+                    },
+                    onClear: () => {
+                        inputValue.value = null;
+                    },
                 },
             },
-        });
+        );
 
         async function onToggle() {
             // radio change event value is always true
@@ -144,6 +162,7 @@ export default defineComponent({
             radioRef,
             isChecked,
             computedColorScheme,
+            computedState,
             computedStyleSet,
             inputValue,
             computedMessages,

--- a/packages/vlossom/src/components/vs-select/VsSelect.vue
+++ b/packages/vlossom/src/components/vs-select/VsSelect.vue
@@ -330,8 +330,6 @@ export default defineComponent({
             }),
         );
 
-        const { stateClasses } = useStateClass(state);
-
         const inputRef = ref<HTMLInputElement | null>(null);
 
         function focus() {
@@ -428,23 +426,32 @@ export default defineComponent({
             }
         }
 
-        const { computedMessages, shake, validate, clear, id } = useInput(inputValue, modelValue, context, label, {
-            messages,
-            rules: allRules,
-            callbacks: {
-                onMounted: () => {
-                    if (multiple.value && !Array.isArray(inputValue.value)) {
-                        inputValue.value = [];
-                    }
+        const { computedMessages, computedState, shake, validate, clear, id } = useInput(
+            inputValue,
+            modelValue,
+            context,
+            label,
+            {
+                messages,
+                rules: allRules,
+                state,
+                callbacks: {
+                    onMounted: () => {
+                        if (multiple.value && !Array.isArray(inputValue.value)) {
+                            inputValue.value = [];
+                        }
+                    },
+                    onChange: () => {
+                        if (multiple.value && !Array.isArray(inputValue.value)) {
+                            inputValue.value = [];
+                        }
+                    },
+                    onClear,
                 },
-                onChange: () => {
-                    if (multiple.value && !Array.isArray(inputValue.value)) {
-                        inputValue.value = [];
-                    }
-                },
-                onClear,
             },
-        });
+        );
+
+        const { stateClasses } = useStateClass(computedState);
 
         const focusing = ref(false);
 

--- a/packages/vlossom/src/components/vs-switch/VsSwitch.vue
+++ b/packages/vlossom/src/components/vs-switch/VsSwitch.vue
@@ -127,8 +127,6 @@ export default defineComponent({
 
         const { computedStyleSet } = useStyleSet(name, styleSet);
 
-        const { stateClasses } = useStateClass(state);
-
         const inputValue = ref(modelValue.value);
 
         const {
@@ -144,27 +142,36 @@ export default defineComponent({
 
         const allRules = computed(() => [...rules.value, requiredCheck]);
 
-        const { computedMessages, shake, validate, clear, id } = useInput(inputValue, modelValue, context, label, {
-            messages,
-            rules: allRules,
-            callbacks: {
-                onMounted: () => {
-                    if (checked.value) {
-                        inputValue.value = getUpdatedValue(true);
-                    } else {
-                        inputValue.value = getInitialValue();
-                    }
-                },
-                onChange: () => {
-                    if (inputValue.value === undefined || inputValue.value === null) {
+        const { computedMessages, computedState, shake, validate, clear, id } = useInput(
+            inputValue,
+            modelValue,
+            context,
+            label,
+            {
+                messages,
+                rules: allRules,
+                state,
+                callbacks: {
+                    onMounted: () => {
+                        if (checked.value) {
+                            inputValue.value = getUpdatedValue(true);
+                        } else {
+                            inputValue.value = getInitialValue();
+                        }
+                    },
+                    onChange: () => {
+                        if (inputValue.value === undefined || inputValue.value === null) {
+                            inputValue.value = getClearedValue();
+                        }
+                    },
+                    onClear: () => {
                         inputValue.value = getClearedValue();
-                    }
-                },
-                onClear: () => {
-                    inputValue.value = getClearedValue();
+                    },
                 },
             },
-        });
+        );
+
+        const { stateClasses } = useStateClass(computedState);
 
         async function toggle() {
             if (disabled.value || readonly.value) {

--- a/packages/vlossom/src/components/vs-textarea/VsTextarea.vue
+++ b/packages/vlossom/src/components/vs-textarea/VsTextarea.vue
@@ -51,7 +51,7 @@ import {
     useStringModifier,
     useStateClass,
 } from '@/composables';
-import { VsComponent, type ColorScheme, StringModifiers } from '@/declaration';
+import { VsComponent, StringModifiers, type ColorScheme } from '@/declaration';
 import { useVsTextareaRules } from './vs-textarea-rules';
 import VsInputWrapper from '@/components/vs-input-wrapper/VsInputWrapper.vue';
 import VsWrapper from '@/components/vs-wrapper/VsWrapper.vue';
@@ -103,8 +103,6 @@ export default defineComponent({
 
         const { computedStyleSet } = useStyleSet<VsTextareaStyleSet>(name, styleSet);
 
-        const { stateClasses } = useStateClass(state);
-
         const { modifyStringValue } = useStringModifier(modelModifiers);
 
         const { requiredCheck, maxCheck, minCheck } = useVsTextareaRules(required, max, min);
@@ -127,19 +125,28 @@ export default defineComponent({
             inputValue.value = '';
         }
 
-        const { computedMessages, shake, validate, clear, id } = useInput(inputValue, modelValue, context, label, {
-            messages,
-            rules: allRules,
-            callbacks: {
-                onMounted: () => {
-                    inputValue.value = convertValue(inputValue.value);
+        const { computedMessages, computedState, shake, validate, clear, id } = useInput(
+            inputValue,
+            modelValue,
+            context,
+            label,
+            {
+                messages,
+                rules: allRules,
+                state,
+                callbacks: {
+                    onMounted: () => {
+                        inputValue.value = convertValue(inputValue.value);
+                    },
+                    onChange: () => {
+                        inputValue.value = convertValue(inputValue.value);
+                    },
+                    onClear,
                 },
-                onChange: () => {
-                    inputValue.value = convertValue(inputValue.value);
-                },
-                onClear,
             },
-        });
+        );
+
+        const { stateClasses } = useStateClass(computedState);
 
         function updateValue(event: Event) {
             const target = event.target as HTMLInputElement;

--- a/packages/vlossom/src/composables/__tests__/input-composable.test.ts
+++ b/packages/vlossom/src/composables/__tests__/input-composable.test.ts
@@ -416,7 +416,6 @@ describe('useInput composable', () => {
                 props: {
                     modelValue: '',
                     'onUpdate:modelValue': (v: string) => wrapper.setProps({ modelValue: v }),
-                    required: true,
                     rules: [(v: string) => (v ? '' : 'required')],
                 },
             });
@@ -433,7 +432,6 @@ describe('useInput composable', () => {
                 props: {
                     modelValue: '',
                     'onUpdate:modelValue': (v: string) => wrapper.setProps({ modelValue: v }),
-                    required: true,
                     rules: [(v: string) => (v ? '' : 'required')],
                     state: UIState.Success,
                 },
@@ -451,7 +449,6 @@ describe('useInput composable', () => {
                 props: {
                     modelValue: '',
                     'onUpdate:modelValue': (v: string) => wrapper.setProps({ modelValue: v }),
-                    required: true,
                     rules: [(v: string) => (v ? '' : 'required')],
                     state: UIState.Success,
                 },
@@ -474,7 +471,6 @@ describe('useInput composable', () => {
                 props: {
                     modelValue: '',
                     'onUpdate:modelValue': (v: string) => wrapper.setProps({ modelValue: v }),
-                    required: true,
                     rules: [(v: string) => (v ? '' : 'required')],
                     state: UIState.Success,
                 },
@@ -499,7 +495,6 @@ describe('useInput composable', () => {
                 props: {
                     modelValue: '',
                     'onUpdate:modelValue': (v: string) => wrapper.setProps({ modelValue: v }),
-                    required: true,
                     rules: [(v: string) => (v ? '' : 'required')],
                     state: UIState.Success,
                 },

--- a/packages/vlossom/src/composables/__tests__/input-composable.test.ts
+++ b/packages/vlossom/src/composables/__tests__/input-composable.test.ts
@@ -34,14 +34,14 @@ describe('useInput composable', () => {
         inputValue.value = '';
     });
 
-    const InputComponent = defineComponent({
+    const TestInputComponent = defineComponent({
         render: () => null,
         props: {
             modelValue: { type: String, default: '' },
             ...getInputProps<string, []>(),
         },
         setup(props, ctx) {
-            const { modelValue, label, messages, rules } = toRefs(props);
+            const { modelValue, label, messages, rules, state } = toRefs(props);
 
             return {
                 ...useInput(inputValue, modelValue, ctx, label, {
@@ -52,6 +52,7 @@ describe('useInput composable', () => {
                     },
                     messages,
                     rules,
+                    state,
                 }),
             };
         },
@@ -73,7 +74,7 @@ describe('useInput composable', () => {
     describe('value binding (inputValue, modelValue)', () => {
         it('inputValue 값을 업데이트 해서 modelValue를 업데이트 할 수 있다', async () => {
             // given
-            const wrapper = mount(InputComponent, {
+            const wrapper = mount(TestInputComponent, {
                 props: {
                     modelValue: '',
                     'onUpdate:modelValue': (v: string) => wrapper.setProps({ modelValue: v }),
@@ -94,7 +95,7 @@ describe('useInput composable', () => {
 
         it('modelValue를 바꿔서 inputValue 값을 바꿀 수 있다', async () => {
             // given
-            const wrapper = mount(InputComponent, {
+            const wrapper = mount(TestInputComponent, {
                 props: {
                     modelValue: '',
                     'onUpdate:modelValue': (v: string) => wrapper.setProps({ modelValue: v }),
@@ -116,7 +117,7 @@ describe('useInput composable', () => {
         it('mount 시점에 onMounted callback을 실행한다', () => {
             // given
             // when
-            const wrapper = mount(InputComponent, {
+            const wrapper = mount(TestInputComponent, {
                 props: {
                     modelValue: '',
                     'onUpdate:modelValue': (v: string) => wrapper.setProps({ modelValue: v }),
@@ -129,7 +130,7 @@ describe('useInput composable', () => {
 
         it('inputValue가 변경되면 onChange callback을 실행한다', async () => {
             // given
-            const wrapper = mount(InputComponent, {
+            const wrapper = mount(TestInputComponent, {
                 props: {
                     modelValue: '',
                     'onUpdate:modelValue': (v: string) => wrapper.setProps({ modelValue: v }),
@@ -155,7 +156,7 @@ describe('useInput composable', () => {
                 { state: UIState.Success, text: 'success message' },
                 { state: UIState.Warning, text: 'warning message' },
             ];
-            const wrapper = mount(InputComponent, {
+            const wrapper = mount(TestInputComponent, {
                 props: {
                     messages,
                 },
@@ -173,7 +174,7 @@ describe('useInput composable', () => {
                 { state: UIState.Success, text: 'success message' },
                 { state: UIState.Warning, text: 'warning message' },
             ];
-            const wrapper = mount(InputComponent, {
+            const wrapper = mount(TestInputComponent, {
                 props: {
                     messages: [() => messages[0], () => messages[1], () => messages[2]],
                 },
@@ -191,7 +192,7 @@ describe('useInput composable', () => {
                 { state: UIState.Success, text: 'success message' },
                 { state: UIState.Warning, text: 'warning message' },
             ];
-            const wrapper = mount(InputComponent, {
+            const wrapper = mount(TestInputComponent, {
                 props: {
                     messages: [
                         () => Promise.resolve(messages[0]),
@@ -212,7 +213,7 @@ describe('useInput composable', () => {
 
         it('messages가 바뀌면 바뀐 message를 반영할 수 있다', async () => {
             // given
-            const wrapper = mount(InputComponent, {
+            const wrapper = mount(TestInputComponent, {
                 props: {
                     messages: [
                         { state: UIState.Info, text: 'info message' },
@@ -236,7 +237,7 @@ describe('useInput composable', () => {
     describe('rules', () => {
         it('rule이 설정되었어도 값의 변경이 없다면 message가 없다', () => {
             //given
-            const wrapper = mount(InputComponent, {
+            const wrapper = mount(TestInputComponent, {
                 props: {
                     rules: [(v: string) => (v ? '' : 'required')],
                 },
@@ -251,7 +252,7 @@ describe('useInput composable', () => {
 
         it('값이 유효하면 rule error message가 없다', async () => {
             //given
-            const wrapper = mount(InputComponent, {
+            const wrapper = mount(TestInputComponent, {
                 props: {
                     rules: [(v: string) => (v ? '' : 'required')],
                 },
@@ -271,7 +272,7 @@ describe('useInput composable', () => {
 
         it('값이 유효하지 않으면 rule error message가 있다', async () => {
             //given
-            const wrapper = mount(InputComponent, {
+            const wrapper = mount(TestInputComponent, {
                 props: {
                     rules: [(v: string) => (v ? '' : 'required')],
                 },
@@ -293,7 +294,7 @@ describe('useInput composable', () => {
 
         it('PromiseLike의 rule도 체크할 수 있다', async () => {
             //given
-            const wrapper = mount(InputComponent, {
+            const wrapper = mount(TestInputComponent, {
                 props: {
                     rules: [
                         (v: string) => Promise.resolve(v ? '' : 'required'),
@@ -321,7 +322,7 @@ describe('useInput composable', () => {
         it('기존 message가 있으면 rule 체크 결과를 danger 타입으로 추가한다', async () => {
             // given
             const infoMsg: StateMessage = { state: UIState.Info, text: 'info message' };
-            const wrapper = mount(InputComponent, {
+            const wrapper = mount(TestInputComponent, {
                 props: {
                     messages: [infoMsg],
                     rules: [(v: string) => (v ? '' : 'required')],
@@ -348,7 +349,7 @@ describe('useInput composable', () => {
     describe('validate', () => {
         it('validate 함수를 호출하면 변경이 없어도 message가 노출된다', async () => {
             //given
-            const wrapper = mount(InputComponent, {
+            const wrapper = mount(TestInputComponent, {
                 props: {
                     rules: [(v: string) => (v ? '' : 'required')],
                 },
@@ -369,7 +370,7 @@ describe('useInput composable', () => {
         describe('shake', () => {
             it('validate를 호출 했을 때 값이 유효하면 shake 값(boolean)에 변화가 없다', async () => {
                 // given
-                const wrapper = mount(InputComponent, {
+                const wrapper = mount(TestInputComponent, {
                     props: {
                         rules: [(v: string) => (v ? '' : 'required')],
                     },
@@ -390,7 +391,7 @@ describe('useInput composable', () => {
 
             it('validate를 호출 했을 때 값이 유효하지 않으면 shake 값(boolean)이 바뀐다', async () => {
                 // given
-                const wrapper = mount(InputComponent, {
+                const wrapper = mount(TestInputComponent, {
                     props: {
                         rules: [(v: string) => (v ? '' : 'required')],
                     },
@@ -408,10 +409,119 @@ describe('useInput composable', () => {
         });
     });
 
+    describe('computedState', () => {
+        it('기본 state는 idle이다', async () => {
+            // given
+            const wrapper = mount(TestInputComponent, {
+                props: {
+                    modelValue: '',
+                    'onUpdate:modelValue': (v: string) => wrapper.setProps({ modelValue: v }),
+                    required: true,
+                    rules: [(v: string) => (v ? '' : 'required')],
+                },
+            });
+
+            // then
+            expect(wrapper.vm.changed).toBe(false);
+            expect(wrapper.vm.valid).toBe(false);
+            expect(wrapper.vm.computedState).toBe(UIState.Idle);
+        });
+
+        it('state가 주입되면 해당 state를 반환한다', async () => {
+            // given
+            const wrapper = mount(TestInputComponent, {
+                props: {
+                    modelValue: '',
+                    'onUpdate:modelValue': (v: string) => wrapper.setProps({ modelValue: v }),
+                    required: true,
+                    rules: [(v: string) => (v ? '' : 'required')],
+                    state: UIState.Success,
+                },
+            });
+
+            // then
+            expect(wrapper.vm.changed).toBe(false);
+            expect(wrapper.vm.valid).toBe(false);
+            expect(wrapper.vm.computedState).toBe(UIState.Success);
+        });
+
+        it('값의 변경이 있어도 valid하다면 주입된 state를 반환한다', async () => {
+            // given
+            const wrapper = mount(TestInputComponent, {
+                props: {
+                    modelValue: '',
+                    'onUpdate:modelValue': (v: string) => wrapper.setProps({ modelValue: v }),
+                    required: true,
+                    rules: [(v: string) => (v ? '' : 'required')],
+                    state: UIState.Success,
+                },
+            });
+
+            // when
+            await nextTick();
+            inputValue.value = 'test';
+            await nextTick();
+
+            // then
+            expect(wrapper.vm.changed).toBe(true);
+            expect(wrapper.vm.valid).toBe(true);
+            expect(wrapper.vm.computedState).toBe(UIState.Success);
+        });
+
+        it('valid하지 않은 값이 입력되면 주입된 state와 관계없이 error state를 반환한다', async () => {
+            // given
+            const wrapper = mount(TestInputComponent, {
+                props: {
+                    modelValue: '',
+                    'onUpdate:modelValue': (v: string) => wrapper.setProps({ modelValue: v }),
+                    required: true,
+                    rules: [(v: string) => (v ? '' : 'required')],
+                    state: UIState.Success,
+                },
+            });
+
+            // when
+            await nextTick();
+            inputValue.value = 'test';
+            await nextTick();
+            inputValue.value = '';
+            await nextTick();
+
+            // then
+            expect(wrapper.vm.changed).toBe(true);
+            expect(wrapper.vm.valid).toBe(false);
+            expect(wrapper.vm.computedState).toBe(UIState.Error);
+        });
+
+        it('valid하지 않을 때 validate를 호출하면 변경이 없어도 error state를 반환한다', async () => {
+            // given
+            const wrapper = mount(TestInputComponent, {
+                props: {
+                    modelValue: '',
+                    'onUpdate:modelValue': (v: string) => wrapper.setProps({ modelValue: v }),
+                    required: true,
+                    rules: [(v: string) => (v ? '' : 'required')],
+                    state: UIState.Success,
+                },
+            });
+
+            // when
+            await nextTick();
+            const result = wrapper.vm.validate();
+            await nextTick();
+
+            // then
+            expect(result).toBe(false);
+            expect(wrapper.vm.changed).toBe(false);
+            expect(wrapper.vm.valid).toBe(false);
+            expect(wrapper.vm.computedState).toBe(UIState.Error);
+        });
+    });
+
     describe('clear', () => {
         it('clear 함수를 호출하면 onClear callback이 실행된다', async () => {
             // given
-            const wrapper = mount(InputComponent, {
+            const wrapper = mount(TestInputComponent, {
                 props: {
                     modelValue: '',
                     'onUpdate:modelValue': (v: string) => wrapper.setProps({ modelValue: v }),

--- a/packages/vlossom/src/composables/input-composable.ts
+++ b/packages/vlossom/src/composables/input-composable.ts
@@ -62,7 +62,7 @@ export function useInput<T = unknown>(
     options?: InputComponentOptions<T>,
 ) {
     const { emit } = ctx;
-    const { messages = ref([]), rules = ref([]) } = options || {};
+    const { messages = ref([]), rules = ref([]), state = ref(UIState.Idle) } = options || {};
 
     const changed = ref(false);
     const isInitialized = ref(false);
@@ -215,6 +215,8 @@ export function useInput<T = unknown>(
         emit('update:changed', changed.value);
     });
 
+    const computedState = computed(() => (showRuleMessages.value && !valid.value ? UIState.Error : state.value));
+
     return {
         changed,
         valid,
@@ -224,5 +226,6 @@ export function useInput<T = unknown>(
         validate,
         clear,
         id,
+        computedState,
     };
 }

--- a/packages/vlossom/src/declaration/types.ts
+++ b/packages/vlossom/src/declaration/types.ts
@@ -106,6 +106,7 @@ export type Message<T = any> = StateMessage | ((v: T) => StateMessage) | ((v: T)
 export interface InputComponentOptions<T = unknown> {
     messages?: Ref<Message<T>[]>;
     rules?: Ref<Rule<T>[]>;
+    state?: Ref<UIState>;
     callbacks?: {
         onChange?: (newValue: T, oldValue: T) => void;
         onMounted?: () => void;


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Feature (feat)

## Summary
Input component가 rules에 맞춰 error state를 표현하도록 수정

## Description
- input composable에서 computedState를 반환
- state class를 결정할 때 computedState를 기반으로 판단

<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
