### PR TITLE
feat(input-component): no default label area & remove noLabel

### DIFF
--- a/packages/vlossom/.storybook-chromatic/preview.ts
+++ b/packages/vlossom/.storybook-chromatic/preview.ts
@@ -57,6 +57,16 @@ const preview: Preview = {
                 desktop: { name: 'Desktop', styles: { width: '1440px', height: '1000px' } },
             },
         },
+        a11y: {
+            config: {
+                rules: [
+                    {
+                        id: 'label',
+                        enabled: false,
+                    },
+                ],
+            },
+        },
     },
     decorators,
 };

--- a/packages/vlossom/.storybook/preview.ts
+++ b/packages/vlossom/.storybook/preview.ts
@@ -64,8 +64,8 @@ const preview: Preview = {
             config: {
                 rules: [
                     {
-                        id: 'color-contrast',
-                        reviewOnFail: true,
+                        id: 'label',
+                        enabled: false,
                     },
                 ],
             },

--- a/packages/vlossom/.storybook/test-runner.ts
+++ b/packages/vlossom/.storybook/test-runner.ts
@@ -4,10 +4,10 @@ import { injectAxe, checkA11y } from 'axe-playwright';
 import type { TestRunnerConfig } from '@storybook/test-runner';
 
 const config: TestRunnerConfig = {
-    async preRender(page) {
+    async preVisit(page) {
         await injectAxe(page);
     },
-    async postRender(page, context) {
+    async postVisit(page, context) {
         const storyContext = await getStoryContext(page, context);
 
         if (!storyContext.parameters?.a11y?.disable) {
@@ -19,6 +19,7 @@ const config: TestRunnerConfig = {
                 axeOptions: {
                     rules: {
                         'color-contrast': { enabled: false },
+                        label: { enabled: false },
                     },
                 },
             });

--- a/packages/vlossom/src/components/vs-checkbox-set/VsCheckboxSet.vue
+++ b/packages/vlossom/src/components/vs-checkbox-set/VsCheckboxSet.vue
@@ -79,7 +79,7 @@ export default defineComponent({
     name,
     components: { VsInputWrapper, VsWrapper, VsCheckboxNode },
     props: {
-        ...getInputProps<any[], ['placeholder', 'noClear']>('placeholder', 'noClear'),
+        ...getInputProps<any[], ['ariaLabel', 'noClear', 'placeholder']>('ariaLabel', 'noClear', 'placeholder'),
         ...getInputOptionProps(),
         ...getResponsiveProps(),
         colorScheme: { type: String as PropType<ColorScheme> },

--- a/packages/vlossom/src/components/vs-checkbox-set/VsCheckboxSet.vue
+++ b/packages/vlossom/src/components/vs-checkbox-set/VsCheckboxSet.vue
@@ -4,13 +4,12 @@
             :label="label"
             :disabled="computedDisabled"
             :messages="computedMessages"
-            :no-label="noLabel"
             :no-message="noMessage"
             :required="required"
             :shake="shake"
             group-label
         >
-            <template #label v-if="!noLabel">
+            <template #label v-if="label || $slots['label']">
                 <slot name="label" />
             </template>
 

--- a/packages/vlossom/src/components/vs-checkbox/VsCheckbox.vue
+++ b/packages/vlossom/src/components/vs-checkbox/VsCheckbox.vue
@@ -70,7 +70,6 @@ export default defineComponent({
         ...getResponsiveProps(),
         colorScheme: { type: String as PropType<ColorScheme> },
         styleSet: { type: [String, Object] as PropType<string | VsCheckboxStyleSet> },
-        ariaLabel: { type: String, default: '' },
         beforeChange: {
             type: Function as PropType<(from: any, to: any) => Promise<boolean> | null>,
             default: null,

--- a/packages/vlossom/src/components/vs-checkbox/VsCheckbox.vue
+++ b/packages/vlossom/src/components/vs-checkbox/VsCheckbox.vue
@@ -5,12 +5,11 @@
             :label="label"
             :disabled="computedDisabled"
             :messages="computedMessages"
-            :no-label="noLabel"
             :no-message="noMessage"
             :required="required"
             :shake="shake"
         >
-            <template #label v-if="!noLabel">
+            <template #label v-if="label || $slots['label']">
                 <slot name="label" />
             </template>
 

--- a/packages/vlossom/src/components/vs-file-input/VsFileInput.vue
+++ b/packages/vlossom/src/components/vs-file-input/VsFileInput.vue
@@ -41,6 +41,7 @@
                     :required="required"
                     :multiple="multiple"
                     :accept="accept"
+                    :aria-label="ariaLabel"
                     @change.stop="updateValue($event)"
                     @focus.stop="onFocus"
                     @blur.stop="onBlur"

--- a/packages/vlossom/src/components/vs-file-input/VsFileInput.vue
+++ b/packages/vlossom/src/components/vs-file-input/VsFileInput.vue
@@ -5,12 +5,11 @@
             :label="label"
             :disabled="computedDisabled"
             :messages="computedMessages"
-            :no-label="noLabel"
             :no-message="noMessage"
             :required="required"
             :shake="shake"
         >
-            <template #label v-if="!noLabel">
+            <template #label v-if="label || $slots['label']">
                 <slot name="label" />
             </template>
 

--- a/packages/vlossom/src/components/vs-input-wrapper/VsInputWrapper.vue
+++ b/packages/vlossom/src/components/vs-input-wrapper/VsInputWrapper.vue
@@ -2,8 +2,8 @@
     <div class="vs-input-wrapper" :class="{ 'shake-horizontal': needToShake }">
         <component :is="groupLabel ? 'fieldset' : 'div'">
             <component
+                v-if="label || $slots['label']"
                 :is="groupLabel ? 'legend' : 'label'"
-                v-if="!noLabel"
                 :for="groupLabel ? undefined : id || undefined"
                 class="vs-label"
             >
@@ -16,7 +16,7 @@
             <slot />
         </component>
 
-        <div class="vs-messages" v-if="!noMessage">
+        <div class="vs-messages" v-if="!noMessage && messages.length">
             <slot name="messages">
                 <vs-message
                     class="message-item"
@@ -43,7 +43,6 @@ export default defineComponent({
         id: { type: String, default: '' },
         label: { type: String, default: '' },
         messages: { type: Array as PropType<StateMessage[]>, default: () => [] },
-        noLabel: { type: Boolean, default: false },
         noMessage: { type: Boolean, default: false },
         required: { type: Boolean, default: false },
         shake: { type: Boolean, default: false },

--- a/packages/vlossom/src/components/vs-input-wrapper/VsInputWrapper.vue
+++ b/packages/vlossom/src/components/vs-input-wrapper/VsInputWrapper.vue
@@ -16,7 +16,7 @@
             <slot />
         </component>
 
-        <div class="vs-messages" v-if="!noMessage && messages.length">
+        <div class="vs-messages" v-if="!noMessage">
             <slot name="messages">
                 <vs-message
                     class="message-item"

--- a/packages/vlossom/src/components/vs-input-wrapper/__tests__/vs-input-wrapper.test.ts
+++ b/packages/vlossom/src/components/vs-input-wrapper/__tests__/vs-input-wrapper.test.ts
@@ -88,12 +88,12 @@ describe('vs-input-wrapper', () => {
             expect(wrapper.find('.vs-messages').exists()).toBe(false);
         });
 
-        it('message가 없다면 message 영역이 없다', () => {
+        it('message가 없어도 message 영역은 있다', () => {
             // given
             const wrapper = mount(VsInputWrapper);
 
             // then
-            expect(wrapper.find('.vs-messages').exists()).toBe(false);
+            expect(wrapper.find('.vs-messages').exists()).toBe(true);
         });
 
         it('message가 있다면 message 영역이 있다', () => {

--- a/packages/vlossom/src/components/vs-input-wrapper/__tests__/vs-input-wrapper.test.ts
+++ b/packages/vlossom/src/components/vs-input-wrapper/__tests__/vs-input-wrapper.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
 import { nextTick } from 'vue';
 import VsInputWrapper from './../VsInputWrapper.vue';
+import { UIState } from '@/declaration';
 
 describe('vs-input-wrapper', () => {
     describe('label', () => {
@@ -20,26 +21,26 @@ describe('vs-input-wrapper', () => {
             expect(label.text()).toBe('My Label');
         });
 
-        it('label을 설정하지 않아도 label 영역이 있다', () => {
+        it('label을 설정하지 않으면 label 영역이 없다', () => {
             // given
             const wrapper = mount(VsInputWrapper);
 
             // then
             const label = wrapper.find('label');
-            expect(label.exists()).toBe(true);
-            expect(label.text()).toBe('');
+            expect(label.exists()).toBe(false);
         });
 
-        it('noLabel props를 설정하면 label 영역이 없다', () => {
+        it('label slot을 넣으면 label 영역이 있다', () => {
             // given
             const wrapper = mount(VsInputWrapper, {
-                props: {
-                    noLabel: true,
+                slots: {
+                    label: 'My Label',
                 },
             });
 
             // then
-            expect(wrapper.find('label').exists()).toBe(false);
+            expect(wrapper.find('label').exists()).toBe(true);
+            expect(wrapper.find('label').text()).toBe('My Label');
         });
 
         it('required props를 설정하면 label 영역에 *이 표시된다', () => {
@@ -75,7 +76,7 @@ describe('vs-input-wrapper', () => {
     });
 
     describe('messages', () => {
-        it('noMessage props가 전달되면 message 영역이 보이지 않는다', () => {
+        it('noMessage props가 전달되면 message 영역이 없다', () => {
             // given
             const wrapper = mount(VsInputWrapper, {
                 props: {
@@ -85,6 +86,26 @@ describe('vs-input-wrapper', () => {
 
             // then
             expect(wrapper.find('.vs-messages').exists()).toBe(false);
+        });
+
+        it('message가 없다면 message 영역이 없다', () => {
+            // given
+            const wrapper = mount(VsInputWrapper);
+
+            // then
+            expect(wrapper.find('.vs-messages').exists()).toBe(false);
+        });
+
+        it('message가 있다면 message 영역이 있다', () => {
+            // given
+            const wrapper = mount(VsInputWrapper, {
+                props: {
+                    messages: [{ state: UIState.Info, text: 'Info Message' }],
+                },
+            });
+
+            // then
+            expect(wrapper.find('.vs-messages').exists()).toBe(true);
         });
     });
 

--- a/packages/vlossom/src/components/vs-input/VsInput.vue
+++ b/packages/vlossom/src/components/vs-input/VsInput.vue
@@ -30,6 +30,7 @@
                     :name="name"
                     :disabled="computedDisabled"
                     :readonly="computedReadonly"
+                    :aria-label="ariaLabel"
                     :aria-required="required"
                     :placeholder="placeholder"
                     @input.stop="updateValue($event)"

--- a/packages/vlossom/src/components/vs-input/VsInput.vue
+++ b/packages/vlossom/src/components/vs-input/VsInput.vue
@@ -5,12 +5,11 @@
             :label="label"
             :disabled="computedDisabled"
             :messages="computedMessages"
-            :no-label="noLabel"
             :no-message="noMessage"
             :required="required"
             :shake="shake"
         >
-            <template #label v-if="!noLabel">
+            <template #label v-if="label || $slots['label']">
                 <slot name="label" />
             </template>
 

--- a/packages/vlossom/src/components/vs-radio-set/VsRadioSet.vue
+++ b/packages/vlossom/src/components/vs-radio-set/VsRadioSet.vue
@@ -4,13 +4,12 @@
             :label="label"
             :disabled="computedDisabled"
             :messages="computedMessages"
-            :no-label="noLabel"
             :no-message="noMessage"
             :required="required"
             :shake="shake"
             group-label
         >
-            <template #label v-if="!noLabel">
+            <template #label v-if="label || $slots['label']">
                 <slot name="label" />
             </template>
 

--- a/packages/vlossom/src/components/vs-radio-set/VsRadioSet.vue
+++ b/packages/vlossom/src/components/vs-radio-set/VsRadioSet.vue
@@ -76,7 +76,7 @@ export default defineComponent({
     name: VsComponent.VsRadioSet,
     components: { VsInputWrapper, VsWrapper, VsRadioNode },
     props: {
-        ...getInputProps<any[], ['placeholder', 'noClear']>('placeholder', 'noClear'),
+        ...getInputProps<any[], ['ariaLabel', 'noClear', 'placeholder']>('ariaLabel', 'noClear', 'placeholder'),
         ...getInputOptionProps(),
         ...getResponsiveProps(),
         colorScheme: { type: String as PropType<ColorScheme> },

--- a/packages/vlossom/src/components/vs-radio/VsRadio.vue
+++ b/packages/vlossom/src/components/vs-radio/VsRadio.vue
@@ -62,7 +62,6 @@ export default defineComponent({
         ...getResponsiveProps(),
         colorScheme: { type: String as PropType<ColorScheme> },
         styleSet: { type: [String, Object] as PropType<string | VsRadioStyleSet> },
-        ariaLabel: { type: String, default: '' },
         checked: { type: Boolean, default: false },
         name: { type: String, required: true },
         radioLabel: { type: String, default: '' },

--- a/packages/vlossom/src/components/vs-radio/VsRadio.vue
+++ b/packages/vlossom/src/components/vs-radio/VsRadio.vue
@@ -5,12 +5,11 @@
             :label="label"
             :disabled="computedDisabled"
             :messages="computedMessages"
-            :no-label="noLabel"
             :no-message="noMessage"
             :required="required"
             :shake="shake"
         >
-            <template #label v-if="!noLabel">
+            <template #label v-if="label || $slots['label']">
                 <slot name="label" />
             </template>
 

--- a/packages/vlossom/src/components/vs-radio/stories/VsRadio.stories.ts
+++ b/packages/vlossom/src/components/vs-radio/stories/VsRadio.stories.ts
@@ -29,7 +29,6 @@ const meta: Meta<typeof VsRadio> = {
     },
     args: {
         radioLabel: 'Radio Input',
-        noLabel: true,
         noMessage: true,
         name: 'test',
         radioValue: 'test',
@@ -94,7 +93,6 @@ export const Disabled: Story = {
 export const Label: Story = {
     args: {
         label: 'Label',
-        noLabel: false,
     },
 };
 

--- a/packages/vlossom/src/components/vs-select/VsSelect.vue
+++ b/packages/vlossom/src/components/vs-select/VsSelect.vue
@@ -5,12 +5,11 @@
             :label="label"
             :disabled="computedDisabled"
             :messages="computedMessages"
-            :no-label="noLabel"
             :no-message="noMessage"
             :required="required"
             :shake="shake"
         >
-            <template #label v-if="!noLabel">
+            <template #label v-if="label || $slots['label']">
                 <slot name="label" />
             </template>
 

--- a/packages/vlossom/src/components/vs-select/VsSelect.vue
+++ b/packages/vlossom/src/components/vs-select/VsSelect.vue
@@ -28,7 +28,7 @@
                         :id="`${id}-input`"
                         :class="['vs-select-input', { autocomplete }]"
                         :aria-expanded="isOpen || isVisible"
-                        :aria-label="ariaLabel || label || 'select input'"
+                        :aria-label="ariaLabel"
                         aria-controls="vs-select-options"
                         :aria-autocomplete="autocomplete ? 'list' : undefined"
                         :aria-activedescendant="focusedOptionId"
@@ -235,7 +235,6 @@ export default defineComponent({
         ...getResponsiveProps(),
         colorScheme: { type: String as PropType<ColorScheme> },
         styleSet: { type: [String, Object] as PropType<string | VsSelectStyleSet> },
-        ariaLabel: { type: String, default: '' },
         autocomplete: { type: Boolean, default: false },
         closableChips: {
             type: Boolean,

--- a/packages/vlossom/src/components/vs-switch/VsSwitch.vue
+++ b/packages/vlossom/src/components/vs-switch/VsSwitch.vue
@@ -30,7 +30,7 @@
                     :disabled="computedDisabled || computedReadonly"
                     :checked="isChecked"
                     :value="convertToString(trueValue)"
-                    :aria-label="ariaLabel || 'switch ' + label"
+                    :aria-label="ariaLabel"
                     :aria-required="required"
                     @focus.stop="onFocus"
                     @blur.stop="onBlur"
@@ -78,7 +78,6 @@ export default defineComponent({
         ...getResponsiveProps(),
         colorScheme: { type: String as PropType<ColorScheme> },
         styleSet: { type: [String, Object] as PropType<string | VsSwitchStyleSet> },
-        ariaLabel: { type: String, default: '' },
         beforeChange: {
             type: Function as PropType<(from: any, to: any) => Promise<boolean> | null>,
             default: null,

--- a/packages/vlossom/src/components/vs-switch/VsSwitch.vue
+++ b/packages/vlossom/src/components/vs-switch/VsSwitch.vue
@@ -5,12 +5,11 @@
             :label="label"
             :disabled="computedDisabled"
             :messages="computedMessages"
-            :no-label="noLabel"
             :no-message="noMessage"
             :required="required"
             :shake="shake"
         >
-            <template #label v-if="!noLabel">
+            <template #label v-if="label || $slots['label']">
                 <slot name="label" />
             </template>
 

--- a/packages/vlossom/src/components/vs-table/VsTable.vue
+++ b/packages/vlossom/src/components/vs-table/VsTable.vue
@@ -83,7 +83,6 @@
                 option-label="label"
                 option-value="value"
                 no-clear
-                no-label
                 no-message
                 dense
             />

--- a/packages/vlossom/src/components/vs-table/VsTableHeader.vue
+++ b/packages/vlossom/src/components/vs-table/VsTableHeader.vue
@@ -7,7 +7,6 @@
                     class="search-input"
                     :placeholder="searchPlaceholder"
                     @change="emitSearchText"
-                    no-label
                     no-message
                     dense
                 />

--- a/packages/vlossom/src/components/vs-table/stories/VsTable.chromatic.stories.ts
+++ b/packages/vlossom/src/components/vs-table/stories/VsTable.chromatic.stories.ts
@@ -67,7 +67,7 @@ const meta: Meta<typeof VsTable> = {
                     </vs-input>
                     <vs-table v-bind="args" :search-text="searchText">
                         <template #item-checked="{ value }">
-                            <vs-switch v-model="value" no-label no-message></vs-switch>
+                            <vs-switch v-model="value" no-message></vs-switch>
                         </template>
                     </vs-table>
                 </div>
@@ -95,7 +95,7 @@ const meta: Meta<typeof VsTable> = {
                             <vs-text-wrap copy no-tooltip width="18rem">{{ value }}</vs-text-wrap>
                         </template>
                 	    <template #item-checked="{ value }">
-                	        <vs-switch v-model="value" no-label no-message></vs-switch>
+                	        <vs-switch v-model="value" no-message></vs-switch>
                         </template>
                     </vs-table>
                 </div>
@@ -106,7 +106,7 @@ const meta: Meta<typeof VsTable> = {
                 		    <vs-text-wrap copy no-tooltip width="18rem">{{ value }}</vs-text-wrap>
                 	    </template>
                 	    <template #item-checked="{ value }">
-                		    <vs-switch v-model="value" no-label no-message></vs-switch>
+                		    <vs-switch v-model="value" no-message></vs-switch>
                 	    </template>
                     </vs-table>
                 </div>

--- a/packages/vlossom/src/components/vs-table/stories/VsTable.stories.ts
+++ b/packages/vlossom/src/components/vs-table/stories/VsTable.stories.ts
@@ -142,7 +142,7 @@ export const SearchText: Story = {
                 </vs-input>
                 <vs-table v-bind="args" :searchText="searchText">
                     <template #item-checked="{ value }">
-                        <vs-switch v-model="value" no-label no-message></vs-switch>
+                        <vs-switch v-model="value" no-message></vs-switch>
                     </template>
                 </vs-table>
             </div>
@@ -279,7 +279,7 @@ export const ItemSlot: Story = {
                         <vs-text-wrap copy noTooltip width="18rem">{{ value }}</vs-text-wrap>
                     </template>
                     <template #item-checked="{ value }">
-                        <vs-switch v-model="value" no-label no-message></vs-switch>
+                        <vs-switch v-model="value" no-message></vs-switch>
                     </template>
                 </vs-table>
             </div>

--- a/packages/vlossom/src/components/vs-textarea/VsTextarea.vue
+++ b/packages/vlossom/src/components/vs-textarea/VsTextarea.vue
@@ -5,12 +5,11 @@
             :label="label"
             :disabled="computedDisabled"
             :messages="computedMessages"
-            :no-label="noLabel"
             :no-message="noMessage"
             :required="required"
             :shake="shake"
         >
-            <template #label v-if="!noLabel">
+            <template #label v-if="label || $slots['label']">
                 <slot name="label" />
             </template>
 

--- a/packages/vlossom/src/components/vs-textarea/VsTextarea.vue
+++ b/packages/vlossom/src/components/vs-textarea/VsTextarea.vue
@@ -22,6 +22,7 @@
                 :name="name"
                 :disabled="computedDisabled"
                 :readonly="computedReadonly"
+                :aria-label="ariaLabel"
                 :aria-required="required"
                 :autocomplete="autocomplete ? 'on' : 'off'"
                 :placeholder="placeholder"

--- a/packages/vlossom/src/composables/__tests__/__snapshots__/input-composable.test.ts.snap
+++ b/packages/vlossom/src/composables/__tests__/__snapshots__/input-composable.test.ts.snap
@@ -2,6 +2,10 @@
 
 exports[`getInputProps > input component에 필요한 props들을 가져올 수 있다 1`] = `
 {
+  "ariaLabel": {
+    "default": "",
+    "type": [Function],
+  },
   "changed": {
     "default": false,
     "type": [Function],
@@ -67,6 +71,10 @@ exports[`getInputProps > input component에 필요한 props들을 가져올 수 
 
 exports[`getInputProps > input props 중 제외할 props를 정할 수 있다 1`] = `
 {
+  "ariaLabel": {
+    "default": "",
+    "type": [Function],
+  },
   "changed": {
     "default": false,
     "type": [Function],

--- a/packages/vlossom/src/composables/__tests__/__snapshots__/input-composable.test.ts.snap
+++ b/packages/vlossom/src/composables/__tests__/__snapshots__/input-composable.test.ts.snap
@@ -30,10 +30,6 @@ exports[`getInputProps > input component에 필요한 props들을 가져올 수 
     "default": false,
     "type": [Function],
   },
-  "noLabel": {
-    "default": false,
-    "type": [Function],
-  },
   "noMessage": {
     "default": false,
     "type": [Function],
@@ -88,10 +84,6 @@ exports[`getInputProps > input props 중 제외할 props를 정할 수 있다 1`
     "type": [Function],
   },
   "noDefaultRules": {
-    "default": false,
-    "type": [Function],
-  },
-  "noLabel": {
     "default": false,
     "type": [Function],
   },

--- a/packages/vlossom/src/composables/__tests__/__snapshots__/input-composable.test.ts.snap
+++ b/packages/vlossom/src/composables/__tests__/__snapshots__/input-composable.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`getInputProps > input component에 필요한 props들을 가져올 수 있다 1`] = `
 {
   "ariaLabel": {
-    "default": "",
+    "default": null,
     "type": [Function],
   },
   "changed": {
@@ -72,7 +72,7 @@ exports[`getInputProps > input component에 필요한 props들을 가져올 수 
 exports[`getInputProps > input props 중 제외할 props를 정할 수 있다 1`] = `
 {
   "ariaLabel": {
-    "default": "",
+    "default": null,
     "type": [Function],
   },
   "changed": {

--- a/packages/vlossom/src/composables/input-composable.ts
+++ b/packages/vlossom/src/composables/input-composable.ts
@@ -12,7 +12,6 @@ interface VsInputProps<T> {
     name: { type: StringConstructor; default: string };
     noClear: { type: BooleanConstructor; default: boolean };
     noDefaultRules: { type: BooleanConstructor; default: boolean };
-    noLabel: { type: BooleanConstructor; default: boolean };
     noMessage: { type: BooleanConstructor; default: boolean };
     placeholder: { type: StringConstructor; default: string };
     readonly: { type: BooleanConstructor; default: boolean };
@@ -38,7 +37,6 @@ export function getInputProps<T = unknown, K extends Array<keyof VsInputProps<T>
             name: { type: String, default: '' },
             noClear: { type: Boolean, default: false },
             noDefaultRules: { type: Boolean, default: false },
-            noLabel: { type: Boolean, default: false },
             noMessage: { type: Boolean, default: false },
             placeholder: { type: String, default: '' },
             readonly: { type: Boolean, default: false },

--- a/packages/vlossom/src/composables/input-composable.ts
+++ b/packages/vlossom/src/composables/input-composable.ts
@@ -6,6 +6,7 @@ import { utils } from '@/utils';
 import type { StateMessage, Rule, Message, InputComponentParams } from '@/declaration';
 
 interface VsInputProps<T> {
+    ariaLabel: { type: StringConstructor; default: null };
     disabled: { type: BooleanConstructor; default: boolean };
     label: { type: StringConstructor; default: string };
     messages: { type: PropType<Message<T>[]>; default: () => Message<T>[] };
@@ -31,6 +32,7 @@ export function getInputProps<T = unknown, K extends Array<keyof VsInputProps<T>
     const inputProps: VsInputProps<T> = Object.assign(
         {},
         {
+            ariaLabel: { type: String, default: null },
             disabled: { type: Boolean, default: false },
             label: { type: String, default: '' },
             messages: { type: Array as PropType<Message<T>[]>, default: () => [] },


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Feature (feat)

## Summary
input component의 label 영역을 기본 노출하지 않도록 합니다

## Description
- label 영역을 기본 노출하지 않도록 변경합니다
- label prop을 설정하거나 label slot을 넣어야 label이 노출됩니다
- messages 영역도 message가 있어야 노출됩니다
- input props에 ariaLabel을 추가합니다 (default: null, string으로 하면 빈 aria-label 생성)
- test-storybook, a11y에서 form element label rule off

<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
