### PR TITLE
fix(VsSelect): fix vs-select autocomplete

### DIFF
--- a/packages/vlossom/src/components/vs-select/VsSelect.scss
+++ b/packages/vlossom/src/components/vs-select/VsSelect.scss
@@ -37,9 +37,14 @@
         color: var(--vs-select-fontColor, var(--vs-font-color));
         cursor: pointer;
         min-width: 2rem;
+        line-height: 1rem;
 
         &.autocomplete {
             cursor: default;
+        }
+
+        &:not(.autocomplete)::selection {
+            background: none;
         }
     }
 

--- a/packages/vlossom/src/components/vs-select/VsSelect.vue
+++ b/packages/vlossom/src/components/vs-select/VsSelect.vue
@@ -64,13 +64,13 @@
                     aria-controls="vs-select-options"
                     :aria-autocomplete="autocomplete ? 'list' : undefined"
                     :aria-activedescendant="focusedOptionId"
-                    :class="{ autocomplete: autocomplete }"
+                    :class="{ autocomplete }"
                     :disabled="disabled"
                     :placeholder="placeholder"
                     :readonly="readonly || !autocomplete"
                     :aria-required="required"
                     :value="inputLabel"
-                    @input.stop="updateAutocompleteText"
+                    @input.stop="onInput"
                     @focus.stop="onFocus"
                     @blur.stop="onBlur"
                     @keydown.stop="onKeyDown"
