### PR TITLE
feat(anchor-positioning-composable): add attachment resizing observer

### DIFF
--- a/packages/vlossom/src/composables/anchor-positioning-composable.ts
+++ b/packages/vlossom/src/composables/anchor-positioning-composable.ts
@@ -102,6 +102,7 @@ export function usePositioning(anchor: Ref<HTMLElement>, attachment: Ref<HTMLEle
                 throttledComputePosition = utils.function.throttle(computePosition.bind(null, attachInfo), 30);
                 resizeObserver = new ResizeObserver(throttledComputePosition);
                 resizeObserver.observe(anchor.value);
+                resizeObserver.observe(attachment.value);
                 document.addEventListener('scroll', throttledComputePosition, true);
                 window.addEventListener('resize', throttledComputePosition, true);
             } catch (error: any) {

--- a/packages/vlossom/src/composables/anchor-positioning-composable.ts
+++ b/packages/vlossom/src/composables/anchor-positioning-composable.ts
@@ -100,9 +100,14 @@ export function usePositioning(anchor: Ref<HTMLElement>, attachment: Ref<HTMLEle
                 computePosition(attachInfo);
 
                 throttledComputePosition = utils.function.throttle(computePosition.bind(null, attachInfo), 30);
-                resizeObserver = new ResizeObserver(throttledComputePosition);
-                resizeObserver.observe(anchor.value);
-                resizeObserver.observe(attachment.value);
+
+                const hasResizeObserver = window && window.ResizeObserver !== undefined;
+                if (hasResizeObserver) {
+                    resizeObserver = new ResizeObserver(throttledComputePosition);
+                    resizeObserver.observe(anchor.value);
+                    resizeObserver.observe(attachment.value);
+                }
+
                 document.addEventListener('scroll', throttledComputePosition, true);
                 window.addEventListener('resize', throttledComputePosition, true);
             } catch (error: any) {


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Feature (feat)

## Summary

- `resizeObserver`가 attachment의 resizing도 감지할 수 있도록 등록합니다.
- SSR 환경 대응을 위해, `hasResizeObserver == true`일 때만 observer를 등록하도록 수정합니다.

## Description

- attachment의 크기가 변했을 때 position을 다시 계산해야 하므로 `resizeObserver`가 attachment resizing을 감시하여 `computePosition`을 실행하도록 합니다.
(e.g. `vs-select`의 options list가 위쪽으로 자리를 잡은 상태에서, autocomplete text를 입력하여 options의 길이가 줄어드는 경우 - 기존에는 attachment 사이즈 변경을 감지하지 않아서 attachment의 위치를 재조정하지 못했음)
- 관련 이슈 : [PUBG-208672](https://jira.krafton.com/browse/PUBG-208672)