### PR TITLE
ci: update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
                   package-name: vlossom
                   path: packages/vlossom
                   changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"chore","section":"Miscellaneous","hidden":false}]'
-
+                  prerelease: true
             - name: Checkout Repository
               uses: actions/checkout@v4
               if: ${{ steps.release.outputs['packages/vlossom--release_created'] }}


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] CI (ci)

## Summary

- release.yml에 `prerelease: true` config 추가 

## Description

-  release-please가 `alpha`, `beta` 와 같은 pre-release PR도 자동 생성할 수 있도록 `release.yml`에 `prerelease: true`를 추가합니다.

## Reference
- release-please docs : https://github.com/googleapis/release-please/blob/main/docs/customizing.md
- release-please versioning rule (Semantic Version) : https://semver.org/