@@ -362,11 +362,9 @@ export default defineComponent({
             useToggleOptions(disabled, readonly);
 
         const { autocompleteText, filteredOptions, updateAutocompleteText } = useAutocomplete(
-            autocomplete,
             computedOptions,
             getOptionLabel,
             isOpen,
-            select,
         );
 
         const { listboxRef, loadedOptions } = useInfiniteScroll(filteredOptions, lazyLoadNum, isOpen);
@@ -457,11 +455,19 @@ export default defineComponent({
 
         function onFocus(e: FocusEvent) {
             focusing.value = true;
+
+            if (autocomplete.value) {
+                select();
+            }
             emit('focus', e);
         }
 
         function onBlur(e: FocusEvent) {
             focusing.value = false;
+
+            if (autocomplete.value) {
+                autocompleteText.value = inputLabel.value;
+            }
             emit('blur', e);
         }
 
@@ -484,6 +490,14 @@ export default defineComponent({
                 return computedPlacement.value === 'top' ? 'fade-leave-bottom' : 'fade-leave-top';
             }
         });
+
+        function onInput(e: Event) {
+            // Open options on typing after focused by tab key
+            if (autocomplete.value && !isOpen.value) {
+                isOpen.value = true;
+            }
+            updateAutocompleteText(e);
+        }
 
         return {
             id,
@@ -532,6 +546,7 @@ export default defineComponent({
             focus,
             blur,
             stateClasses,
+            onInput,
         };
     },
 });

--- a/packages/vlossom/src/components/vs-select/VsSelect.vue
+++ b/packages/vlossom/src/components/vs-select/VsSelect.vue
@@ -457,6 +457,7 @@ export default defineComponent({
             focusing.value = true;
 
             if (autocomplete.value) {
+                e.preventDefault();
                 select();
             }
             emit('focus', e);
@@ -496,7 +497,9 @@ export default defineComponent({
             if (autocomplete.value && !isOpen.value) {
                 isOpen.value = true;
             }
-            updateAutocompleteText(e);
+
+            const target = e.target as HTMLInputElement;
+            updateAutocompleteText(target.value);
         }
 
         return {

--- a/packages/vlossom/src/components/vs-select/__tests__/vs-select.test.ts
+++ b/packages/vlossom/src/components/vs-select/__tests__/vs-select.test.ts
@@ -590,6 +590,77 @@ describe('vs-select', () => {
             expect(wrapper.findAll('li.option')).toHaveLength(1);
             expect(wrapper.html()).toContain('banana');
         });
+
+        it('autocomplete가 true이면, 기존에 인풋에 입력된 텍스트가 있으면 onFous시에 해당 텍스트가 select된다', async () => {
+            // given
+            const wrapper: ReturnType<typeof mountComponent> = mount(VsSelect, {
+                props: {
+                    autocomplete: true,
+                    options: ['apple', 'banana', 'carrot'],
+                },
+                global: {
+                    stubs: {
+                        teleport: true,
+                    },
+                },
+            });
+
+            // when
+            const input = wrapper.find('input');
+            await input.setValue('apple');
+            await input.trigger('focus');
+
+            // then
+            expect(input.element.value).toBe('apple');
+            expect(input.element.selectionEnd).toBe('apple'.length);
+        });
+
+        it('autocomplete가 false이면 기존에 입력된 텍스트가 있어도 onFous시에 텍스트가 select되지 않는다', async () => {
+            // given
+            const wrapper: ReturnType<typeof mountComponent> = mount(VsSelect, {
+                props: {
+                    autocomplete: false,
+                    options: ['apple', 'banana', 'carrot'],
+                },
+                global: {
+                    stubs: {
+                        teleport: true,
+                    },
+                },
+            });
+
+            // when
+            const input = wrapper.find('input');
+            await input.setValue('apple');
+            await input.trigger('focus');
+
+            // then
+            expect(input.element.selectionEnd).toBe(0);
+        });
+
+        it('autocomplete가 true이면, input 이벤트가 발생할 때 옵션 리스트가 열리고, 옵션 필터가 초기화된다', async () => {
+            // given
+            const wrapper: ReturnType<typeof mountComponent> = mount(VsSelect, {
+                props: {
+                    autocomplete: true,
+                    options: ['apple', 'banana', 'carrot'],
+                },
+                global: {
+                    stubs: {
+                        teleport: true,
+                    },
+                },
+            });
+
+            // when
+            const input = wrapper.find('input');
+            await input.setValue('apple');
+            await input.trigger('input');
+
+            // then
+            expect(wrapper.find('ul#vs-select-options').exists()).toBe(true);
+            expect(wrapper.vm.filteredOptions).toHaveLength(3);
+        });
     });
 
     describe('focus management', () => {

--- a/packages/vlossom/src/components/vs-select/__tests__/vs-select.test.ts
+++ b/packages/vlossom/src/components/vs-select/__tests__/vs-select.test.ts
@@ -605,6 +605,11 @@ describe('vs-select', () => {
                 },
             });
 
+            wrapper.vm.filteredOptions = [
+                { id: '1', value: 'apple' },
+                { id: '2', value: 'banana' },
+            ];
+
             // when
             const input = wrapper.find('input');
             await input.setValue('apple');

--- a/packages/vlossom/src/components/vs-select/__tests__/vs-select.test.ts
+++ b/packages/vlossom/src/components/vs-select/__tests__/vs-select.test.ts
@@ -591,53 +591,6 @@ describe('vs-select', () => {
             expect(wrapper.html()).toContain('banana');
         });
 
-        it('autocomplete가 true이면, 기존에 인풋에 입력된 텍스트가 있으면 onFous시에 해당 텍스트가 select된다', async () => {
-            // given
-            const wrapper: ReturnType<typeof mountComponent> = mount(VsSelect, {
-                props: {
-                    autocomplete: true,
-                    options: ['apple', 'banana', 'carrot'],
-                },
-                global: {
-                    stubs: {
-                        teleport: true,
-                    },
-                },
-            });
-
-            // when
-            const input = wrapper.find('input');
-            await input.setValue('apple');
-            await input.trigger('focus');
-
-            // then
-            expect(input.element.value).toBe('apple');
-            expect(input.element.selectionEnd).toBe('apple'.length);
-        });
-
-        it('autocomplete가 false이면 기존에 입력된 텍스트가 있어도 onFous시에 텍스트가 select되지 않는다', async () => {
-            // given
-            const wrapper: ReturnType<typeof mountComponent> = mount(VsSelect, {
-                props: {
-                    autocomplete: false,
-                    options: ['apple', 'banana', 'carrot'],
-                },
-                global: {
-                    stubs: {
-                        teleport: true,
-                    },
-                },
-            });
-
-            // when
-            const input = wrapper.find('input');
-            await input.setValue('apple');
-            await input.trigger('focus');
-
-            // then
-            expect(input.element.selectionEnd).toBe(0);
-        });
-
         it('autocomplete가 true이면, input 이벤트가 발생할 때 옵션 리스트가 열리고, 옵션 필터가 초기화된다', async () => {
             // given
             const wrapper: ReturnType<typeof mountComponent> = mount(VsSelect, {
@@ -655,7 +608,6 @@ describe('vs-select', () => {
             // when
             const input = wrapper.find('input');
             await input.setValue('apple');
-            await input.trigger('input');
 
             // then
             expect(wrapper.find('ul#vs-select-options').exists()).toBe(true);

--- a/packages/vlossom/src/components/vs-select/composables/autocomplete-composable.ts
+++ b/packages/vlossom/src/components/vs-select/composables/autocomplete-composable.ts
@@ -9,9 +9,8 @@ export function useAutocomplete(
     const autocompleteText = ref('');
     const filteredOptions: Ref<{ id: string; value: any }[]> = ref([...computedOptions.value]);
 
-    function updateAutocompleteText(event: Event) {
-        const target = event.target as HTMLInputElement;
-        autocompleteText.value = target.value;
+    function updateAutocompleteText(text: string) {
+        autocompleteText.value = text;
     }
 
     watch(

--- a/packages/vlossom/src/components/vs-select/composables/autocomplete-composable.ts
+++ b/packages/vlossom/src/components/vs-select/composables/autocomplete-composable.ts
@@ -1,12 +1,10 @@
-import { ref, watch, nextTick, type Ref } from 'vue';
+import { ref, watch, type Ref } from 'vue';
 import { utils } from '@/utils';
 
 export function useAutocomplete(
-    autocomplete: Ref<boolean>,
     computedOptions: Ref<{ id: string; value: any }[]>,
     getOptionLabel: (option: any) => string,
     isOpen: Ref<boolean>,
-    inputSelect: () => void,
 ) {
     const autocompleteText = ref('');
     const filteredOptions: Ref<{ id: string; value: any }[]> = ref([...computedOptions.value]);
@@ -27,11 +25,9 @@ export function useAutocomplete(
         }, 300),
     );
 
-    watch(isOpen, () => {
-        if (isOpen.value && autocomplete.value) {
-            nextTick(() => {
-                inputSelect();
-            });
+    watch(isOpen, (val) => {
+        if (val) {
+            filteredOptions.value = [...computedOptions.value];
         }
     });
 

--- a/packages/vlossom/src/components/vs-select/composables/focus-control-composable.ts
+++ b/packages/vlossom/src/components/vs-select/composables/focus-control-composable.ts
@@ -155,7 +155,10 @@ export function useFocusControl(
     });
 
     watch([isOpen, filteredOptions], (newValues, oldValues) => {
-        if (!oldValues[0] && newValues[0]) {
+        const previouslyOpened = oldValues[0];
+        const currentlyOpen = newValues[0];
+
+        if (!previouslyOpened && currentlyOpen) {
             return;
         }
         resetFocusInfo();

--- a/packages/vlossom/src/components/vs-select/composables/focus-control-composable.ts
+++ b/packages/vlossom/src/components/vs-select/composables/focus-control-composable.ts
@@ -154,7 +154,12 @@ export function useFocusControl(
         }
     });
 
-    watch(filteredOptions, resetFocusInfo);
+    watch([isOpen, filteredOptions], (newValues, oldValues) => {
+        if (!oldValues[0] && newValues[0]) {
+            return;
+        }
+        resetFocusInfo();
+    });
 
     function isChasedOption(optionIndex: number) {
         return (

--- a/packages/vlossom/src/components/vs-select/stories/VsSelect.chromatic.stories.ts
+++ b/packages/vlossom/src/components/vs-select/stories/VsSelect.chromatic.stories.ts
@@ -51,9 +51,9 @@ const meta: Meta<typeof VsSelect> = {
 
                 <vs-select v-bind="args" v-model="modelValue1" label="Select Multiple" multiple :style="{ marginBottom: '12px' }"/>
 
-                <vs-select v-bind="args" v-model="modelValue2" label="Select with ClosableChips" multiple closableChips :style="{ marginBottom: '12px' }"/>
+                <vs-select v-bind="args" v-model="modelValue2" label="Select Multiple with ClosableChips" multiple closableChips :style="{ marginBottom: '12px' }"/>
 
-                <vs-select v-bind="args" v-model="modelValue3" label="Select with CollapseChips" multiple collapseChips />
+                <vs-select v-bind="args" v-model="modelValue3" label="Select Multiple with CollapseChips" multiple collapseChips />
             </div>`,
     }),
     argTypes: {


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary
- vs-select autocomplete 동작 버그 수정 
  -  vs-select 선택값이 있을 때 tab focus 이상한 버그 (스타일 수정)
  - vs-select 값이 선택된 상태에서 autocomplete에 tab으로 접근한 뒤에 수정 가능한 이슈 (옵션은 안 열리지 않는 이슈) 
  - vs-select autocomplete로 값 선택 후 다시 열었을 때 filter된 options가 노출되는 버그
  
## Description

<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
