### PR TITLE
feat(VsForm): add vs-form disabled, readonly

### DIFF
--- a/packages/vlossom/src/components/vs-checkbox-set/VsCheckboxSet.vue
+++ b/packages/vlossom/src/components/vs-checkbox-set/VsCheckboxSet.vue
@@ -2,7 +2,7 @@
     <vs-wrapper :width="width" :grid="grid" v-show="visible">
         <vs-input-wrapper
             :label="label"
-            :disabled="disabled"
+            :disabled="computedDisabled"
             :messages="computedMessages"
             :no-label="noLabel"
             :no-message="noMessage"
@@ -23,11 +23,11 @@
                     :color-scheme="computedColorScheme"
                     :style-set="checkboxStyleSet"
                     :checked="isChecked(option)"
-                    :disabled="disabled"
+                    :disabled="computedDisabled"
                     :id="`${id}-${optionIds[index]}`"
                     :label="getOptionLabel(option)"
                     :name="name"
-                    :readonly="readonly"
+                    :readonly="computedReadonly"
                     :required="required"
                     :state="computedState"
                     :value="getOptionValue(option)"
@@ -130,11 +130,6 @@ export default defineComponent({
             styleSet,
         );
 
-        const classObj = computed(() => ({
-            disabled: disabled.value,
-            readonly: readonly.value,
-        }));
-
         const inputValue = ref(modelValue.value);
 
         const { getOptionLabel, getOptionValue } = useInputOption(
@@ -151,12 +146,13 @@ export default defineComponent({
 
         const allRules = computed(() => [...rules.value, requiredCheck]);
 
-        const { computedMessages, computedState, shake, validate, clear, id } = useInput(
-            inputValue,
-            modelValue,
-            context,
-            label,
-            {
+        const { computedMessages, computedState, computedDisabled, computedReadonly, shake, validate, clear, id } =
+            useInput(context, {
+                inputValue,
+                modelValue,
+                label,
+                disabled,
+                readonly,
                 messages,
                 rules: allRules,
                 state,
@@ -175,8 +171,12 @@ export default defineComponent({
                         inputValue.value = [];
                     },
                 },
-            },
-        );
+            });
+
+        const classObj = computed(() => ({
+            disabled: computedDisabled.value,
+            readonly: computedReadonly.value,
+        }));
 
         function isChecked(option: any) {
             if (!inputValue.value) {
@@ -227,6 +227,8 @@ export default defineComponent({
             classObj,
             computedColorScheme,
             computedState,
+            computedDisabled,
+            computedReadonly,
             checkboxStyleSet,
             checkboxSetStyleSet,
             isChecked,

--- a/packages/vlossom/src/components/vs-checkbox/VsCheckbox.vue
+++ b/packages/vlossom/src/components/vs-checkbox/VsCheckbox.vue
@@ -3,7 +3,7 @@
         <vs-input-wrapper
             :id="checkLabel ? '' : id"
             :label="label"
-            :disabled="disabled"
+            :disabled="computedDisabled"
             :messages="computedMessages"
             :no-label="noLabel"
             :no-message="noMessage"
@@ -20,12 +20,12 @@
                 :style-set="computedStyleSet"
                 :aria-label="ariaLabel"
                 :checked="isChecked"
-                :disabled="disabled"
+                :disabled="computedDisabled"
                 :id="id"
                 :indeterminate="indeterminate"
                 :label="checkLabel"
                 :name="name"
-                :readonly="readonly"
+                :readonly="computedReadonly"
                 :required="required"
                 :state="computedState"
                 :value="trueValue"
@@ -93,6 +93,8 @@ export default defineComponent({
             checked,
             colorScheme,
             label,
+            disabled,
+            readonly,
             modelValue,
             messages,
             required,
@@ -126,12 +128,13 @@ export default defineComponent({
 
         const allRules = computed(() => [...rules.value, requiredCheck]);
 
-        const { computedMessages, computedState, shake, validate, clear, id } = useInput(
-            inputValue,
-            modelValue,
-            context,
-            label,
-            {
+        const { computedMessages, computedState, computedDisabled, computedReadonly, shake, validate, clear, id } =
+            useInput(context, {
+                inputValue,
+                modelValue,
+                label,
+                disabled,
+                readonly,
                 messages,
                 rules: allRules,
                 state,
@@ -152,8 +155,7 @@ export default defineComponent({
                         inputValue.value = getClearedValue();
                     },
                 },
-            },
-        );
+            });
 
         async function onToggle(c: boolean) {
             const toValue = getUpdatedValue(c);
@@ -191,6 +193,8 @@ export default defineComponent({
             isChecked,
             computedColorScheme,
             computedState,
+            computedDisabled,
+            computedReadonly,
             computedStyleSet,
             inputValue,
             computedMessages,

--- a/packages/vlossom/src/components/vs-drawer/__tests__/vs-drawer.test.ts
+++ b/packages/vlossom/src/components/vs-drawer/__tests__/vs-drawer.test.ts
@@ -13,10 +13,12 @@ describe('vs-drawer', () => {
                 props: {
                     modelValue: false,
                 },
+                attachTo: document.body,
             });
 
             // then
-            expect(wrapper.find('div.vs-dialog')?.isVisible()).toBe(false);
+            expect(wrapper.vm.isOpen).toBe(false);
+            expect(wrapper.find('.vs-drawer').isVisible()).toBe(false);
         });
 
         it('modelValue가 true이면 drawer가 열린다', async () => {
@@ -25,13 +27,15 @@ describe('vs-drawer', () => {
                 props: {
                     modelValue: false,
                 },
+                attachTo: document.body,
             });
 
             // when
             await wrapper.setProps({ modelValue: true });
 
             // then
-            expect(wrapper.find('div.vs-dialog')?.isVisible()).toBe(true);
+            expect(wrapper.vm.isOpen).toBe(true);
+            expect(wrapper.find('.vs-drawer').isVisible()).toBe(true);
         });
     });
 

--- a/packages/vlossom/src/components/vs-file-input/VsFileInput.vue
+++ b/packages/vlossom/src/components/vs-file-input/VsFileInput.vue
@@ -3,7 +3,7 @@
         <vs-input-wrapper
             :id="id"
             :label="label"
-            :disabled="disabled"
+            :disabled="computedDisabled"
             :messages="computedMessages"
             :no-label="noLabel"
             :no-message="noMessage"
@@ -37,8 +37,8 @@
                     :id="id"
                     type="file"
                     :name="name"
-                    :disabled="disabled"
-                    :readonly="readonly"
+                    :disabled="computedDisabled || computedReadonly"
+                    :readonly="computedReadonly"
                     :required="required"
                     :multiple="multiple"
                     :accept="accept"
@@ -48,7 +48,7 @@
                 />
 
                 <button
-                    v-if="!noClear && hasValue && !readonly && !disabled"
+                    v-if="!noClear && hasValue && !computedReadonly && !computedDisabled"
                     class="clear-button"
                     aria-hidden="true"
                     tabindex="-1"
@@ -118,13 +118,6 @@ export default defineComponent({
 
         const { computedStyleSet } = useStyleSet<VsFileInputStyleSet>(name, styleSet);
 
-        const classObj = computed(() => ({
-            dense: dense.value,
-            disabled: disabled.value,
-            dragging: dragging.value,
-            readonly: readonly.value,
-        }));
-
         const inputValue = ref(modelValue.value);
 
         const hasValue = computed(() => {
@@ -184,12 +177,13 @@ export default defineComponent({
             }
         }
 
-        const { computedMessages, computedState, shake, validate, clear, id } = useInput(
-            inputValue,
-            modelValue,
-            context,
-            label,
-            {
+        const { computedMessages, computedState, computedDisabled, computedReadonly, shake, validate, clear, id } =
+            useInput(context, {
+                inputValue,
+                modelValue,
+                label,
+                disabled,
+                readonly,
                 messages,
                 rules: allRules,
                 state,
@@ -198,8 +192,14 @@ export default defineComponent({
                     onChange: correctEmptyValue,
                     onClear,
                 },
-            },
-        );
+            });
+
+        const classObj = computed(() => ({
+            dense: dense.value,
+            disabled: computedDisabled.value,
+            readonly: computedReadonly.value,
+            dragging: dragging.value,
+        }));
 
         const { stateClasses } = useStateClass(computedState);
 
@@ -247,6 +247,8 @@ export default defineComponent({
             updateValue,
             hasValue,
             computedMessages,
+            computedDisabled,
+            computedReadonly,
             shake,
             onClear,
             clear,

--- a/packages/vlossom/src/components/vs-file-input/VsFileInput.vue
+++ b/packages/vlossom/src/components/vs-file-input/VsFileInput.vue
@@ -37,7 +37,7 @@
                     :id="id"
                     type="file"
                     :name="name"
-                    :disabled="computedDisabled || computedReadonly"
+                    :disabled="computedDisabled"
                     :readonly="computedReadonly"
                     :required="required"
                     :multiple="multiple"

--- a/packages/vlossom/src/components/vs-form/VsForm.vue
+++ b/packages/vlossom/src/components/vs-form/VsForm.vue
@@ -11,7 +11,7 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, nextTick, provide, watch } from 'vue';
+import { computed, defineComponent, nextTick, provide, toRefs, watch } from 'vue';
 import { VS_FORM, VsComponent, type VsFormProvide } from '@/declaration';
 import { getGridProps, useFormProvide } from '@/composables';
 import VsContainer from '@/components/vs-container/VsContainer.vue';
@@ -23,14 +23,26 @@ export default defineComponent({
     props: {
         ...getGridProps(name),
         autocomplete: { type: Boolean, default: false },
+        disabled: { type: Boolean, default: false },
+        readonly: { type: Boolean, default: false },
         // v-model
         changed: { type: Boolean, default: false },
         valid: { type: Boolean, default: true },
     },
     emits: ['update:changed', 'update:valid', 'error'],
     expose: ['validate', 'clear'],
-    setup(_, { emit }) {
-        const { labelObj, validObj, changedObj, validateFlag, clearFlag, getDefaultFormProvide } = useFormProvide();
+    setup(props, { emit }) {
+        const { disabled, readonly } = toRefs(props);
+        const {
+            labelObj,
+            validObj,
+            setDisabled,
+            setReadonly,
+            changedObj,
+            validateFlag,
+            clearFlag,
+            getDefaultFormProvide,
+        } = useFormProvide();
 
         provide<VsFormProvide>(VS_FORM, getDefaultFormProvide());
 
@@ -54,6 +66,10 @@ export default defineComponent({
         function clear() {
             clearFlag.value = !clearFlag.value;
         }
+
+        watch(disabled, setDisabled, { immediate: true });
+
+        watch(readonly, setReadonly, { immediate: true });
 
         watch(isValid, (valid) => {
             emit('update:valid', valid);

--- a/packages/vlossom/src/components/vs-form/__tests__/vs-form.test.ts
+++ b/packages/vlossom/src/components/vs-form/__tests__/vs-form.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, afterEach, describe, it, expect } from 'vitest';
-import { nextTick } from 'vue';
+import { defineComponent, inject, nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
+import { useFormProvide } from '@/composables';
+import { VS_FORM, VsFormProvide } from '@/declaration';
 import VsForm from './../VsForm.vue';
 
 function mountComponent() {
@@ -9,7 +11,23 @@ function mountComponent() {
 
 describe('vs-form', () => {
     let wrapper: ReturnType<typeof mountComponent>;
-
+    const SlotComponent = defineComponent({
+        template: `
+            <div>
+                disabled: {{ disabled }}
+                readonly: {{ readonly }}
+            </div>`,
+        setup() {
+            const { disabled, readonly } = inject<VsFormProvide>(
+                VS_FORM,
+                useFormProvide().getDefaultFormProvide(), // for no provide error
+            );
+            return {
+                disabled,
+                readonly,
+            };
+        },
+    });
     beforeEach(() => {
         wrapper = mount(VsForm, {
             props: {
@@ -17,6 +35,9 @@ describe('vs-form', () => {
                 'onUpdate:changed': (v: boolean) => wrapper.setProps({ changed: v }),
                 valid: false,
                 'onUpdate:valid': (v: boolean) => wrapper.setProps({ valid: v }),
+            },
+            slots: {
+                default: SlotComponent,
             },
         });
     });
@@ -71,6 +92,34 @@ describe('vs-form', () => {
             // then
             expect(valid).toBe(false);
             expect(wrapper.emitted('error')?.[0][0]).toEqual(['test']);
+        });
+    });
+
+    describe('disabled', () => {
+        it('disabled의 기본값은 false이다', () => {
+            expect(wrapper.html()).toContain('disabled: false');
+        });
+
+        it('disabled props가 설정되면 disabled 값을 provide 객체로 자식 Component(SlotComponent)에 전달한다', async () => {
+            // when
+            await wrapper.setProps({ disabled: true });
+
+            // then
+            expect(wrapper.html()).toContain('disabled: true');
+        });
+    });
+
+    describe('readonly', () => {
+        it('readonly의 기본값은 false이다', () => {
+            expect(wrapper.html()).toContain('readonly: false');
+        });
+
+        it('readonly props가 설정되면 readonly 값을 provide 객체로 자식 Component(SlotComponent)에 전달한다', async () => {
+            // when
+            await wrapper.setProps({ readonly: true });
+
+            // then
+            expect(wrapper.html()).toContain('readonly: true');
         });
     });
 

--- a/packages/vlossom/src/components/vs-input/VsInput.vue
+++ b/packages/vlossom/src/components/vs-input/VsInput.vue
@@ -3,7 +3,7 @@
         <vs-input-wrapper
             :id="id"
             :label="label"
-            :disabled="disabled"
+            :disabled="computedDisabled"
             :messages="computedMessages"
             :no-label="noLabel"
             :no-message="noMessage"
@@ -29,8 +29,8 @@
                     :value="inputValue"
                     :autocomplete="autocomplete ? 'on' : 'off'"
                     :name="name"
-                    :disabled="disabled"
-                    :readonly="readonly"
+                    :disabled="computedDisabled"
+                    :readonly="computedReadonly"
                     :aria-required="required"
                     :placeholder="placeholder"
                     @input.stop="updateValue($event)"
@@ -41,7 +41,7 @@
                 />
 
                 <button
-                    v-if="!noClear && !readonly && !disabled"
+                    v-if="!noClear && !computedReadonly && !computedDisabled"
                     type="button"
                     class="clear-button"
                     :class="{ show: inputValue }"
@@ -131,6 +131,7 @@ export default defineComponent({
             modelValue,
             label,
             messages,
+            readonly,
             required,
             rules,
             max,
@@ -150,11 +151,6 @@ export default defineComponent({
         const { modifyStringValue } = useStringModifier(modelModifiers);
 
         const { requiredCheck, maxCheck, minCheck } = useVsInputRules(required, max, min, type);
-
-        const classObj = computed(() => ({
-            dense: dense.value,
-            disabled: disabled.value,
-        }));
 
         const isNumberInput = computed(() => type.value === InputType.Number);
 
@@ -176,12 +172,13 @@ export default defineComponent({
             inputValue.value = null;
         }
 
-        const { computedMessages, computedState, shake, validate, clear, id } = useInput(
-            inputValue,
-            modelValue,
-            context,
-            label,
-            {
+        const { computedMessages, computedState, computedDisabled, computedReadonly, shake, validate, clear, id } =
+            useInput(context, {
+                inputValue,
+                modelValue,
+                label,
+                disabled,
+                readonly,
                 messages,
                 rules: allRules,
                 state,
@@ -194,8 +191,13 @@ export default defineComponent({
                     },
                     onClear,
                 },
-            },
-        );
+            });
+
+        const classObj = computed(() => ({
+            dense: dense.value,
+            disabled: computedDisabled.value,
+            readonly: computedReadonly.value,
+        }));
 
         const { stateClasses } = useStateClass(computedState);
 
@@ -245,6 +247,8 @@ export default defineComponent({
             updateValue,
             inputRef,
             computedMessages,
+            computedDisabled,
+            computedReadonly,
             shake,
             focus,
             blur,

--- a/packages/vlossom/src/components/vs-radio-set/VsRadioSet.vue
+++ b/packages/vlossom/src/components/vs-radio-set/VsRadioSet.vue
@@ -2,7 +2,7 @@
     <vs-wrapper :width="width" :grid="grid" v-show="visible">
         <vs-input-wrapper
             :label="label"
-            :disabled="disabled"
+            :disabled="computedDisabled"
             :messages="computedMessages"
             :no-label="noLabel"
             :no-message="noMessage"
@@ -23,11 +23,11 @@
                     :color-scheme="computedColorScheme"
                     :style-set="radioStyleSet"
                     :checked="isChecked(option)"
-                    :disabled="disabled"
+                    :disabled="computedDisabled"
                     :id="`${id}-${optionIds[index]}`"
                     :label="getOptionLabel(option)"
                     :name="name"
-                    :readonly="readonly"
+                    :readonly="computedReadonly"
                     :required="required"
                     :state="computedState"
                     :value="getOptionValue(option)"
@@ -119,11 +119,6 @@ export default defineComponent({
             styleSet,
         );
 
-        const classObj = computed(() => ({
-            disabled: disabled.value,
-            readonly: readonly.value,
-        }));
-
         const inputValue = ref(modelValue.value);
 
         const { getOptionLabel, getOptionValue } = useInputOption(inputValue, options, optionLabel, optionValue);
@@ -144,12 +139,13 @@ export default defineComponent({
 
         const allRules = computed(() => [...rules.value, requiredCheck]);
 
-        const { computedMessages, computedState, shake, validate, clear, id } = useInput(
-            inputValue,
-            modelValue,
-            context,
-            label,
-            {
+        const { computedMessages, computedState, computedDisabled, computedReadonly, shake, validate, clear, id } =
+            useInput(context, {
+                inputValue,
+                modelValue,
+                label,
+                disabled,
+                readonly,
                 messages,
                 rules: allRules,
                 state,
@@ -158,8 +154,12 @@ export default defineComponent({
                         inputValue.value = null;
                     },
                 },
-            },
-        );
+            });
+
+        const classObj = computed(() => ({
+            disabled: computedDisabled.value,
+            readonly: computedReadonly.value,
+        }));
 
         async function onToggle(option: any) {
             // radio change event value is always true
@@ -191,6 +191,8 @@ export default defineComponent({
             classObj,
             computedColorScheme,
             computedState,
+            computedDisabled,
+            computedReadonly,
             radioStyleSet,
             radioSetStyleSet,
             isChecked,

--- a/packages/vlossom/src/components/vs-radio/VsRadio.vue
+++ b/packages/vlossom/src/components/vs-radio/VsRadio.vue
@@ -3,7 +3,7 @@
         <vs-input-wrapper
             :id="radioLabel ? '' : id"
             :label="label"
-            :disabled="disabled"
+            :disabled="computedDisabled"
             :messages="computedMessages"
             :no-label="noLabel"
             :no-message="noMessage"
@@ -20,11 +20,11 @@
                 :style-set="computedStyleSet"
                 :aria-label="ariaLabel"
                 :checked="isChecked"
-                :disabled="disabled"
+                :disabled="computedDisabled"
                 :id="id"
                 :label="radioLabel"
                 :name="name"
-                :readonly="readonly"
+                :readonly="computedReadonly"
                 :required="required"
                 :state="computedState"
                 :value="radioValue"
@@ -78,6 +78,8 @@ export default defineComponent({
             checked,
             colorScheme,
             label,
+            disabled,
+            readonly,
             messages,
             modelValue,
             name,
@@ -114,12 +116,13 @@ export default defineComponent({
 
         const allRules = computed(() => [...rules.value, requiredCheck]);
 
-        const { computedMessages, computedState, shake, validate, clear, id } = useInput(
-            inputValue,
-            modelValue,
-            context,
-            label,
-            {
+        const { computedMessages, computedState, computedDisabled, computedReadonly, shake, validate, clear, id } =
+            useInput(context, {
+                inputValue,
+                modelValue,
+                label,
+                disabled,
+                readonly,
                 messages,
                 rules: allRules,
                 state,
@@ -133,8 +136,7 @@ export default defineComponent({
                         inputValue.value = null;
                     },
                 },
-            },
-        );
+            });
 
         async function onToggle() {
             // radio change event value is always true
@@ -164,6 +166,8 @@ export default defineComponent({
             computedColorScheme,
             computedState,
             computedStyleSet,
+            computedDisabled,
+            computedReadonly,
             inputValue,
             computedMessages,
             shake,

--- a/packages/vlossom/src/components/vs-select/VsSelect.vue
+++ b/packages/vlossom/src/components/vs-select/VsSelect.vue
@@ -3,7 +3,7 @@
         <vs-input-wrapper
             :id="id"
             :label="label"
-            :disabled="disabled"
+            :disabled="computedDisabled"
             :messages="computedMessages"
             :no-label="noLabel"
             :no-message="noMessage"
@@ -33,9 +33,9 @@
                         aria-controls="vs-select-options"
                         :aria-autocomplete="autocomplete ? 'list' : undefined"
                         :aria-activedescendant="focusedOptionId"
-                        :disabled="disabled"
+                        :disabled="computedDisabled"
                         :placeholder="placeholder"
-                        :readonly="readonly || !autocomplete"
+                        :readonly="computedReadonly || !autocomplete"
                         :aria-required="required"
                         :value="inputLabel"
                         @input.stop="onInput"
@@ -87,7 +87,7 @@
                 </div>
                 <div class="vs-select-side">
                     <button
-                        v-if="!noClear && selectedOptions.length && !readonly && !disabled"
+                        v-if="!noClear && selectedOptions.length && !computedReadonly && !computedDisabled"
                         type="button"
                         class="clear-button"
                         aria-hidden="true"
@@ -312,12 +312,6 @@ export default defineComponent({
 
         const { emit } = context;
 
-        const classObj = computed(() => ({
-            dense: dense.value,
-            disabled: disabled.value,
-            readonly: readonly.value,
-        }));
-
         const { computedColorScheme } = useColorScheme(name, colorScheme);
 
         const { computedStyleSet } = useStyleSet<VsSelectStyleSet>(name, styleSet);
@@ -386,12 +380,13 @@ export default defineComponent({
             closeOptions();
         }
 
-        const { computedMessages, computedState, shake, validate, clear, id } = useInput(
-            inputValue,
-            modelValue,
-            context,
-            label,
-            {
+        const { computedMessages, computedState, computedDisabled, computedReadonly, shake, validate, clear, id } =
+            useInput(context, {
+                inputValue,
+                modelValue,
+                label,
+                disabled,
+                readonly,
                 messages,
                 rules: allRules,
                 state,
@@ -408,8 +403,13 @@ export default defineComponent({
                     },
                     onClear,
                 },
-            },
-        );
+            });
+
+        const classObj = computed(() => ({
+            dense: dense.value,
+            disabled: computedDisabled.value,
+            readonly: computedReadonly.value,
+        }));
 
         const { stateClasses } = useStateClass(computedState);
 
@@ -434,7 +434,7 @@ export default defineComponent({
         });
 
         const { isOpen, isClosing, toggleOptions, closeOptions, triggerRef, optionsRef, isVisible, computedPlacement } =
-            useToggleOptions(id, disabled, readonly);
+            useToggleOptions(id, computedDisabled, computedReadonly);
 
         const { autocompleteText, filteredOptions, updateAutocompleteText } = useAutocomplete(
             autocomplete,
@@ -468,8 +468,8 @@ export default defineComponent({
             onMouseMove,
             isChasedOption,
         } = useFocusControl(
-            disabled,
-            readonly,
+            computedDisabled,
+            computedReadonly,
             isOpen,
             closeOptions,
             selectAll,
@@ -528,6 +528,8 @@ export default defineComponent({
             classObj,
             computedColorScheme,
             computedStyleSet,
+            computedDisabled,
+            computedReadonly,
             chipStyleSets,
             collapseChipStyleSets,
             animationClass,

--- a/packages/vlossom/src/components/vs-switch/VsSwitch.vue
+++ b/packages/vlossom/src/components/vs-switch/VsSwitch.vue
@@ -3,7 +3,7 @@
         <vs-input-wrapper
             :id="id"
             :label="label"
-            :disabled="disabled"
+            :disabled="computedDisabled"
             :messages="computedMessages"
             :no-label="noLabel"
             :no-message="noMessage"
@@ -15,7 +15,11 @@
             </template>
 
             <div
-                :class="['vs-switch', `vs-${computedColorScheme}`, { checked: isChecked, disabled, readonly }]"
+                :class="[
+                    'vs-switch',
+                    `vs-${computedColorScheme}`,
+                    { checked: isChecked, disabled: computedDisabled, readonly: computedReadonly },
+                ]"
                 :style="computedStyleSet"
             >
                 <input
@@ -24,7 +28,7 @@
                     class="vs-switch-input"
                     :id="id"
                     :name="name"
-                    :disabled="disabled || readonly"
+                    :disabled="computedDisabled || computedReadonly"
                     :checked="isChecked"
                     :value="convertToString(trueValue)"
                     :aria-label="ariaLabel || 'switch ' + label"
@@ -133,12 +137,13 @@ export default defineComponent({
 
         const allRules = computed(() => [...rules.value, requiredCheck]);
 
-        const { computedMessages, computedState, shake, validate, clear, id } = useInput(
-            inputValue,
-            modelValue,
-            context,
-            label,
-            {
+        const { computedMessages, computedState, computedDisabled, computedReadonly, shake, validate, clear, id } =
+            useInput(context, {
+                inputValue,
+                modelValue,
+                label,
+                disabled,
+                readonly,
                 messages,
                 rules: allRules,
                 state,
@@ -159,13 +164,12 @@ export default defineComponent({
                         inputValue.value = getClearedValue();
                     },
                 },
-            },
-        );
+            });
 
         const { stateClasses } = useStateClass(computedState);
 
         async function onClick() {
-            if (disabled.value || readonly.value) {
+            if (computedDisabled.value || computedReadonly.value) {
                 return;
             }
 
@@ -203,6 +207,8 @@ export default defineComponent({
             inputValue,
             computedColorScheme,
             computedStyleSet,
+            computedDisabled,
+            computedReadonly,
             isChecked,
             onClick,
             onFocus,

--- a/packages/vlossom/src/components/vs-textarea/VsTextarea.vue
+++ b/packages/vlossom/src/components/vs-textarea/VsTextarea.vue
@@ -3,7 +3,7 @@
         <vs-input-wrapper
             :id="id"
             :label="label"
-            :disabled="disabled"
+            :disabled="computedDisabled"
             :messages="computedMessages"
             :no-label="noLabel"
             :no-message="noMessage"
@@ -21,8 +21,8 @@
                 :id="id"
                 :value="inputValue"
                 :name="name"
-                :disabled="disabled"
-                :readonly="readonly"
+                :disabled="computedDisabled"
+                :readonly="computedReadonly"
                 :aria-required="required"
                 :autocomplete="autocomplete ? 'on' : 'off'"
                 :placeholder="placeholder"
@@ -87,6 +87,7 @@ export default defineComponent({
             modelValue,
             label,
             messages,
+            readonly,
             required,
             rules,
             max,
@@ -107,10 +108,6 @@ export default defineComponent({
 
         const { requiredCheck, maxCheck, minCheck } = useVsTextareaRules(required, max, min);
 
-        const classObj = computed(() => ({
-            disabled: disabled.value,
-        }));
-
         const allRules = computed(() => [...rules.value, requiredCheck, maxCheck, minCheck]);
 
         function convertValue(v: string): string {
@@ -125,12 +122,13 @@ export default defineComponent({
             inputValue.value = '';
         }
 
-        const { computedMessages, computedState, shake, validate, clear, id } = useInput(
-            inputValue,
-            modelValue,
-            context,
-            label,
-            {
+        const { computedMessages, computedState, computedDisabled, computedReadonly, shake, validate, clear, id } =
+            useInput(context, {
+                inputValue,
+                modelValue,
+                label,
+                disabled,
+                readonly,
                 messages,
                 rules: allRules,
                 state,
@@ -143,8 +141,12 @@ export default defineComponent({
                     },
                     onClear,
                 },
-            },
-        );
+            });
+
+        const classObj = computed(() => ({
+            disabled: computedDisabled.value,
+            readonly: computedReadonly.value,
+        }));
 
         const { stateClasses } = useStateClass(computedState);
 
@@ -184,6 +186,8 @@ export default defineComponent({
             classObj,
             computedColorScheme,
             computedStyleSet,
+            computedReadonly,
+            computedDisabled,
             inputValue,
             updateValue,
             textareaRef,

--- a/packages/vlossom/src/composables/__tests__/form-provide-composable.test.ts
+++ b/packages/vlossom/src/composables/__tests__/form-provide-composable.test.ts
@@ -2,6 +2,28 @@ import { describe, expect, it } from 'vitest';
 import { useFormProvide } from '@/composables';
 
 describe('form-provide-composable', () => {
+    it('disabled 값을 업데이트 할 수 있다', () => {
+        // given
+        const { disabled, setDisabled } = useFormProvide();
+
+        // when
+        setDisabled(true);
+
+        // then
+        expect(disabled.value).toBe(true);
+    });
+
+    it('readonly 값을 업데이트 할 수 있다', () => {
+        // given
+        const { readonly, setReadonly } = useFormProvide();
+
+        // when
+        setReadonly(true);
+
+        // then
+        expect(readonly.value).toBe(true);
+    });
+
     it('labelObj에 label 값이 업데이트 된다', () => {
         // given
         const { labelObj, updateLabel } = useFormProvide();

--- a/packages/vlossom/src/composables/__tests__/input-composable.test.ts
+++ b/packages/vlossom/src/composables/__tests__/input-composable.test.ts
@@ -41,10 +41,15 @@ describe('useInput composable', () => {
             ...getInputProps<string, []>(),
         },
         setup(props, ctx) {
-            const { modelValue, label, messages, rules, state } = toRefs(props);
+            const { modelValue, label, messages, rules, state, disabled, readonly } = toRefs(props);
 
             return {
-                ...useInput(inputValue, modelValue, ctx, label, {
+                ...useInput(ctx, {
+                    inputValue,
+                    modelValue,
+                    label,
+                    disabled,
+                    readonly,
                     callbacks: {
                         onMounted: onMountedSpy,
                         onChange: onChangeSpy,

--- a/packages/vlossom/src/composables/__tests__/input-form-composable.test.ts
+++ b/packages/vlossom/src/composables/__tests__/input-form-composable.test.ts
@@ -12,7 +12,7 @@ describe('form-composable', () => {
     const validateSpy = vi.fn(() => true);
     const clearSpy = vi.fn();
 
-    const InputComponent = defineComponent({
+    const TestInputComponent = defineComponent({
         render: () => null,
         setup() {
             const { id } = useInputForm(label, valid, changed, validateSpy, clearSpy);
@@ -21,7 +21,7 @@ describe('form-composable', () => {
     });
 
     function createWrapper(provide: any = {}) {
-        return mount(InputComponent, {
+        return mount(TestInputComponent, {
             global: {
                 provide,
             },

--- a/packages/vlossom/src/composables/form-provide-composable.ts
+++ b/packages/vlossom/src/composables/form-provide-composable.ts
@@ -3,11 +3,21 @@ import { Ref, ref } from 'vue';
 import type { VsFormProvide } from '@/declaration';
 
 export function useFormProvide() {
+    const disabled = ref(false);
+    const readonly = ref(false);
     const labelObj: Ref<Record<string, string>> = ref({});
     const changedObj: Ref<Record<string, boolean>> = ref({});
     const validObj: Ref<Record<string, boolean>> = ref({});
     const validateFlag = ref(false);
     const clearFlag = ref(false);
+
+    function setDisabled(value: boolean) {
+        disabled.value = value;
+    }
+
+    function setReadonly(value: boolean) {
+        readonly.value = value;
+    }
 
     function updateLabel(id: string, label: string) {
         labelObj.value[id] = label;
@@ -29,6 +39,8 @@ export function useFormProvide() {
 
     function getDefaultFormProvide(): VsFormProvide {
         return {
+            disabled,
+            readonly,
             labelObj,
             changedObj,
             validObj,
@@ -42,11 +54,15 @@ export function useFormProvide() {
     }
 
     return {
+        disabled,
+        readonly,
         labelObj,
         changedObj,
         validObj,
         validateFlag,
         clearFlag,
+        setDisabled,
+        setReadonly,
         updateLabel,
         updateChanged,
         updateValid,

--- a/packages/vlossom/src/composables/input-form-composable.ts
+++ b/packages/vlossom/src/composables/input-form-composable.ts
@@ -12,10 +12,11 @@ export function useInputForm(
 ) {
     const id = utils.string.createID();
 
-    const { validateFlag, clearFlag, updateLabel, updateChanged, updateValid, removeFromForm } = inject<VsFormProvide>(
-        VS_FORM,
-        useFormProvide().getDefaultFormProvide(), // for no provide error
-    );
+    const { disabled, readonly, validateFlag, clearFlag, updateLabel, updateChanged, updateValid, removeFromForm } =
+        inject<VsFormProvide>(
+            VS_FORM,
+            useFormProvide().getDefaultFormProvide(), // for no provide error
+        );
 
     watch(label, () => {
         updateLabel(id, label.value);
@@ -45,5 +46,7 @@ export function useInputForm(
 
     return {
         id,
+        formDisabled: disabled,
+        formReadonly: readonly,
     };
 }

--- a/packages/vlossom/src/declaration/types.ts
+++ b/packages/vlossom/src/declaration/types.ts
@@ -103,7 +103,12 @@ export interface StateMessage {
 export type Rule<T = any> = ((v: T) => string) | ((v: T) => PromiseLike<string>);
 export type Message<T = any> = StateMessage | ((v: T) => StateMessage) | ((v: T) => PromiseLike<StateMessage>);
 
-export interface InputComponentOptions<T = unknown> {
+export interface InputComponentParams<T = unknown> {
+    inputValue: Ref<T>;
+    modelValue: Ref<T>;
+    label: Ref<string>;
+    disabled?: Ref<boolean>;
+    readonly?: Ref<boolean>;
     messages?: Ref<Message<T>[]>;
     rules?: Ref<Rule<T>[]>;
     state?: Ref<UIState>;
@@ -121,6 +126,8 @@ export interface StringModifiers {
 }
 
 export interface VsFormProvide {
+    disabled: Ref<boolean>;
+    readonly: Ref<boolean>;
     labelObj: Ref<Record<string, string>>;
     changedObj: Ref<Record<string, boolean>>;
     validObj: Ref<Record<string, boolean>>;


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Feature (feat)

## Summary
vs-form에서 하위 component로 disabled, readonly가 전달되고, 전달된 내용을 적용하도록 합니다

## description
- input-composable의 useInput 파라미터를 Object로 변경해서 유연하게 변경합니다
- vs-form의 disabled, readonly 상태를 provide하도록 구현합니다.

<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
