### PR TITLE
feat(VsConfirm): add closeOnEsc props to VsConfirm

### DIFF
--- a/packages/vlossom/src/components/vs-confirm/VsConfirm.vue
+++ b/packages/vlossom/src/components/vs-confirm/VsConfirm.vue
@@ -4,7 +4,7 @@
         :style-set="dialogStylSet"
         :size="confirmInfo.size || 'sm'"
         :close-on-dimmed-click="false"
-        :close-on-esc="false"
+        :close-on-esc="confirmInfo.closeOnEsc ?? true"
         :color-scheme="computedColorScheme === 'default' ? undefined : computedColorScheme"
     >
         <div class="confirm-text scale-up-center">

--- a/packages/vlossom/src/components/vs-confirm/__tests__/vs-confirm.test.ts
+++ b/packages/vlossom/src/components/vs-confirm/__tests__/vs-confirm.test.ts
@@ -12,11 +12,8 @@ describe('vs-confirm', () => {
         originalResolve = store.confirm.executeResolve;
         originalPop = store.dialog.pop;
 
-        store.confirm.executeResolve = vi
-            .spyOn(store.confirm, 'executeResolve')
-            .mockImplementation(() => undefined).mockClear;
-
-        store.dialog.pop = vi.spyOn(store.dialog, 'pop').mockImplementation(() => undefined).mockClear;
+        store.confirm.executeResolve = vi.fn();
+        store.dialog.pop = vi.fn();
     });
 
     afterEach(() => {
@@ -79,9 +76,6 @@ describe('vs-confirm', () => {
 
     it('ok 버튼을 클릭하면 resolve 가 true 로 이행되고 confirm dialog가 닫힌다', async () => {
         // given
-        vi.spyOn(store.confirm, 'executeResolve').mockImplementation(() => vi.fn());
-        vi.spyOn(store.dialog, 'pop').mockImplementation(() => vi.fn());
-
         const wrapper = mount(VsConfirm, {
             props: {
                 confirmInfo: {
@@ -105,9 +99,6 @@ describe('vs-confirm', () => {
 
     it('cancel 버튼을 클릭하면 resolve 가 false 로 이행되고 confirm dialog가 닫힌다', async () => {
         // given
-        vi.spyOn(store.confirm, 'executeResolve').mockImplementation(() => vi.fn());
-        vi.spyOn(store.dialog, 'pop').mockImplementation(() => vi.fn());
-
         const wrapper = mount(VsConfirm, {
             props: {
                 confirmInfo: {
@@ -129,7 +120,26 @@ describe('vs-confirm', () => {
         expect(store.dialog.pop).toHaveBeenCalledTimes(1);
     });
 
-    it('close-on-esc prop을 false로 전달하면 Escape 키를 눌러도 close 이벤트를 emit 하지 않는다', () => {
+    it('close-on-esc 옵션을 전달하지 않으면 기본으로 true로 설정되며, esc key를 눌렀을 때 confirm dialog가 닫힌다', async () => {
+        // given
+        const wrapper = mount(VsConfirm, {
+            props: {
+                confirmInfo: {
+                    text: 'This is Confirm Text',
+                },
+            },
+        });
+
+        // when
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+        await nextTick();
+
+        // then
+        expect(wrapper.vm.isOpen).toBe(false);
+        expect(store.dialog.pop).toHaveBeenCalledTimes(1);
+    });
+
+    it('close-on-esc 옵션을 false로 전달하면 esc key를 눌러도 confirm dialog가 닫히지 않는다', async () => {
         // given
         const wrapper = mount(VsConfirm, {
             props: {
@@ -142,8 +152,10 @@ describe('vs-confirm', () => {
 
         // when
         document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+        await nextTick();
 
         // then
-        expect(wrapper.emitted('close')).toBeFalsy();
+        expect(wrapper.vm.isOpen).toBe(true);
+        expect(store.dialog.pop).not.toHaveBeenCalled();
     });
 });

--- a/packages/vlossom/src/components/vs-confirm/__tests__/vs-confirm.test.ts
+++ b/packages/vlossom/src/components/vs-confirm/__tests__/vs-confirm.test.ts
@@ -128,4 +128,22 @@ describe('vs-confirm', () => {
         expect(store.confirm.executeResolve).toHaveBeenCalledTimes(1);
         expect(store.dialog.pop).toHaveBeenCalledTimes(1);
     });
+
+    it('close-on-esc prop을 false로 전달하면 Escape 키를 눌러도 close 이벤트를 emit 하지 않는다', () => {
+        // given
+        const wrapper = mount(VsConfirm, {
+            props: {
+                confirmInfo: {
+                    text: 'This is Confirm Text',
+                    closeOnEsc: false,
+                },
+            },
+        });
+
+        // when
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+
+        // then
+        expect(wrapper.emitted('close')).toBeFalsy();
+    });
 });

--- a/packages/vlossom/src/components/vs-confirm/stories/VsConfirm.stories.ts
+++ b/packages/vlossom/src/components/vs-confirm/stories/VsConfirm.stories.ts
@@ -25,6 +25,7 @@ const meta: Meta = {
                     cancelText: args.cancelText,
                     size: args.size,
                     colorScheme: args.colorScheme,
+                    closeOnEsc: args.closeOnEsc,
                 });
                 showResult.value = true;
             }
@@ -49,6 +50,7 @@ export const Default: OpenStory = {
         text: 'Are you sure?',
         okText: '',
         cancelText: '',
+        closeOnEsc: true,
     },
     argTypes: {
         size,

--- a/packages/vlossom/src/components/vs-drawer/__tests__/vs-drawer.test.ts
+++ b/packages/vlossom/src/components/vs-drawer/__tests__/vs-drawer.test.ts
@@ -154,7 +154,7 @@ describe('vs-drawer', () => {
             const wrapper = mount(VsDrawer, {
                 props: {
                     modelValue: true,
-                    closeOnEscKey: false,
+                    closeOnEsc: false,
                 },
                 attachTo: document.body,
             });

--- a/packages/vlossom/src/components/vs-modal/__tests__/vs-modal.test.ts
+++ b/packages/vlossom/src/components/vs-modal/__tests__/vs-modal.test.ts
@@ -193,12 +193,12 @@ describe('vs-modal', () => {
             expect(updateModelValueEvent?.[0]).toEqual([false]);
         });
 
-        it('close-on-esc-key prop을 false로 전달하면 esc key를 눌러도 modal이 닫히지 않는다', async () => {
+        it('close-on-esc prop을 false로 전달하면 esc key를 눌러도 modal이 닫히지 않는다', async () => {
             // given
             const wrapper = mount(VsModal, {
                 props: {
                     modelValue: true,
-                    closeOnEscKey: false,
+                    closeOnEsc: false,
                 },
                 global: {
                     stubs: ['Teleport'],

--- a/packages/vlossom/src/plugins/confirm-plugin/types.ts
+++ b/packages/vlossom/src/plugins/confirm-plugin/types.ts
@@ -5,6 +5,7 @@ export interface ConfirmOptions {
     cancelText?: string;
     colorScheme?: ColorScheme;
     size?: Size | string;
+    closeOnEsc?: boolean;
 }
 
 export interface ConfirmInfo extends ConfirmOptions {


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Feature (feat)

## Summary
- VsConfirm에 closeOnEsc props 추가 
- vs-confirm 테스트코드 개선
- vs-modal, vs-drawer 테스트코드에서 오타 수정


