### PR TITLE
fix(VsSelect): fix vs-select click outside

### DIFF
--- a/packages/vlossom/src/components/vs-select/VsSelect.scss
+++ b/packages/vlossom/src/components/vs-select/VsSelect.scss
@@ -105,14 +105,14 @@
     }
 }
 
-.options-container {
+.vs-options-container {
     z-index: 900;
     background-color: var(--vs-select-backgroundColor, var(--vs-no-color));
     border: var(--vs-select-border, solid 1px var(--vs-line-color));
     border-radius: var(--vs-select-borderRadius, calc(var(--vs-radius-ratio) * 0.4rem));
     overflow: hidden;
 
-    .options {
+    .vs-select-options {
         max-height: 25rem;
         overflow: auto;
         list-style-type: none;

--- a/packages/vlossom/src/components/vs-select/VsSelect.vue
+++ b/packages/vlossom/src/components/vs-select/VsSelect.vue
@@ -101,7 +101,7 @@
                     <div
                         ref="optionsRef"
                         :class="[
-                            'options-container',
+                            'vs-options-container',
                             `vs-${computedColorScheme}`,
                             animationClass,
                             { dense: dense, closing: isClosing },
@@ -113,11 +113,10 @@
                         </div>
                         <ul
                             ref="listboxRef"
-                            id="vs-select-options"
                             role="listbox"
+                            class="vs-select-options"
                             :aria-multi-selectable="multiple"
                             :aria-activedescendant="focusedOptionId"
-                            class="options"
                             tabindex="-1"
                             @keydown.stop="onKeyDown"
                         >
@@ -350,54 +349,6 @@ export default defineComponent({
             options.value.map((option) => ({ id: utils.string.createID(), value: option })),
         );
 
-        const { getOptionLabel, getOptionValue } = useInputOption(
-            inputValue,
-            options,
-            optionLabel,
-            optionValue,
-            multiple,
-        );
-
-        const { isOpen, isClosing, toggleOptions, closeOptions, triggerRef, optionsRef, isVisible, computedPlacement } =
-            useToggleOptions(disabled, readonly);
-
-        const { autocompleteText, filteredOptions, updateAutocompleteText } = useAutocomplete(
-            computedOptions,
-            getOptionLabel,
-            isOpen,
-        );
-
-        const { listboxRef, loadedOptions } = useInfiniteScroll(filteredOptions, lazyLoadNum, isOpen);
-
-        const { selectOption, selectAllOptions, isSelectedOption, isAllSelected, removeSelected, selectedOptions } =
-            useSelectOption(
-                inputValue,
-                computedOptions,
-                getOptionLabel,
-                getOptionValue,
-                multiple,
-                closeOptions,
-                autocomplete,
-                autocompleteText,
-                focus,
-            );
-
-        const { focusedIndex, hoveredIndex, chasingMouse, onKeyDown, onMouseMove, isChasedOption, focusedOptionId } =
-            useFocusControl(
-                disabled,
-                readonly,
-                isOpen,
-                closeOptions,
-                selectAll,
-                isAllSelected,
-                selectedOptions,
-                filteredOptions,
-                loadedOptions,
-                selectOption,
-                selectAllOptions,
-                focus,
-            );
-
         function requiredCheck() {
             if (!required.value) {
                 return '';
@@ -450,6 +401,54 @@ export default defineComponent({
         );
 
         const { stateClasses } = useStateClass(computedState);
+
+        const { getOptionLabel, getOptionValue } = useInputOption(
+            inputValue,
+            options,
+            optionLabel,
+            optionValue,
+            multiple,
+        );
+
+        const { isOpen, isClosing, toggleOptions, closeOptions, triggerRef, optionsRef, isVisible, computedPlacement } =
+            useToggleOptions(id, disabled, readonly);
+
+        const { autocompleteText, filteredOptions, updateAutocompleteText } = useAutocomplete(
+            computedOptions,
+            getOptionLabel,
+            isOpen,
+        );
+
+        const { listboxRef, loadedOptions } = useInfiniteScroll(filteredOptions, lazyLoadNum, isOpen);
+
+        const { selectOption, selectAllOptions, isSelectedOption, isAllSelected, removeSelected, selectedOptions } =
+            useSelectOption(
+                inputValue,
+                computedOptions,
+                getOptionLabel,
+                getOptionValue,
+                multiple,
+                closeOptions,
+                autocomplete,
+                autocompleteText,
+                focus,
+            );
+
+        const { focusedIndex, hoveredIndex, chasingMouse, onKeyDown, onMouseMove, isChasedOption, focusedOptionId } =
+            useFocusControl(
+                disabled,
+                readonly,
+                isOpen,
+                closeOptions,
+                selectAll,
+                isAllSelected,
+                selectedOptions,
+                filteredOptions,
+                loadedOptions,
+                selectOption,
+                selectAllOptions,
+                focus,
+            );
 
         const focusing = ref(false);
 

--- a/packages/vlossom/src/components/vs-select/__tests__/vs-select.test.ts
+++ b/packages/vlossom/src/components/vs-select/__tests__/vs-select.test.ts
@@ -401,7 +401,7 @@ describe('vs-select', () => {
 
             // then
             expect(wrapper.find('input').element.value).toBe('B');
-            expect(wrapper.find('ul#vs-select-options').exists()).toBe(false);
+            expect(wrapper.find('ul.vs-select-options').exists()).toBe(false);
         });
 
         it('multiple이 true일 때 옵션을 선택하면 선택한 옵션 값이 chip 형태로 보여지고 옵션 리스트 창은 여전히 존재한다', async () => {
@@ -426,7 +426,7 @@ describe('vs-select', () => {
             expect(wrapper.find('input').element.value).toBe('');
             expect(wrapper.findComponent({ name: 'VsChip' }).exists()).toBe(true);
             expect(wrapper.findComponent({ name: 'VsChip' }).html()).toContain('B');
-            expect(wrapper.find('ul#vs-select-options').exists()).toBe(true);
+            expect(wrapper.find('ul.vs-select-options').exists()).toBe(true);
         });
 
         it('multiple이 true일 때 선택된 옵션을 다시 선택하면 선택한 옵션 값이 chip 리스트에서 사라지고 옵션 리스트 창은 여전히 존재한다', async () => {
@@ -453,7 +453,7 @@ describe('vs-select', () => {
             expect(wrapper.find('input').element.value).toBe('');
             expect(wrapper.findAllComponents({ name: 'VsChip' })).toHaveLength(1);
             expect(wrapper.findComponent({ name: 'VsChip' }).html()).toContain('A');
-            expect(wrapper.find('ul#vs-select-options').exists()).toBe(true);
+            expect(wrapper.find('ul.vs-select-options').exists()).toBe(true);
         });
 
         it('selectAll이 true일 때 모든 옵션을 선택할 수 있는 옵션을 제공한다', async () => {
@@ -476,7 +476,7 @@ describe('vs-select', () => {
             // when
             await wrapper.find('input').trigger('click');
             // then
-            expect(wrapper.find('ul#vs-select-options').html()).toContain('Select All');
+            expect(wrapper.find('ul.vs-select-options').html()).toContain('Select All');
 
             // when
             await wrapper.find('li.option').trigger('click');
@@ -488,7 +488,7 @@ describe('vs-select', () => {
     });
 
     describe('click outside', () => {
-        it('옵션 리스트가 열려있는 상태에서 외부를 클릭하면 옵션 리스트가 닫힌다', async () => {
+        it('옵션 리스트가 열려 있는 상태에서 외부를 클릭하면 옵션 리스트가 닫힌다', async () => {
             // given
             const wrapper: ReturnType<typeof mountComponent> = mount(VsSelect, {
                 props: {
@@ -505,12 +505,12 @@ describe('vs-select', () => {
             // when
             await wrapper.find('input').trigger('click');
             await vi.advanceTimersByTime(0);
-            document.dispatchEvent(new Event('click'));
+            document.body.click();
             await nextTick();
             await vi.advanceTimersByTime(500);
 
             // then
-            expect(document.body.querySelector('ul#vs-select-options')).toBeNull();
+            expect(document.body.querySelector('ul.vs-select-options')).toBeNull();
         });
     });
 
@@ -615,7 +615,7 @@ describe('vs-select', () => {
             await input.setValue('apple');
 
             // then
-            expect(wrapper.find('ul#vs-select-options').exists()).toBe(true);
+            expect(wrapper.find('ul.vs-select-options').exists()).toBe(true);
             expect(wrapper.vm.filteredOptions).toHaveLength(3);
         });
     });
@@ -642,24 +642,24 @@ describe('vs-select', () => {
                 // when
                 await wrapper.find('input').trigger('keydown', { code: 'Enter' });
                 // then
-                expect(wrapper.find('ul#vs-select-options').exists()).toBe(true);
+                expect(wrapper.find('ul.vs-select-options').exists()).toBe(true);
 
                 // when
                 await wrapper.find('input').trigger('keydown', { code: 'Enter' });
                 await vi.advanceTimersByTime(500);
                 // then
-                expect(wrapper.find('ul#vs-select-options').exists()).toBe(false);
+                expect(wrapper.find('ul.vs-select-options').exists()).toBe(false);
 
                 // when
                 await wrapper.find('input').trigger('keydown', { code: 'Space' });
                 // then
-                expect(wrapper.find('ul#vs-select-options').exists()).toBe(true);
+                expect(wrapper.find('ul.vs-select-options').exists()).toBe(true);
 
                 // when
                 await wrapper.find('input').trigger('keydown', { code: 'Space' });
                 await vi.advanceTimersByTime(500);
                 // then
-                expect(wrapper.find('ul#vs-select-options').exists()).toBe(false);
+                expect(wrapper.find('ul.vs-select-options').exists()).toBe(false);
             });
 
             it('combobox가 focus를 받은 상태에서 Arrow Down 키를 누르면 옵션 리스트가 열리고 listbox의 첫번째 옵션으로 focus가 이동한다', async () => {
@@ -667,9 +667,9 @@ describe('vs-select', () => {
                 await wrapper.find('input').trigger('keydown', { code: 'ArrowDown' });
 
                 // then
-                expect(wrapper.find('ul#vs-select-options').exists()).toBe(true);
-                const firstId = wrapper.find('ul#vs-select-options').find('li').attributes('id');
-                expect(wrapper.find('ul#vs-select-options').attributes('aria-activedescendant')).toBe(firstId);
+                expect(wrapper.find('ul.vs-select-options').exists()).toBe(true);
+                const firstId = wrapper.find('ul.vs-select-options').find('li').attributes('id');
+                expect(wrapper.find('ul.vs-select-options').attributes('aria-activedescendant')).toBe(firstId);
             });
 
             it('옵션 리스트를 열고 Arrow Down 키를 누르면 listbox의 첫번째 옵션으로 focus가 이동하고 Enter 키를 누르면 그 옵션이 선택된다', async () => {
@@ -678,7 +678,7 @@ describe('vs-select', () => {
                 await wrapper.find('input').trigger('keydown', { code: 'ArrowDown' });
 
                 // then
-                const firstId = wrapper.find('ul#vs-select-options').find('li').attributes('id');
+                const firstId = wrapper.find('ul.vs-select-options').find('li').attributes('id');
                 expect(wrapper.find('input').attributes('aria-activedescendant')).toBe(firstId);
 
                 // when
@@ -712,7 +712,7 @@ describe('vs-select', () => {
                 await vi.advanceTimersByTime(500);
 
                 // then
-                expect(wrapper.find('ul#vs-select-options').exists()).toBe(false);
+                expect(wrapper.find('ul.vs-select-options').exists()).toBe(false);
             });
 
             it('Tab 키를 누르면 focus 중인 옵션이 선택되고 옵션 리스트가 닫힌다', async () => {
@@ -727,7 +727,7 @@ describe('vs-select', () => {
                 expect(wrapper.emitted('update:modelValue')).toHaveLength(1);
                 expect(wrapper.emitted('update:modelValue')?.[0]).toEqual(['B']);
                 expect(wrapper.find('input').element.value).toBe('B');
-                expect(wrapper.find('ul#vs-select-options').exists()).toBe(false);
+                expect(wrapper.find('ul.vs-select-options').exists()).toBe(false);
             });
 
             it('multiple이 true일 때도 Tab 키를 누르면 focus 중인 옵션이 선택되고 옵션 리스트가 닫힌다', async () => {
@@ -745,7 +745,7 @@ describe('vs-select', () => {
                 expect(wrapper.emitted('update:modelValue')).toHaveLength(1);
                 expect(wrapper.emitted('update:modelValue')?.[0]).toEqual([['B']]);
                 expect(wrapper.find('input').element.value).toBe('');
-                expect(wrapper.find('ul#vs-select-options').exists()).toBe(false);
+                expect(wrapper.find('ul.vs-select-options').exists()).toBe(false);
             });
         });
 

--- a/packages/vlossom/src/components/vs-select/__tests__/vs-select.test.ts
+++ b/packages/vlossom/src/components/vs-select/__tests__/vs-select.test.ts
@@ -502,8 +502,9 @@ describe('vs-select', () => {
                 attachTo: document.body,
             });
 
-            // when
             await wrapper.find('input').trigger('click');
+
+            // when
             await vi.advanceTimersByTime(0);
             document.body.click();
             await nextTick();
@@ -511,6 +512,31 @@ describe('vs-select', () => {
 
             // then
             expect(document.body.querySelector('ul.vs-select-options')).toBeNull();
+        });
+
+        it('multiple 상태의 select의 옵션 리스트가 열려 있을 때 해당 select의 옵션을 선택해도 리스트가 닫히지 않는다', async () => {
+            // given
+            const wrapper: ReturnType<typeof mountComponent> = mount(VsSelect, {
+                props: {
+                    options: ['A', 'B', 'C'],
+                    multiple: true,
+                },
+                global: {
+                    stubs: {
+                        teleport: true,
+                    },
+                },
+                attachTo: document.body,
+            });
+
+            await wrapper.find('input').trigger('click');
+
+            // when
+            await wrapper.findAll('ul.vs-select-options li.option')[1].trigger('click');
+            await nextTick();
+
+            // then
+            expect(wrapper.find('ul.vs-select-options').exists()).toBe(true);
         });
     });
 

--- a/packages/vlossom/src/utils/__tests__/string.test.ts
+++ b/packages/vlossom/src/utils/__tests__/string.test.ts
@@ -5,14 +5,14 @@ describe('string util', () => {
     describe('createID', () => {
         const { createID } = stringUtil;
 
-        it('임의의 ID를 생성할 수 있다 (ID는 알파벳 소문자와 숫자로만 이루어져 있다)', () => {
+        it('임의의 ID를 생성할 수 있다 (ID는 알파벳 대문자와 소문자로 이루어져 있다)', () => {
             // when
             const result = createID();
 
             // then
             expect(result).toBeDefined();
             expect(result).toHaveLength(10);
-            expect(result).toMatch(/^[a-z0-9]+$/);
+            expect(result).toMatch(/^[A-Za-z]+$/);
         });
 
         it('ID의 길이를 제한해서 만들 수 있다', () => {

--- a/packages/vlossom/src/utils/string.ts
+++ b/packages/vlossom/src/utils/string.ts
@@ -2,7 +2,9 @@ import { customAlphabet } from 'nanoid';
 
 export const stringUtil = {
     createID(size = 10): string {
-        const chars = '0123456789abcdefghijklmnopqrstuvwxyz';
+        // element ID should not start with a number
+        // https://www.w3schools.com/html/html_id.asp
+        const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
         const nanoid = customAlphabet(chars, size);
         return nanoid();
     },


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary
vs-select 외부 영역 클릭 시 안 닫히는 버그를 수정

## Description
- vs-select 외부 click event가 stopPropagation 때문에 제대로 동작하지 않는 이슈가 있음
- document에 걸던 click event listener를 capturing 방식으로 바꿈
- event target에서 closest를 이용해서 해당 select의 아이템인지 확인하는 로직을 작성함

<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
