### PR TITLE
feat(vs-select, vs-checkbox-set): add max/min props and rules

### DIFF
--- a/packages/vlossom/src/components/vs-checkbox-set/VsCheckboxSet.vue
+++ b/packages/vlossom/src/components/vs-checkbox-set/VsCheckboxSet.vue
@@ -89,8 +89,16 @@ export default defineComponent({
             type: Function as PropType<(from: any, to: any, option: any) => Promise<boolean> | null>,
             default: null,
         },
-        max: { type: [Number, String], default: Number.MAX_SAFE_INTEGER },
-        min: { type: [Number, String], default: 0 },
+        max: {
+            type: [Number, String],
+            default: Number.MAX_SAFE_INTEGER,
+            validator: (value: number | string) => utils.props.checkValidNumber(name, 'max', value),
+        },
+        min: {
+            type: [Number, String],
+            default: 0,
+            validator: (value: number | string) => utils.props.checkValidNumber(name, 'min', value),
+        },
         vertical: { type: Boolean, default: false },
         // v-model
         modelValue: {

--- a/packages/vlossom/src/components/vs-checkbox-set/VsCheckboxSet.vue
+++ b/packages/vlossom/src/components/vs-checkbox-set/VsCheckboxSet.vue
@@ -90,7 +90,7 @@ export default defineComponent({
             default: null,
         },
         max: { type: [Number, String], default: Number.MAX_SAFE_INTEGER },
-        min: { type: [Number, String], default: Number.MIN_SAFE_INTEGER },
+        min: { type: [Number, String], default: 0 },
         vertical: { type: Boolean, default: false },
         // v-model
         modelValue: {

--- a/packages/vlossom/src/components/vs-checkbox-set/VsCheckboxSet.vue
+++ b/packages/vlossom/src/components/vs-checkbox-set/VsCheckboxSet.vue
@@ -90,7 +90,7 @@ export default defineComponent({
             default: null,
         },
         max: { type: [Number, String], default: Number.MAX_SAFE_INTEGER },
-        min: { type: [Number, String], default: 0 },
+        min: { type: [Number, String], default: Number.MIN_SAFE_INTEGER },
         vertical: { type: Boolean, default: false },
         // v-model
         modelValue: {

--- a/packages/vlossom/src/components/vs-checkbox-set/VsCheckboxSet.vue
+++ b/packages/vlossom/src/components/vs-checkbox-set/VsCheckboxSet.vue
@@ -69,6 +69,7 @@ import { utils } from '@/utils';
 import VsInputWrapper from '@/components/vs-input-wrapper/VsInputWrapper.vue';
 import VsWrapper from '@/components/vs-wrapper/VsWrapper.vue';
 import { VsCheckboxNode } from '@/nodes';
+import { useVsCheckboxSetRules } from './vs-checkbox-set-rules';
 
 import type { VsCheckboxSetStyleSet } from './types';
 import type { VsCheckboxStyleSet } from '@/components/vs-checkbox/types';
@@ -88,6 +89,8 @@ export default defineComponent({
             type: Function as PropType<(from: any, to: any, option: any) => Promise<boolean> | null>,
             default: null,
         },
+        max: { type: [Number, String], default: Number.MAX_SAFE_INTEGER },
+        min: { type: [Number, String], default: 0 },
         vertical: { type: Boolean, default: false },
         // v-model
         modelValue: {
@@ -113,6 +116,8 @@ export default defineComponent({
             required,
             rules,
             state,
+            max,
+            min,
         } = toRefs(props);
 
         const checkboxRefs: Ref<HTMLInputElement[]> = ref([]);
@@ -145,11 +150,9 @@ export default defineComponent({
             ref(true),
         );
 
-        function requiredCheck() {
-            return required.value && inputValue.value && inputValue.value.length === 0 ? 'required' : '';
-        }
+        const { requiredCheck, maxCheck, minCheck } = useVsCheckboxSetRules(required, max, min);
 
-        const allRules = computed(() => [...rules.value, requiredCheck]);
+        const allRules = computed(() => [...rules.value, requiredCheck, maxCheck, minCheck]);
 
         const { computedMessages, computedState, shake, validate, clear, id } = useInput(
             inputValue,

--- a/packages/vlossom/src/components/vs-checkbox-set/VsCheckboxSet.vue
+++ b/packages/vlossom/src/components/vs-checkbox-set/VsCheckboxSet.vue
@@ -89,28 +89,8 @@ export default defineComponent({
             type: Function as PropType<(from: any, to: any, option: any) => Promise<boolean> | null>,
             default: null,
         },
-        max: {
-            type: Number,
-            default: Number.MAX_SAFE_INTEGER,
-            validator: (prop: number) => {
-                const isValid = prop >= 1;
-                if (!isValid) {
-                    utils.log.propError(name, 'max', 'max must be 1 or more');
-                }
-                return isValid;
-            },
-        },
-        min: {
-            type: Number,
-            default: 0,
-            validator: (prop: number) => {
-                const isValid = prop >= 0;
-                if (!isValid) {
-                    utils.log.propError(name, 'min', 'min must be 0 or more');
-                }
-                return isValid;
-            },
-        },
+        max: { type: [Number, String], default: Number.MAX_SAFE_INTEGER },
+        min: { type: [Number, String], default: 0 },
         vertical: { type: Boolean, default: false },
         // v-model
         modelValue: {

--- a/packages/vlossom/src/components/vs-checkbox-set/VsCheckboxSet.vue
+++ b/packages/vlossom/src/components/vs-checkbox-set/VsCheckboxSet.vue
@@ -89,8 +89,28 @@ export default defineComponent({
             type: Function as PropType<(from: any, to: any, option: any) => Promise<boolean> | null>,
             default: null,
         },
-        max: { type: [Number, String], default: Number.MAX_SAFE_INTEGER },
-        min: { type: [Number, String], default: 0 },
+        max: {
+            type: Number,
+            default: Number.MAX_SAFE_INTEGER,
+            validator: (prop: number) => {
+                const isValid = prop >= 1;
+                if (!isValid) {
+                    utils.log.propError(name, 'max', 'max must be 1 or more');
+                }
+                return isValid;
+            },
+        },
+        min: {
+            type: Number,
+            default: 0,
+            validator: (prop: number) => {
+                const isValid = prop >= 0;
+                if (!isValid) {
+                    utils.log.propError(name, 'min', 'min must be 0 or more');
+                }
+                return isValid;
+            },
+        },
         vertical: { type: Boolean, default: false },
         // v-model
         modelValue: {

--- a/packages/vlossom/src/components/vs-checkbox-set/__tests__/vs-checkbox-set.test.ts
+++ b/packages/vlossom/src/components/vs-checkbox-set/__tests__/vs-checkbox-set.test.ts
@@ -285,6 +285,47 @@ describe('vs-checkbox-set', () => {
             expect(wrapper.vm.computedMessages).toHaveLength(1);
             expect(wrapper.html()).toContain('required');
         });
+
+        it('최대로 선택 가능한 아이템 수를 max props를 통해 제한하고 체크할 수 있다', async () => {
+            // given
+            const wrapper: ReturnType<typeof mountComponent> = mount(VsCheckboxSet, {
+                props: {
+                    modelValue: [],
+                    'onUpdate:modelValue': (e) => wrapper.setProps({ modelValue: e }),
+                    options: ['A', 'B', 'C'],
+                    max: 1,
+                },
+            });
+
+            // when
+            await nextTick();
+            await wrapper.find('input[value="A"]').trigger('click');
+            await wrapper.find('input[value="B"]').trigger('click');
+
+            // then
+            expect(wrapper.vm.computedMessages).toHaveLength(1);
+            expect(wrapper.html()).toContain('max number of items: 1');
+        });
+
+        it('최소로 선택 가능한 아이템 수를 max props를 통해 제한하고 체크할 수 있다', async () => {
+            // given
+            const wrapper: ReturnType<typeof mountComponent> = mount(VsCheckboxSet, {
+                props: {
+                    modelValue: [],
+                    'onUpdate:modelValue': (e) => wrapper.setProps({ modelValue: e }),
+                    options: ['A', 'B', 'C'],
+                    min: 2,
+                },
+            });
+
+            // when
+            await nextTick();
+            await wrapper.find('input[value="A"]').trigger('click');
+
+            // then
+            expect(wrapper.vm.computedMessages).toHaveLength(1);
+            expect(wrapper.html()).toContain('min number of items: 2');
+        });
     });
 
     describe('validate', () => {

--- a/packages/vlossom/src/components/vs-checkbox-set/vs-checkbox-set-rules.ts
+++ b/packages/vlossom/src/components/vs-checkbox-set/vs-checkbox-set-rules.ts
@@ -1,16 +1,28 @@
 import { Ref } from 'vue';
 
-export function useVsCheckboxSetRules(required: Ref<boolean>, max: Ref<number>, min: Ref<number>) {
+export function useVsCheckboxSetRules(required: Ref<boolean>, max: Ref<number | string>, min: Ref<number | string>) {
     function requiredCheck(v: any[]) {
         return required.value && v && v.length === 0 ? 'required' : '';
     }
 
     function maxCheck(v: any[]) {
-        return v && v.length > max.value ? 'max number of items: ' + max.value : '';
+        const limit = Number(max.value);
+
+        if (isNaN(limit) || limit > Number.MAX_SAFE_INTEGER) {
+            return '';
+        }
+
+        return v && v.length > limit ? 'max number of items: ' + max.value : '';
     }
 
     function minCheck(v: any[]) {
-        return v && v.length < min.value ? 'min number of items: ' + min.value : '';
+        const limit = Number(min.value);
+
+        if (isNaN(limit) || limit < Number.MIN_SAFE_INTEGER) {
+            return '';
+        }
+
+        return v && v.length < limit ? 'min number of items: ' + min.value : '';
     }
 
     return {

--- a/packages/vlossom/src/components/vs-checkbox-set/vs-checkbox-set-rules.ts
+++ b/packages/vlossom/src/components/vs-checkbox-set/vs-checkbox-set-rules.ts
@@ -1,28 +1,16 @@
 import { Ref } from 'vue';
 
-export function useVsCheckboxSetRules(required: Ref<boolean>, max: Ref<number | string>, min: Ref<number | string>) {
+export function useVsCheckboxSetRules(required: Ref<boolean>, max: Ref<number>, min: Ref<number>) {
     function requiredCheck(v: any[]) {
         return required.value && v && v.length === 0 ? 'required' : '';
     }
 
     function maxCheck(v: any[]) {
-        const limit = Number(max.value);
-
-        if (isNaN(limit) || limit > Number.MAX_SAFE_INTEGER) {
-            return '';
-        }
-
-        return v && v.length > limit ? 'max number of items: ' + max.value : '';
+        return v && v.length > max.value ? 'max number of items: ' + max.value : '';
     }
 
     function minCheck(v: any[]) {
-        const limit = Number(min.value);
-
-        if (isNaN(limit) || limit < Number.MIN_SAFE_INTEGER) {
-            return '';
-        }
-
-        return v && v.length < limit ? 'min number of items: ' + min.value : '';
+        return v && v.length < min.value ? 'min number of items: ' + min.value : '';
     }
 
     return {

--- a/packages/vlossom/src/components/vs-checkbox-set/vs-checkbox-set-rules.ts
+++ b/packages/vlossom/src/components/vs-checkbox-set/vs-checkbox-set-rules.ts
@@ -1,0 +1,33 @@
+import { Ref } from 'vue';
+
+export function useVsCheckboxSetRules(required: Ref<boolean>, max: Ref<number | string>, min: Ref<number | string>) {
+    function requiredCheck(v: any[]) {
+        return required.value && v && v.length === 0 ? 'required' : '';
+    }
+
+    function maxCheck(v: any[]) {
+        const limit = Number(max.value);
+
+        if (isNaN(limit) || limit > Number.MAX_SAFE_INTEGER) {
+            return '';
+        }
+
+        return v && v.length > limit ? 'max number of items: ' + max.value : '';
+    }
+
+    function minCheck(v: any[]) {
+        const limit = Number(min.value);
+
+        if (isNaN(limit) || limit < Number.MIN_SAFE_INTEGER) {
+            return '';
+        }
+
+        return v && v.length < limit ? 'min number of items: ' + min.value : '';
+    }
+
+    return {
+        requiredCheck,
+        maxCheck,
+        minCheck,
+    };
+}

--- a/packages/vlossom/src/components/vs-checkbox-set/vs-checkbox-set-rules.ts
+++ b/packages/vlossom/src/components/vs-checkbox-set/vs-checkbox-set-rules.ts
@@ -7,21 +7,11 @@ export function useVsCheckboxSetRules(required: Ref<boolean>, max: Ref<number | 
 
     function maxCheck(v: any[]) {
         const limit = Number(max.value);
-
-        if (isNaN(limit) || limit > Number.MAX_SAFE_INTEGER) {
-            return '';
-        }
-
         return v && v.length > limit ? 'max number of items: ' + max.value : '';
     }
 
     function minCheck(v: any[]) {
         const limit = Number(min.value);
-
-        if (isNaN(limit) || limit < Number.MIN_SAFE_INTEGER) {
-            return '';
-        }
-
         return v && v.length < limit ? 'min number of items: ' + min.value : '';
     }
 

--- a/packages/vlossom/src/components/vs-input/VsInput.vue
+++ b/packages/vlossom/src/components/vs-input/VsInput.vue
@@ -84,6 +84,7 @@ import { VsIcon } from '@/icons';
 import { InputType } from './types';
 
 import type { InputValueType, VsInputStyleSet } from './types';
+import { utils } from '@/utils';
 
 const name = VsComponent.VsInput;
 export default defineComponent({
@@ -96,8 +97,16 @@ export default defineComponent({
         styleSet: { type: [String, Object] as PropType<string | VsInputStyleSet> },
         autocomplete: { type: Boolean, default: false },
         dense: { type: Boolean, default: false },
-        max: { type: [Number, String], default: Number.MAX_SAFE_INTEGER },
-        min: { type: [Number, String], default: Number.MIN_SAFE_INTEGER },
+        max: {
+            type: [Number, String],
+            default: Number.MAX_SAFE_INTEGER,
+            validator: (value: number | string) => utils.props.checkValidNumber(name, 'max', value),
+        },
+        min: {
+            type: [Number, String],
+            default: Number.MIN_SAFE_INTEGER,
+            validator: (value: number | string) => utils.props.checkValidNumber(name, 'min', value),
+        },
         type: { type: String as PropType<InputType>, default: InputType.Text },
         // v-model
         modelValue: {

--- a/packages/vlossom/src/components/vs-input/VsInput.vue
+++ b/packages/vlossom/src/components/vs-input/VsInput.vue
@@ -96,8 +96,8 @@ export default defineComponent({
         styleSet: { type: [String, Object] as PropType<string | VsInputStyleSet> },
         autocomplete: { type: Boolean, default: false },
         dense: { type: Boolean, default: false },
-        max: { type: Number, default: Number.MAX_SAFE_INTEGER },
-        min: { type: Number, default: Number.MIN_SAFE_INTEGER },
+        max: { type: [Number, String], default: Number.MAX_SAFE_INTEGER },
+        min: { type: [Number, String], default: Number.MIN_SAFE_INTEGER },
         type: { type: String as PropType<InputType>, default: InputType.Text },
         // v-model
         modelValue: {

--- a/packages/vlossom/src/components/vs-input/VsInput.vue
+++ b/packages/vlossom/src/components/vs-input/VsInput.vue
@@ -96,8 +96,8 @@ export default defineComponent({
         styleSet: { type: [String, Object] as PropType<string | VsInputStyleSet> },
         autocomplete: { type: Boolean, default: false },
         dense: { type: Boolean, default: false },
-        max: { type: [Number, String], default: Number.MAX_SAFE_INTEGER },
-        min: { type: [Number, String], default: Number.MIN_SAFE_INTEGER },
+        max: { type: Number, default: Number.MAX_SAFE_INTEGER },
+        min: { type: Number, default: Number.MIN_SAFE_INTEGER },
         type: { type: String as PropType<InputType>, default: InputType.Text },
         // v-model
         modelValue: {

--- a/packages/vlossom/src/components/vs-input/vs-input-rules.ts
+++ b/packages/vlossom/src/components/vs-input/vs-input-rules.ts
@@ -1,7 +1,12 @@
 import { Ref } from 'vue';
 import { InputType, InputValueType } from './types';
 
-export function useVsInputRules(required: Ref<boolean>, max: Ref<number>, min: Ref<number>, type: Ref<InputType>) {
+export function useVsInputRules(
+    required: Ref<boolean>,
+    max: Ref<number | string>,
+    min: Ref<number | string>,
+    type: Ref<InputType>,
+) {
     function requiredCheck(v: InputValueType) {
         if (required.value && v === '') {
             return 'required';
@@ -11,11 +16,17 @@ export function useVsInputRules(required: Ref<boolean>, max: Ref<number>, min: R
     }
 
     function maxCheck(v: InputValueType) {
-        if (type.value === InputType.Number && typeof v === 'number' && v > max.value) {
+        const limit = Number(max.value);
+
+        if (isNaN(limit) || limit > Number.MAX_SAFE_INTEGER) {
+            return '';
+        }
+
+        if (type.value === InputType.Number && typeof v === 'number' && v > limit) {
             return 'max value: ' + max.value;
         }
 
-        if (type.value !== InputType.Number && typeof v === 'string' && v.length > max.value) {
+        if (type.value !== InputType.Number && typeof v === 'string' && v.length > limit) {
             return 'max length: ' + max.value;
         }
 
@@ -23,11 +34,17 @@ export function useVsInputRules(required: Ref<boolean>, max: Ref<number>, min: R
     }
 
     function minCheck(v: InputValueType) {
-        if (type.value === InputType.Number && typeof v === 'number' && v < min.value) {
+        const limit = Number(min.value);
+
+        if (isNaN(limit) || limit < Number.MIN_SAFE_INTEGER) {
+            return '';
+        }
+
+        if (type.value === InputType.Number && typeof v === 'number' && v < limit) {
             return 'min value: ' + min.value;
         }
 
-        if (type.value !== InputType.Number && typeof v === 'string' && v.length < min.value) {
+        if (type.value !== InputType.Number && typeof v === 'string' && v.length < limit) {
             return 'min length: ' + min.value;
         }
 

--- a/packages/vlossom/src/components/vs-input/vs-input-rules.ts
+++ b/packages/vlossom/src/components/vs-input/vs-input-rules.ts
@@ -1,12 +1,7 @@
 import { Ref } from 'vue';
 import { InputType, InputValueType } from './types';
 
-export function useVsInputRules(
-    required: Ref<boolean>,
-    max: Ref<number | string>,
-    min: Ref<number | string>,
-    type: Ref<InputType>,
-) {
+export function useVsInputRules(required: Ref<boolean>, max: Ref<number>, min: Ref<number>, type: Ref<InputType>) {
     function requiredCheck(v: InputValueType) {
         if (required.value && v === '') {
             return 'required';
@@ -16,17 +11,11 @@ export function useVsInputRules(
     }
 
     function maxCheck(v: InputValueType) {
-        const limit = Number(max.value);
-
-        if (isNaN(limit) || limit > Number.MAX_SAFE_INTEGER) {
-            return '';
-        }
-
-        if (type.value === InputType.Number && typeof v === 'number' && v > limit) {
+        if (type.value === InputType.Number && typeof v === 'number' && v > max.value) {
             return 'max value: ' + max.value;
         }
 
-        if (type.value !== InputType.Number && typeof v === 'string' && v.length > limit) {
+        if (type.value !== InputType.Number && typeof v === 'string' && v.length > max.value) {
             return 'max length: ' + max.value;
         }
 
@@ -34,17 +23,11 @@ export function useVsInputRules(
     }
 
     function minCheck(v: InputValueType) {
-        const limit = Number(min.value);
-
-        if (isNaN(limit) || limit < Number.MIN_SAFE_INTEGER) {
-            return '';
-        }
-
-        if (type.value === InputType.Number && typeof v === 'number' && v < limit) {
+        if (type.value === InputType.Number && typeof v === 'number' && v < min.value) {
             return 'min value: ' + min.value;
         }
 
-        if (type.value !== InputType.Number && typeof v === 'string' && v.length < limit) {
+        if (type.value !== InputType.Number && typeof v === 'string' && v.length < min.value) {
             return 'min length: ' + min.value;
         }
 

--- a/packages/vlossom/src/components/vs-input/vs-input-rules.ts
+++ b/packages/vlossom/src/components/vs-input/vs-input-rules.ts
@@ -17,11 +17,6 @@ export function useVsInputRules(
 
     function maxCheck(v: InputValueType) {
         const limit = Number(max.value);
-
-        if (isNaN(limit) || limit > Number.MAX_SAFE_INTEGER) {
-            return '';
-        }
-
         if (type.value === InputType.Number && typeof v === 'number' && v > limit) {
             return 'max value: ' + max.value;
         }
@@ -35,11 +30,6 @@ export function useVsInputRules(
 
     function minCheck(v: InputValueType) {
         const limit = Number(min.value);
-
-        if (isNaN(limit) || limit < Number.MIN_SAFE_INTEGER) {
-            return '';
-        }
-
         if (type.value === InputType.Number && typeof v === 'number' && v < limit) {
             return 'min value: ' + min.value;
         }

--- a/packages/vlossom/src/components/vs-select/VsSelect.vue
+++ b/packages/vlossom/src/components/vs-select/VsSelect.vue
@@ -275,26 +275,12 @@ export default defineComponent({
         max: {
             type: [Number, String],
             default: Number.MAX_SAFE_INTEGER,
-            validator: (value: number | string) => {
-                const limit = Number(value);
-                const isValid = !isNaN(limit) && limit <= Number.MAX_SAFE_INTEGER;
-                if (!isValid) {
-                    utils.log.propError(name, 'max', 'invalid max value');
-                }
-                return isValid;
-            },
+            validator: (value: number | string) => utils.props.checkValidNumber(name, 'max', value),
         },
         min: {
             type: [Number, String],
             default: 0,
-            validator: (value: number | string) => {
-                const limit = Number(value);
-                const isValid = !isNaN(limit) && limit >= 0 && limit <= Number.MAX_SAFE_INTEGER;
-                if (!isValid) {
-                    utils.log.propError(name, 'min', 'invalid min value');
-                }
-                return isValid;
-            },
+            validator: (value: number | string) => utils.props.checkValidNumber(name, 'min', value),
         },
         multiple: { type: Boolean, default: false },
         selectAll: {

--- a/packages/vlossom/src/components/vs-select/VsSelect.vue
+++ b/packages/vlossom/src/components/vs-select/VsSelect.vue
@@ -272,8 +272,28 @@ export default defineComponent({
                 return isValid;
             },
         },
-        max: { type: [Number, String], default: Number.MAX_SAFE_INTEGER },
-        min: { type: [Number, String], default: 0 },
+        max: {
+            type: Number,
+            default: Number.MAX_SAFE_INTEGER,
+            validator: (prop: number) => {
+                const isValid = prop >= 1;
+                if (!isValid) {
+                    utils.log.propError(name, 'max', 'max must be 1 or more');
+                }
+                return isValid;
+            },
+        },
+        min: {
+            type: Number,
+            default: 0,
+            validator: (prop: number) => {
+                const isValid = prop >= 0;
+                if (!isValid) {
+                    utils.log.propError(name, 'min', 'min must be 0 or more');
+                }
+                return isValid;
+            },
+        },
         multiple: { type: Boolean, default: false },
         selectAll: {
             type: Boolean,

--- a/packages/vlossom/src/components/vs-select/VsSelect.vue
+++ b/packages/vlossom/src/components/vs-select/VsSelect.vue
@@ -275,12 +275,24 @@ export default defineComponent({
         max: {
             type: [Number, String],
             default: Number.MAX_SAFE_INTEGER,
-            validator: (value: number | string) => utils.props.checkValidNumber(name, 'max', value),
+            validator: (value: number | string, props) => {
+                if (!props.multiple && value) {
+                    utils.log.propError(name, 'max', 'max can only be used with multiple prop');
+                    return false;
+                }
+                return utils.props.checkValidNumber(name, 'max', value);
+            },
         },
         min: {
             type: [Number, String],
             default: 0,
-            validator: (value: number | string) => utils.props.checkValidNumber(name, 'min', value),
+            validator: (value: number | string, props) => {
+                if (!props.multiple && value) {
+                    utils.log.propError(name, 'min', 'min can only be used with multiple prop');
+                    return false;
+                }
+                return utils.props.checkValidNumber(name, 'min', value);
+            },
         },
         multiple: { type: Boolean, default: false },
         selectAll: {

--- a/packages/vlossom/src/components/vs-select/VsSelect.vue
+++ b/packages/vlossom/src/components/vs-select/VsSelect.vue
@@ -216,6 +216,7 @@ import {
 } from '@/composables';
 import { useAutocomplete, useFocusControl, useInfiniteScroll, useSelectOption, useToggleOptions } from './composables';
 import { VsComponent, type ColorScheme } from '@/declaration';
+import { useVsSelectRules } from './vs-select-rules';
 import { VsSelectStyleSet } from './types';
 import { VsIcon } from '@/icons';
 import { utils } from '@/utils';
@@ -271,6 +272,8 @@ export default defineComponent({
                 return isValid;
             },
         },
+        max: { type: [Number, String], default: Number.MAX_SAFE_INTEGER },
+        min: { type: [Number, String], default: 0 },
         multiple: { type: Boolean, default: false },
         selectAll: {
             type: Boolean,
@@ -308,6 +311,8 @@ export default defineComponent({
             rules,
             selectAll,
             state,
+            max,
+            min,
         } = toRefs(props);
 
         const { emit } = context;
@@ -358,19 +363,9 @@ export default defineComponent({
             options.value.map((option) => ({ id: utils.string.createID(), value: option })),
         );
 
-        function requiredCheck() {
-            if (!required.value) {
-                return '';
-            }
+        const { requiredCheck, maxCheck, minCheck } = useVsSelectRules(required, max, min, multiple);
 
-            if (multiple.value) {
-                return inputValue.value && inputValue.value.length > 0 ? '' : 'required';
-            } else {
-                return inputValue.value ? '' : 'required';
-            }
-        }
-
-        const allRules = computed(() => [...rules.value, requiredCheck]);
+        const allRules = computed(() => [...rules.value, requiredCheck, maxCheck, minCheck]);
 
         function onClear() {
             if (multiple.value) {

--- a/packages/vlossom/src/components/vs-select/VsSelect.vue
+++ b/packages/vlossom/src/components/vs-select/VsSelect.vue
@@ -272,8 +272,30 @@ export default defineComponent({
                 return isValid;
             },
         },
-        max: { type: [Number, String], default: Number.MAX_SAFE_INTEGER },
-        min: { type: [Number, String], default: 0 },
+        max: {
+            type: [Number, String],
+            default: Number.MAX_SAFE_INTEGER,
+            validator: (value: number | string) => {
+                const limit = Number(value);
+                const isValid = !isNaN(limit) && limit <= Number.MAX_SAFE_INTEGER;
+                if (!isValid) {
+                    utils.log.propError(name, 'max', 'invalid max value');
+                }
+                return isValid;
+            },
+        },
+        min: {
+            type: [Number, String],
+            default: 0,
+            validator: (value: number | string) => {
+                const limit = Number(value);
+                const isValid = !isNaN(limit) && limit >= 0 && limit <= Number.MAX_SAFE_INTEGER;
+                if (!isValid) {
+                    utils.log.propError(name, 'min', 'invalid min value');
+                }
+                return isValid;
+            },
+        },
         multiple: { type: Boolean, default: false },
         selectAll: {
             type: Boolean,

--- a/packages/vlossom/src/components/vs-select/VsSelect.vue
+++ b/packages/vlossom/src/components/vs-select/VsSelect.vue
@@ -273,7 +273,7 @@ export default defineComponent({
             },
         },
         max: { type: [Number, String], default: Number.MAX_SAFE_INTEGER },
-        min: { type: [Number, String], default: 0 },
+        min: { type: [Number, String], default: Number.MIN_SAFE_INTEGER },
         multiple: { type: Boolean, default: false },
         selectAll: {
             type: Boolean,

--- a/packages/vlossom/src/components/vs-select/VsSelect.vue
+++ b/packages/vlossom/src/components/vs-select/VsSelect.vue
@@ -273,7 +273,7 @@ export default defineComponent({
             },
         },
         max: { type: [Number, String], default: Number.MAX_SAFE_INTEGER },
-        min: { type: [Number, String], default: Number.MIN_SAFE_INTEGER },
+        min: { type: [Number, String], default: 0 },
         multiple: { type: Boolean, default: false },
         selectAll: {
             type: Boolean,

--- a/packages/vlossom/src/components/vs-select/VsSelect.vue
+++ b/packages/vlossom/src/components/vs-select/VsSelect.vue
@@ -272,28 +272,8 @@ export default defineComponent({
                 return isValid;
             },
         },
-        max: {
-            type: Number,
-            default: Number.MAX_SAFE_INTEGER,
-            validator: (prop: number) => {
-                const isValid = prop >= 1;
-                if (!isValid) {
-                    utils.log.propError(name, 'max', 'max must be 1 or more');
-                }
-                return isValid;
-            },
-        },
-        min: {
-            type: Number,
-            default: 0,
-            validator: (prop: number) => {
-                const isValid = prop >= 0;
-                if (!isValid) {
-                    utils.log.propError(name, 'min', 'min must be 0 or more');
-                }
-                return isValid;
-            },
-        },
+        max: { type: [Number, String], default: Number.MAX_SAFE_INTEGER },
+        min: { type: [Number, String], default: 0 },
         multiple: { type: Boolean, default: false },
         selectAll: {
             type: Boolean,

--- a/packages/vlossom/src/components/vs-select/__tests__/vs-select.test.ts
+++ b/packages/vlossom/src/components/vs-select/__tests__/vs-select.test.ts
@@ -911,6 +911,59 @@ describe('vs-select', () => {
             expect(wrapper.vm.computedMessages).toHaveLength(1);
             expect(wrapper.html()).toContain('required');
         });
+
+        it('multiple이 true일 때, 최대로 선택 가능한 아이템 수를 max props를 통해 제한하고 체크할 수 있다', async () => {
+            // given
+            const wrapper: ReturnType<typeof mountComponent> = mount(VsSelect, {
+                props: {
+                    modelValue: [],
+                    'onUpdate:modelValue': (e) => wrapper.setProps({ modelValue: e }),
+                    options: ['A', 'B', 'C'],
+                    max: 1,
+                    multiple: true,
+                },
+                global: {
+                    stubs: {
+                        teleport: true,
+                    },
+                },
+            });
+
+            // when
+            await wrapper.find('.vs-select').trigger('click');
+            await wrapper.findAll('.vs-option')[1].trigger('click');
+            await wrapper.findAll('.vs-option')[2].trigger('click');
+
+            // then
+            expect(wrapper.vm.computedMessages).toHaveLength(1);
+            expect(wrapper.html()).toContain('max number of items: 1');
+        });
+
+        it('multiple이 true일 때, 최소로 선택 가능한 아이템 수를 min props를 통해 제한하고 체크할 수 있다', async () => {
+            // given
+            const wrapper: ReturnType<typeof mountComponent> = mount(VsSelect, {
+                props: {
+                    modelValue: [],
+                    'onUpdate:modelValue': (e) => wrapper.setProps({ modelValue: e }),
+                    options: ['A', 'B', 'C'],
+                    min: 2,
+                    multiple: true,
+                },
+                global: {
+                    stubs: {
+                        teleport: true,
+                    },
+                },
+            });
+
+            // when
+            await wrapper.find('.vs-select').trigger('click');
+            await wrapper.findAll('.vs-option')[1].trigger('click');
+
+            // then
+            expect(wrapper.vm.computedMessages).toHaveLength(1);
+            expect(wrapper.html()).toContain('min number of items: 2');
+        });
     });
 
     describe('validate', () => {

--- a/packages/vlossom/src/components/vs-select/vs-select-rules.ts
+++ b/packages/vlossom/src/components/vs-select/vs-select-rules.ts
@@ -2,8 +2,8 @@ import { Ref } from 'vue';
 
 export function useVsSelectRules(
     required: Ref<boolean>,
-    max: Ref<number | string>,
-    min: Ref<number | string>,
+    max: Ref<number>,
+    min: Ref<number>,
     multiple: Ref<boolean>,
 ) {
     function requiredCheck(v: any) {
@@ -19,28 +19,16 @@ export function useVsSelectRules(
     }
 
     function maxCheck(v: any) {
-        const limit = Number(max.value);
-
-        if (isNaN(limit) || limit > Number.MAX_SAFE_INTEGER) {
-            return '';
-        }
-
         if (multiple.value) {
-            return v && v.length > limit ? 'max number of items: ' + max.value : '';
+            return v && v.length > max.value ? 'max number of items: ' + max.value : '';
         }
 
         return '';
     }
 
     function minCheck(v: any) {
-        const limit = Number(min.value);
-
-        if (isNaN(limit) || limit < Number.MIN_SAFE_INTEGER) {
-            return '';
-        }
-
         if (multiple.value) {
-            return v && v.length < limit ? 'min number of items: ' + min.value : '';
+            return v && v.length < min.value ? 'min number of items: ' + min.value : '';
         }
 
         return '';

--- a/packages/vlossom/src/components/vs-select/vs-select-rules.ts
+++ b/packages/vlossom/src/components/vs-select/vs-select-rules.ts
@@ -2,8 +2,8 @@ import { Ref } from 'vue';
 
 export function useVsSelectRules(
     required: Ref<boolean>,
-    max: Ref<number>,
-    min: Ref<number>,
+    max: Ref<number | string>,
+    min: Ref<number | string>,
     multiple: Ref<boolean>,
 ) {
     function requiredCheck(v: any) {
@@ -19,16 +19,28 @@ export function useVsSelectRules(
     }
 
     function maxCheck(v: any) {
+        const limit = Number(max.value);
+
+        if (isNaN(limit) || limit > Number.MAX_SAFE_INTEGER) {
+            return '';
+        }
+
         if (multiple.value) {
-            return v && v.length > max.value ? 'max number of items: ' + max.value : '';
+            return v && v.length > limit ? 'max number of items: ' + max.value : '';
         }
 
         return '';
     }
 
     function minCheck(v: any) {
+        const limit = Number(min.value);
+
+        if (isNaN(limit) || limit < Number.MIN_SAFE_INTEGER) {
+            return '';
+        }
+
         if (multiple.value) {
-            return v && v.length < min.value ? 'min number of items: ' + min.value : '';
+            return v && v.length < limit ? 'min number of items: ' + min.value : '';
         }
 
         return '';

--- a/packages/vlossom/src/components/vs-select/vs-select-rules.ts
+++ b/packages/vlossom/src/components/vs-select/vs-select-rules.ts
@@ -20,11 +20,6 @@ export function useVsSelectRules(
 
     function maxCheck(v: any) {
         const limit = Number(max.value);
-
-        if (isNaN(limit) || limit > Number.MAX_SAFE_INTEGER) {
-            return '';
-        }
-
         if (multiple.value) {
             return v && v.length > limit ? 'max number of items: ' + max.value : '';
         }
@@ -34,11 +29,6 @@ export function useVsSelectRules(
 
     function minCheck(v: any) {
         const limit = Number(min.value);
-
-        if (isNaN(limit) || limit < Number.MIN_SAFE_INTEGER) {
-            return '';
-        }
-
         if (multiple.value) {
             return v && v.length < limit ? 'min number of items: ' + min.value : '';
         }

--- a/packages/vlossom/src/components/vs-select/vs-select-rules.ts
+++ b/packages/vlossom/src/components/vs-select/vs-select-rules.ts
@@ -1,0 +1,54 @@
+import { Ref } from 'vue';
+
+export function useVsSelectRules(
+    required: Ref<boolean>,
+    max: Ref<number | string>,
+    min: Ref<number | string>,
+    multiple: Ref<boolean>,
+) {
+    function requiredCheck(v: any) {
+        if (!required.value) {
+            return '';
+        }
+
+        if (multiple.value) {
+            return v && v.length > 0 ? '' : 'required';
+        } else {
+            return v ? '' : 'required';
+        }
+    }
+
+    function maxCheck(v: any) {
+        const limit = Number(max.value);
+
+        if (isNaN(limit) || limit > Number.MAX_SAFE_INTEGER) {
+            return '';
+        }
+
+        if (multiple.value) {
+            return v && v.length > limit ? 'max number of items: ' + max.value : '';
+        }
+
+        return '';
+    }
+
+    function minCheck(v: any) {
+        const limit = Number(min.value);
+
+        if (isNaN(limit) || limit < Number.MIN_SAFE_INTEGER) {
+            return '';
+        }
+
+        if (multiple.value) {
+            return v && v.length < limit ? 'min number of items: ' + min.value : '';
+        }
+
+        return '';
+    }
+
+    return {
+        requiredCheck,
+        maxCheck,
+        minCheck,
+    };
+}

--- a/packages/vlossom/src/components/vs-textarea/VsTextarea.vue
+++ b/packages/vlossom/src/components/vs-textarea/VsTextarea.vue
@@ -72,26 +72,12 @@ export default defineComponent({
         max: {
             type: [Number, String],
             default: Number.MAX_SAFE_INTEGER,
-            validator: (value: number | string) => {
-                const limit = Number(value);
-                const isValid = !isNaN(limit) && limit <= Number.MAX_SAFE_INTEGER;
-                if (!isValid) {
-                    utils.log.propError(name, 'max', 'invalid max value');
-                }
-                return isValid;
-            },
+            validator: (value: number | string) => utils.props.checkValidNumber(name, 'max', value),
         },
         min: {
             type: [Number, String],
             default: 0,
-            validator: (value: number | string) => {
-                const limit = Number(value);
-                const isValid = !isNaN(limit) && limit >= 0 && limit <= Number.MAX_SAFE_INTEGER;
-                if (!isValid) {
-                    utils.log.propError(name, 'min', 'invalid min value');
-                }
-                return isValid;
-            },
+            validator: (value: number | string) => utils.props.checkValidNumber(name, 'min', value),
         },
         // v-model
         modelValue: { type: String, default: '' },

--- a/packages/vlossom/src/components/vs-textarea/VsTextarea.vue
+++ b/packages/vlossom/src/components/vs-textarea/VsTextarea.vue
@@ -69,7 +69,7 @@ export default defineComponent({
         styleSet: { type: [String, Object] as PropType<string | VsTextareaStyleSet> },
         autocomplete: { type: Boolean, default: false },
         max: { type: [Number, String], default: Number.MAX_SAFE_INTEGER },
-        min: { type: [Number, String], default: Number.MIN_SAFE_INTEGER },
+        min: { type: [Number, String], default: 0 },
         // v-model
         modelValue: { type: String, default: '' },
         modelModifiers: {

--- a/packages/vlossom/src/components/vs-textarea/VsTextarea.vue
+++ b/packages/vlossom/src/components/vs-textarea/VsTextarea.vue
@@ -55,6 +55,7 @@ import { VsComponent, StringModifiers, type ColorScheme } from '@/declaration';
 import { useVsTextareaRules } from './vs-textarea-rules';
 import VsInputWrapper from '@/components/vs-input-wrapper/VsInputWrapper.vue';
 import VsWrapper from '@/components/vs-wrapper/VsWrapper.vue';
+import { utils } from '@/utils';
 
 import type { InputValueType, VsTextareaStyleSet } from './types';
 
@@ -68,8 +69,30 @@ export default defineComponent({
         colorScheme: { type: String as PropType<ColorScheme> },
         styleSet: { type: [String, Object] as PropType<string | VsTextareaStyleSet> },
         autocomplete: { type: Boolean, default: false },
-        max: { type: [Number, String], default: Number.MAX_SAFE_INTEGER },
-        min: { type: [Number, String], default: 0 },
+        max: {
+            type: [Number, String],
+            default: Number.MAX_SAFE_INTEGER,
+            validator: (value: number | string) => {
+                const limit = Number(value);
+                const isValid = !isNaN(limit) && limit <= Number.MAX_SAFE_INTEGER;
+                if (!isValid) {
+                    utils.log.propError(name, 'max', 'invalid max value');
+                }
+                return isValid;
+            },
+        },
+        min: {
+            type: [Number, String],
+            default: 0,
+            validator: (value: number | string) => {
+                const limit = Number(value);
+                const isValid = !isNaN(limit) && limit >= 0 && limit <= Number.MAX_SAFE_INTEGER;
+                if (!isValid) {
+                    utils.log.propError(name, 'min', 'invalid min value');
+                }
+                return isValid;
+            },
+        },
         // v-model
         modelValue: { type: String, default: '' },
         modelModifiers: {

--- a/packages/vlossom/src/components/vs-textarea/VsTextarea.vue
+++ b/packages/vlossom/src/components/vs-textarea/VsTextarea.vue
@@ -55,6 +55,7 @@ import { VsComponent, StringModifiers, type ColorScheme } from '@/declaration';
 import { useVsTextareaRules } from './vs-textarea-rules';
 import VsInputWrapper from '@/components/vs-input-wrapper/VsInputWrapper.vue';
 import VsWrapper from '@/components/vs-wrapper/VsWrapper.vue';
+import { utils } from '@/utils';
 
 import type { InputValueType, VsTextareaStyleSet } from './types';
 
@@ -68,8 +69,28 @@ export default defineComponent({
         colorScheme: { type: String as PropType<ColorScheme> },
         styleSet: { type: [String, Object] as PropType<string | VsTextareaStyleSet> },
         autocomplete: { type: Boolean, default: false },
-        max: { type: [Number, String], default: Number.MAX_SAFE_INTEGER },
-        min: { type: [Number, String], default: 0 },
+        max: {
+            type: Number,
+            default: Number.MAX_SAFE_INTEGER,
+            validator: (prop: number) => {
+                const isValid = prop >= 1;
+                if (!isValid) {
+                    utils.log.propError(name, 'max', 'max must be 1 or more');
+                }
+                return isValid;
+            },
+        },
+        min: {
+            type: Number,
+            default: 0,
+            validator: (prop: number) => {
+                const isValid = prop >= 0;
+                if (!isValid) {
+                    utils.log.propError(name, 'min', 'min must be 0 or more');
+                }
+                return isValid;
+            },
+        },
         // v-model
         modelValue: { type: String, default: '' },
         modelModifiers: {

--- a/packages/vlossom/src/components/vs-textarea/VsTextarea.vue
+++ b/packages/vlossom/src/components/vs-textarea/VsTextarea.vue
@@ -55,7 +55,6 @@ import { VsComponent, StringModifiers, type ColorScheme } from '@/declaration';
 import { useVsTextareaRules } from './vs-textarea-rules';
 import VsInputWrapper from '@/components/vs-input-wrapper/VsInputWrapper.vue';
 import VsWrapper from '@/components/vs-wrapper/VsWrapper.vue';
-import { utils } from '@/utils';
 
 import type { InputValueType, VsTextareaStyleSet } from './types';
 
@@ -69,28 +68,8 @@ export default defineComponent({
         colorScheme: { type: String as PropType<ColorScheme> },
         styleSet: { type: [String, Object] as PropType<string | VsTextareaStyleSet> },
         autocomplete: { type: Boolean, default: false },
-        max: {
-            type: Number,
-            default: Number.MAX_SAFE_INTEGER,
-            validator: (prop: number) => {
-                const isValid = prop >= 1;
-                if (!isValid) {
-                    utils.log.propError(name, 'max', 'max must be 1 or more');
-                }
-                return isValid;
-            },
-        },
-        min: {
-            type: Number,
-            default: 0,
-            validator: (prop: number) => {
-                const isValid = prop >= 0;
-                if (!isValid) {
-                    utils.log.propError(name, 'min', 'min must be 0 or more');
-                }
-                return isValid;
-            },
-        },
+        max: { type: [Number, String], default: Number.MAX_SAFE_INTEGER },
+        min: { type: [Number, String], default: 0 },
         // v-model
         modelValue: { type: String, default: '' },
         modelModifiers: {

--- a/packages/vlossom/src/components/vs-textarea/vs-textarea-rules.ts
+++ b/packages/vlossom/src/components/vs-textarea/vs-textarea-rules.ts
@@ -12,11 +12,6 @@ export function useVsTextareaRules(required: Ref<boolean>, max: Ref<number | str
 
     function maxCheck(v: InputValueType) {
         const limit = Number(max.value);
-
-        if (isNaN(limit) || limit > Number.MAX_SAFE_INTEGER) {
-            return '';
-        }
-
         if (typeof v === 'string' && v.length > limit) {
             return 'max length: ' + max.value;
         }
@@ -26,11 +21,6 @@ export function useVsTextareaRules(required: Ref<boolean>, max: Ref<number | str
 
     function minCheck(v: InputValueType) {
         const limit = Number(min.value);
-
-        if (isNaN(limit) || limit < Number.MIN_SAFE_INTEGER) {
-            return '';
-        }
-
         if (typeof v === 'string' && v.length < limit) {
             return 'min length: ' + min.value;
         }

--- a/packages/vlossom/src/components/vs-textarea/vs-textarea-rules.ts
+++ b/packages/vlossom/src/components/vs-textarea/vs-textarea-rules.ts
@@ -1,7 +1,7 @@
 import { Ref } from 'vue';
 import { InputValueType } from './types';
 
-export function useVsTextareaRules(required: Ref<boolean>, max: Ref<number>, min: Ref<number>) {
+export function useVsTextareaRules(required: Ref<boolean>, max: Ref<number | string>, min: Ref<number | string>) {
     function requiredCheck(v: InputValueType) {
         if (required.value && v === '') {
             return 'required';
@@ -11,7 +11,13 @@ export function useVsTextareaRules(required: Ref<boolean>, max: Ref<number>, min
     }
 
     function maxCheck(v: InputValueType) {
-        if (typeof v === 'string' && v.length > max.value) {
+        const limit = Number(max.value);
+
+        if (isNaN(limit) || limit > Number.MAX_SAFE_INTEGER) {
+            return '';
+        }
+
+        if (typeof v === 'string' && v.length > limit) {
             return 'max length: ' + max.value;
         }
 
@@ -19,7 +25,13 @@ export function useVsTextareaRules(required: Ref<boolean>, max: Ref<number>, min
     }
 
     function minCheck(v: InputValueType) {
-        if (typeof v === 'string' && v.length < min.value) {
+        const limit = Number(min.value);
+
+        if (isNaN(limit) || limit < Number.MIN_SAFE_INTEGER) {
+            return '';
+        }
+
+        if (typeof v === 'string' && v.length < limit) {
             return 'min length: ' + min.value;
         }
 

--- a/packages/vlossom/src/components/vs-textarea/vs-textarea-rules.ts
+++ b/packages/vlossom/src/components/vs-textarea/vs-textarea-rules.ts
@@ -1,7 +1,7 @@
 import { Ref } from 'vue';
 import { InputValueType } from './types';
 
-export function useVsTextareaRules(required: Ref<boolean>, max: Ref<number | string>, min: Ref<number | string>) {
+export function useVsTextareaRules(required: Ref<boolean>, max: Ref<number>, min: Ref<number>) {
     function requiredCheck(v: InputValueType) {
         if (required.value && v === '') {
             return 'required';
@@ -11,13 +11,7 @@ export function useVsTextareaRules(required: Ref<boolean>, max: Ref<number | str
     }
 
     function maxCheck(v: InputValueType) {
-        const limit = Number(max.value);
-
-        if (isNaN(limit) || limit > Number.MAX_SAFE_INTEGER) {
-            return '';
-        }
-
-        if (typeof v === 'string' && v.length > limit) {
+        if (typeof v === 'string' && v.length > max.value) {
             return 'max length: ' + max.value;
         }
 
@@ -25,13 +19,7 @@ export function useVsTextareaRules(required: Ref<boolean>, max: Ref<number | str
     }
 
     function minCheck(v: InputValueType) {
-        const limit = Number(min.value);
-
-        if (isNaN(limit) || limit < Number.MIN_SAFE_INTEGER) {
-            return '';
-        }
-
-        if (typeof v === 'string' && v.length < limit) {
+        if (typeof v === 'string' && v.length < min.value) {
             return 'min length: ' + min.value;
         }
 

--- a/packages/vlossom/src/utils/props.ts
+++ b/packages/vlossom/src/utils/props.ts
@@ -8,4 +8,12 @@ export const propsUtil = {
         }
         return true;
     },
+    checkValidNumber(componentName: string, property: string, value: number | string) {
+        const num = Number(value);
+        const isValid = !isNaN(num) && num >= Number.MIN_SAFE_INTEGER && num <= Number.MAX_SAFE_INTEGER;
+        if (!isValid) {
+            logUtil.propError(componentName, property, `invalid ${property} value`);
+        }
+        return isValid;
+    },
 };


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Feature (feat)

## Summary

- vs-select, vs-checkbox-set에 max, min props를 추가합니다.
- vs-select: `multiple = true`일 때 최대/최소 아이템 수를 체크하는 maxCheck, minCheck rule을 추가합니다.
- vs-checkbox-set: 최대/최소 아이템 수를 체크하는 maxCheck, minCheck rule을 추가합니다.