### PR TITLE
fix(VsSelect): remove multiple props check for max, min props

### DIFF
--- a/packages/vlossom/src/components/vs-select/VsSelect.vue
+++ b/packages/vlossom/src/components/vs-select/VsSelect.vue
@@ -273,22 +273,14 @@ export default defineComponent({
         max: {
             type: [Number, String],
             default: Number.MAX_SAFE_INTEGER,
-            validator: (value: number | string, props) => {
-                if (!props.multiple && value) {
-                    utils.log.propError(name, 'max', 'max can only be used with multiple prop');
-                    return false;
-                }
+            validator: (value: number | string) => {
                 return utils.props.checkValidNumber(name, 'max', value);
             },
         },
         min: {
             type: [Number, String],
             default: 0,
-            validator: (value: number | string, props) => {
-                if (!props.multiple && value) {
-                    utils.log.propError(name, 'min', 'min can only be used with multiple prop');
-                    return false;
-                }
+            validator: (value: number | string) => {
                 return utils.props.checkValidNumber(name, 'min', value);
             },
         },


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary

- vs-select의 max, min props validator에서 multiple이 설정되어 있지 않을 때 propError를 출력하는 코드를 제거합니다.

## Description
- max, min props에 default 값이 설정되어 있기 때문에 multiple=false일 때 무조건 propError가 출력되는 문제가 있음
- multiple=false일 때 max, min props를 설정하는 것이 아무런 효과가 없는 것은 맞으나, max, min props를 설정한다고 해서 propsError를 출력할 이유는 없어 보여 해당 코드 제거