### PR TITLE
feat(VsTable): add search input

### DIFF
--- a/packages/vlossom/src/components/vs-table/VsTable.scss
+++ b/packages/vlossom/src/components/vs-table/VsTable.scss
@@ -44,6 +44,31 @@
             background-color: var(--vs-table-headerBackgroundColor, var(--vs-area-bg-active));
             border: var(--vs-table-headerBorder, 1px solid var(--vs-line-color));
 
+            &.search {
+                position: relative;
+                width: 100%;
+                display: flex;
+                border-bottom: none;
+
+                th {
+                    width: 100%;
+                    display: flex;
+                    align-items: center;
+                    justify-content: flex-start;
+                    padding: 0.6rem;
+                    padding-right: 1rem;
+
+                    .search-icon {
+                        color: var(--vs-primary-comp-bg);
+                        margin-right: 0.8rem;
+                        flex-shrink: 0;
+                    }
+                    .search-input {
+                        flex-grow: 1;
+                    }
+                }
+            }
+
             th {
                 color: var(--vs-table-headerFontColor, var(--vs-font-color));
                 font-size: var(--vs-table-headerFontSize, 0.9rem);

--- a/packages/vlossom/src/components/vs-table/VsTable.vue
+++ b/packages/vlossom/src/components/vs-table/VsTable.vue
@@ -9,10 +9,13 @@
                     :headers="headers"
                     :draggable="canDrag"
                     :expandable="hasExpand"
+                    :search="search"
+                    :search-placeholder="searchPlaceholder"
                     :selectable="hasSelectable"
                     :loading="loading"
                     :tr-style="trStyle"
                     v-model:sort-types="sortTypes"
+                    @change:search-text="updateInnerSearchText"
                 >
                     <template #check>
                         <vs-checkbox-node
@@ -39,7 +42,7 @@
                     :hasExpand="hasExpand"
                     :rows="rows"
                     :loading="loading"
-                    :search="search"
+                    :search-text="computedSearchText"
                     :searchable-keys="searchableKeys"
                     :selectable="hasSelectable"
                     :selected-items="selectedItems"
@@ -138,7 +141,9 @@ export default defineComponent({
             default: () => DEFAULT_TABLE_PAGE_COUNT,
         },
         pageEdgeButtons: { type: Boolean, default: false },
-        search: { type: String, default: '' },
+        search: { type: Boolean, default: false },
+        searchPlaceholder: { type: String, default: 'search' },
+        searchText: { type: String, default: '' },
         searchableKeys: {
             type: Array as PropType<string[]>,
             default: () => [] as string[],
@@ -169,12 +174,13 @@ export default defineComponent({
             styleSet,
             draggable,
             headers,
-            selectable,
             itemsPerPage,
             page,
             pagination,
             paginationOptions,
             rows,
+            selectable,
+            searchText,
             totalLength,
         } = toRefs(props);
 
@@ -204,6 +210,14 @@ export default defineComponent({
                 },
                 {} as { [key: string]: any },
             );
+        });
+
+        const innerSearchText = ref('');
+        function updateInnerSearchText(text: string) {
+            innerSearchText.value = text;
+        }
+        const computedSearchText = computed(() => {
+            return searchText.value || innerSearchText.value;
         });
 
         const canDrag = computed(() => {
@@ -314,6 +328,7 @@ export default defineComponent({
         return {
             computedColorScheme,
             computedStyleSet,
+            computedSearchText,
             headerSlots,
             itemSlots,
             trStyle,
@@ -321,6 +336,8 @@ export default defineComponent({
             hasExpand,
             isSelectedAll,
             utils,
+            innerSearchText,
+            updateInnerSearchText,
             innerPage,
             innerItemsPerPage,
             paginationLength,

--- a/packages/vlossom/src/components/vs-table/VsTableBody.vue
+++ b/packages/vlossom/src/components/vs-table/VsTableBody.vue
@@ -101,7 +101,7 @@ export default defineComponent({
         loading: { type: Boolean, default: false },
         pagination: { type: Boolean, default: false },
         rows: { type: Object as PropType<TableRow>, default: () => ({}) },
-        search: { type: String, default: '' },
+        searchText: { type: String, default: '' },
         searchableKeys: { type: Array as PropType<string[]>, default: () => [] as string[] },
         selectable: { type: Boolean, default: false },
         selectedItems: {
@@ -135,7 +135,7 @@ export default defineComponent({
         const {
             headers,
             items,
-            search,
+            searchText,
             searchableKeys,
             filter,
             sortTypes,
@@ -164,7 +164,7 @@ export default defineComponent({
         const { getPagedTableItems } = useTablePagination();
 
         function getResultTableItems() {
-            const searched = getSearchedTableItems(innerTableItems.value, search);
+            const searched = getSearchedTableItems(innerTableItems.value, searchText);
             const filtered = getFilteredTableItems(searched, filter);
             const sorted = getSortedTableItems(filtered, sortTypes);
             return sorted;

--- a/packages/vlossom/src/components/vs-table/VsTableHeader.vue
+++ b/packages/vlossom/src/components/vs-table/VsTableHeader.vue
@@ -1,5 +1,18 @@
 <template>
     <thead>
+        <tr v-if="search" class="search">
+            <th>
+                <vs-icon class="search-icon" icon="search" size="26px" />
+                <vs-input
+                    class="search-input"
+                    :placeholder="searchPlaceholder"
+                    @change="emitSearchText"
+                    no-label
+                    no-message
+                    dense
+                />
+            </th>
+        </tr>
         <tr :style="trStyle">
             <th class="draggable-th" v-if="draggable">drag</th>
             <th class="selectable-th" v-if="selectable" aria-label="select">
@@ -26,16 +39,19 @@
 <script lang="ts">
 import { defineComponent, PropType, toRefs } from 'vue';
 import { VsIcon } from '@/icons';
-import { type TableHeader, SortType } from './types';
+import VsInput from '@/components/vs-input/VsInput.vue';
+import { SortType, type TableHeader } from './types';
 import { useSortableHeader } from './composables/useSortableHeader';
 
 export default defineComponent({
     name: 'VsTableHeader',
-    components: { VsIcon },
+    components: { VsIcon, VsInput },
     props: {
         draggable: { type: Boolean, default: false },
         expandable: { type: Boolean, default: false },
         headers: { type: Array as PropType<TableHeader[]>, required: true },
+        search: { type: Boolean, default: false },
+        searchPlaceholder: { type: String, default: 'search' },
         selectable: { type: Boolean, default: false },
         trStyle: {
             type: Object as PropType<{ [key: string]: any }>,
@@ -47,13 +63,17 @@ export default defineComponent({
             default: () => ({}),
         },
     },
-    emits: ['update:sortTypes'],
+    emits: ['change:searchText', 'update:sortTypes'],
     setup(props, context) {
         const { headers } = toRefs(props);
 
         const { updateSortTypes, getSortIcon } = useSortableHeader(headers, context);
 
-        return { updateSortTypes, getSortIcon };
+        function emitSearchText(searchText: string) {
+            context.emit('change:searchText', searchText);
+        }
+
+        return { updateSortTypes, getSortIcon, emitSearchText };
     },
 });
 </script>

--- a/packages/vlossom/src/components/vs-table/__tests__/vs-table.test.ts
+++ b/packages/vlossom/src/components/vs-table/__tests__/vs-table.test.ts
@@ -163,22 +163,52 @@ describe('VsTable', () => {
     });
 
     describe('search', () => {
-        it('search props를 통해 입력된 키워드로 table item들을 검색할 수 있다 (단, searchable:false인 key는 검색 대상에서 제외된다)', async () => {
+        it('search 영역이 있고, 값이 업데이트 되면 table item들을 검색할 수 있다', async () => {
             // given
             const wrapper: ReturnType<typeof mountComponent> = mount(VsTable, {
                 props: {
                     headers,
                     items,
-                    search: '',
+                    search: true,
                 },
             });
 
             // when
-            await wrapper.setProps({ search: 'apple' });
+            await nextTick();
+            const input = wrapper.find('.search input');
+            (input.element as any).value = 'apple';
+            await input.trigger('input');
+            await nextTick();
+
+            // then
+            expect(wrapper.find('.search').exists()).toBe(true);
+            const visibleRows = wrapper.findAll('tbody tr').filter((node) => node.isVisible());
+            expect(visibleRows).toHaveLength(1);
+            const containsApple = visibleRows.some((row) => row.text().includes('Apple'));
+            const containsDurian = visibleRows.some((row) => row.text().includes('Durian'));
+            expect(containsApple).toBe(true);
+            expect(containsDurian).toBe(false);
+        });
+    });
+
+    describe('search text', () => {
+        it('searchText props를 통해 입력된 키워드로 table item들을 검색할 수 있다 (단, searchable:false인 key는 검색 대상에서 제외된다)', async () => {
+            // given
+            const wrapper: ReturnType<typeof mountComponent> = mount(VsTable, {
+                props: {
+                    headers,
+                    items,
+                    searchText: '',
+                },
+            });
+
+            // when
+            await wrapper.setProps({ searchText: 'apple' });
             await nextTick();
 
             // then
             const visibleRows = wrapper.findAll('tbody tr').filter((node) => node.isVisible());
+            expect(visibleRows).toHaveLength(1);
             const containsApple = visibleRows.some((row) => row.text().includes('Apple'));
             const containsDurian = visibleRows.some((row) => row.text().includes('Durian'));
             expect(containsApple).toBe(true);

--- a/packages/vlossom/src/components/vs-table/stories/VsTable.chromatic.stories.ts
+++ b/packages/vlossom/src/components/vs-table/stories/VsTable.chromatic.stories.ts
@@ -14,7 +14,7 @@ const meta: Meta<typeof VsTable> = {
         setup() {
             const selected = items.slice(0, 2);
 
-            const search = ref('');
+            const searchText = ref('');
 
             const id: Ref<string | number> = ref('all');
             const checked = ref('false');
@@ -37,14 +37,14 @@ const meta: Meta<typeof VsTable> = {
                 { label: '4', value: 4 },
                 { label: 'All', value: -1 },
             ];
-            return { args, selected, search, id, checked, options, filter, paginationOptions };
+            return { args, selected, searchText, id, checked, options, filter, paginationOptions };
         },
         template: `
             <div>
                 <vs-table v-bind="args" :style="{ marginBottom: '50px' }"/>
 
                 <vs-table v-bind="args" caption="Fruit Shopping List" :style="{ marginBottom: '50px' }"/>
-            
+
                 <vs-table v-bind="args" dense :style="{ marginBottom: '50px' }"/>
 
                 <div :style="{ marginBottom: '50px' }">
@@ -55,15 +55,17 @@ const meta: Meta<typeof VsTable> = {
                     </div>
                 </div>
 
+                <vs-table v-bind="args" search :style="{ marginBottom: '50px' }"/>
+
                 <div :style="{ marginBottom: '50px' }">
-                    <vs-input v-bind="args" v-model="search" placeholder="Search">
+                    <vs-input v-bind="args" v-model="searchText" placeholder="Search">
                         <template #prepend>
                             <svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 -960 960 960" width="24" fill="#FFFFFF">
                                 <path d="M784-120 532-372q-30 24-69 38t-83 14q-109 0-184.5-75.5T120-580q0-109 75.5-184.5T380-840q109 0 184.5 75.5T640-580q0 44-14 83t-38 69l252 252-56 56ZM380-400q75 0 127.5-52.5T560-580q0-75-52.5-127.5T380-760q-75 0-127.5 52.5T200-580q0 75 52.5 127.5T380-400Z"/>
                             </svg>
                         </template>
                     </vs-input>
-                    <vs-table v-bind="args" :search="search">
+                    <vs-table v-bind="args" :search-text="searchText">
                         <template #item-checked="{ value }">
                             <vs-switch v-model="value" no-label no-message></vs-switch>
                         </template>
@@ -80,7 +82,7 @@ const meta: Meta<typeof VsTable> = {
                 </div>
 
                 <vs-table v-bind="args" draggable :style="{ marginBottom: '50px' }"/>
-                 
+
                 <vs-table v-bind="args" pagination pageEdgeButtons :paginationOptions="paginationOptions" :style="{ marginBottom: '50px' }"/>
 
                 <vs-table v-bind="args" loading :style="{ marginBottom: '50px' }"/>

--- a/packages/vlossom/src/components/vs-table/stories/VsTable.stories.ts
+++ b/packages/vlossom/src/components/vs-table/stories/VsTable.stories.ts
@@ -119,22 +119,28 @@ export const Selectable: Story = {
 };
 
 export const Search: Story = {
+    args: {
+        search: true,
+    },
+};
+
+export const SearchText: Story = {
     render: (args: any) => ({
         components: { VsTable, VsIcon },
         setup() {
-            const search = ref('');
-            return { args, search };
+            const searchText = ref('');
+            return { args, searchText };
         },
         template: `
             <div>
-                <vs-input v-bind="args" v-model="search" placeholder="Search">
+                <vs-input v-bind="args" v-model="searchText" placeholder="Search">
                     <template #prepend>
                         <svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 -960 960 960" width="24" fill="#FFFFFF" stroke="gray" stroke-width="30">
                             <path d="M784-120 532-372q-30 24-69 38t-83 14q-109 0-184.5-75.5T120-580q0-109 75.5-184.5T380-840q109 0 184.5 75.5T640-580q0 44-14 83t-38 69l252 252-56 56ZM380-400q75 0 127.5-52.5T560-580q0-75-52.5-127.5T380-760q-75 0-127.5 52.5T200-580q0 75 52.5 127.5T380-400Z"/>
                         </svg>
                     </template>
                 </vs-input>
-                <vs-table v-bind="args" :search="search">
+                <vs-table v-bind="args" :searchText="searchText">
                     <template #item-checked="{ value }">
                         <vs-switch v-model="value" no-label no-message></vs-switch>
                     </template>

--- a/packages/vlossom/src/icons/icons.ts
+++ b/packages/vlossom/src/icons/icons.ts
@@ -123,6 +123,10 @@ export const iconSvgs = {
             >
             </path>
         </svg>`,
+    search: `
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960" fill="currentColor">
+            <path d="M784-120 532-372q-30 24-69 38t-83 14q-109 0-184.5-75.5T120-580q0-109 75.5-184.5T380-840q109 0 184.5 75.5T640-580q0 44-14 83t-38 69l252 252-56 56ZM380-400q75 0 127.5-52.5T560-580q0-75-52.5-127.5T380-760q-75 0-127.5 52.5T200-580q0 75 52.5 127.5T380-400Z"/>
+        </svg>`,
     // check_circle
     success: `
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960">


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Feature (feat)

## Summary
vs-table에 search 기능을 추가합니다

## Description
- table 상단에 search 영역을 thead > tr > th 로 추가합니다
- 기존 search는 searchText로 이름을 변경하고, 외부에서 주입하는 query로 그대로 사용합니다
- searchPlaceholder prop도 추가해서 placeholder 수정을 가능하게 합니다

<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
