### PR TITLE
feat(VsInputWrapper): remove vs-responsive from each input components

### DIFF
--- a/packages/vlossom/src/components/vs-checkbox-set/VsCheckboxSet.vue
+++ b/packages/vlossom/src/components/vs-checkbox-set/VsCheckboxSet.vue
@@ -1,57 +1,58 @@
 <template>
-    <vs-responsive :width="width" :grid="grid" v-show="visible">
-        <vs-input-wrapper
-            :label="label"
-            :dense="dense"
-            :disabled="computedDisabled"
-            :messages="computedMessages"
-            :no-message="noMessage"
-            :required="required"
-            :shake="shake"
-            group-label
-        >
-            <template #label v-if="label || $slots['label']">
-                <slot name="label" />
-            </template>
+    <vs-input-wrapper
+        v-show="visible"
+        :width="width"
+        :grid="grid"
+        :label="label"
+        :required="required"
+        :disabled="computedDisabled"
+        :dense="dense"
+        :messages="computedMessages"
+        :no-message="noMessage"
+        :shake="shake"
+        group-label
+    >
+        <template #label v-if="label || $slots['label']">
+            <slot name="label" />
+        </template>
 
-            <div :class="['vs-checkbox-set', { vertical }]" :style="checkboxSetStyleSet">
-                <vs-checkbox-node
-                    v-for="(option, index) in options"
-                    :key="getOptionValue(option)"
-                    ref="checkboxRefs"
-                    class="vs-checkbox-item"
-                    :color-scheme="computedColorScheme"
-                    :style-set="checkboxStyleSet"
-                    :checked="isChecked(option)"
-                    :dense="dense"
-                    :disabled="computedDisabled"
-                    :id="`${computedId}-${optionIds[index]}`"
-                    :label="getOptionLabel(option)"
-                    :name="name"
-                    :readonly="computedReadonly"
-                    :required="required"
-                    :state="computedState"
-                    :value="getOptionValue(option)"
-                    @toggle="onToggle(option, $event)"
-                    @focus="onFocus(option, $event)"
-                    @blur="onBlur(option, $event)"
-                >
-                    <template #label v-if="$slots['check-label']">
-                        <slot
-                            name="check-label"
-                            :option="option"
-                            :value="getOptionValue(option)"
-                            :label="getOptionLabel(option)"
-                        />
-                    </template>
-                </vs-checkbox-node>
-            </div>
+        <div :class="['vs-checkbox-set', { vertical }]" :style="checkboxSetStyleSet">
+            <vs-checkbox-node
+                v-for="(option, index) in options"
+                :key="getOptionValue(option)"
+                ref="checkboxRefs"
+                class="vs-checkbox-item"
+                :color-scheme="computedColorScheme"
+                :style-set="checkboxStyleSet"
+                :checked="isChecked(option)"
+                :dense="dense"
+                :disabled="computedDisabled"
+                :id="`${computedId}-${optionIds[index]}`"
+                :label="getOptionLabel(option)"
+                :name="name"
+                :readonly="computedReadonly"
+                :required="required"
+                :state="computedState"
+                :value="getOptionValue(option)"
+                @toggle="onToggle(option, $event)"
+                @focus="onFocus(option, $event)"
+                @blur="onBlur(option, $event)"
+            >
+                <template #label v-if="$slots['check-label']">
+                    <slot
+                        name="check-label"
+                        :option="option"
+                        :value="getOptionValue(option)"
+                        :label="getOptionLabel(option)"
+                    />
+                </template>
+            </vs-checkbox-node>
+        </div>
 
-            <template #messages v-if="!noMessage">
-                <slot name="messages" />
-            </template>
-        </vs-input-wrapper>
-    </vs-responsive>
+        <template #messages v-if="!noMessage">
+            <slot name="messages" />
+        </template>
+    </vs-input-wrapper>
 </template>
 
 <script lang="ts">
@@ -68,7 +69,6 @@ import {
 import { VsComponent, type ColorScheme } from '@/declaration';
 import { utils } from '@/utils';
 import VsInputWrapper from '@/components/vs-input-wrapper/VsInputWrapper.vue';
-import VsResponsive from '@/components/vs-responsive/VsResponsive.vue';
 import { VsCheckboxNode } from '@/nodes';
 import { useVsCheckboxSetRules } from './vs-checkbox-set-rules';
 
@@ -78,7 +78,7 @@ import type { VsCheckboxStyleSet } from '@/components/vs-checkbox/types';
 const name = VsComponent.VsCheckboxSet;
 export default defineComponent({
     name,
-    components: { VsInputWrapper, VsResponsive, VsCheckboxNode },
+    components: { VsInputWrapper, VsCheckboxNode },
     props: {
         ...getInputProps<any[], ['ariaLabel', 'noClear', 'placeholder']>('ariaLabel', 'noClear', 'placeholder'),
         ...getInputOptionProps(),

--- a/packages/vlossom/src/components/vs-checkbox/VsCheckbox.vue
+++ b/packages/vlossom/src/components/vs-checkbox/VsCheckbox.vue
@@ -1,49 +1,50 @@
 <template>
-    <vs-responsive :width="width" :grid="grid" v-show="visible">
-        <vs-input-wrapper
-            :id="checkLabel ? '' : computedId"
-            :label="label"
+    <vs-input-wrapper
+        v-show="visible"
+        :width="width"
+        :grid="grid"
+        :id="checkLabel ? '' : computedId"
+        :label="label"
+        :required="required"
+        :disabled="computedDisabled"
+        :dense="dense"
+        :messages="computedMessages"
+        :no-message="noMessage"
+        :shake="shake"
+    >
+        <template #label v-if="label || $slots['label']">
+            <slot name="label" />
+        </template>
+
+        <vs-checkbox-node
+            ref="checkboxRef"
+            :color-scheme="computedColorScheme"
+            :style-set="computedStyleSet"
+            :aria-label="ariaLabel"
+            :checked="isChecked"
             :dense="dense"
             :disabled="computedDisabled"
-            :messages="computedMessages"
-            :no-message="noMessage"
+            :id="computedId"
+            :indeterminate="indeterminate"
+            :label="checkLabel"
+            :name="name"
+            :readonly="computedReadonly"
             :required="required"
-            :shake="shake"
+            :state="computedState"
+            :value="trueValue"
+            @toggle="onToggle"
+            @focus="onFocus"
+            @blur="onBlur"
         >
-            <template #label v-if="label || $slots['label']">
-                <slot name="label" />
+            <template #label v-if="$slots['check-label']">
+                <slot name="check-label" />
             </template>
+        </vs-checkbox-node>
 
-            <vs-checkbox-node
-                ref="checkboxRef"
-                :color-scheme="computedColorScheme"
-                :style-set="computedStyleSet"
-                :aria-label="ariaLabel"
-                :checked="isChecked"
-                :dense="dense"
-                :disabled="computedDisabled"
-                :id="computedId"
-                :indeterminate="indeterminate"
-                :label="checkLabel"
-                :name="name"
-                :readonly="computedReadonly"
-                :required="required"
-                :state="computedState"
-                :value="trueValue"
-                @toggle="onToggle"
-                @focus="onFocus"
-                @blur="onBlur"
-            >
-                <template #label v-if="$slots['check-label']">
-                    <slot name="check-label" />
-                </template>
-            </vs-checkbox-node>
-
-            <template #messages v-if="!noMessage">
-                <slot name="messages" />
-            </template>
-        </vs-input-wrapper>
-    </vs-responsive>
+        <template #messages v-if="!noMessage">
+            <slot name="messages" />
+        </template>
+    </vs-input-wrapper>
 </template>
 
 <script lang="ts">
@@ -58,7 +59,6 @@ import {
 } from '@/composables';
 import { VsComponent, type ColorScheme } from '@/declaration';
 import VsInputWrapper from '@/components/vs-input-wrapper/VsInputWrapper.vue';
-import VsResponsive from '@/components/vs-responsive/VsResponsive.vue';
 import { VsCheckboxNode } from '@/nodes';
 
 import type { VsCheckboxStyleSet } from './types';
@@ -66,7 +66,7 @@ import type { VsCheckboxStyleSet } from './types';
 const name = VsComponent.VsCheckbox;
 export default defineComponent({
     name,
-    components: { VsInputWrapper, VsResponsive, VsCheckboxNode },
+    components: { VsInputWrapper, VsCheckboxNode },
     props: {
         ...getInputProps<any, ['placeholder', 'noClear']>('placeholder', 'noClear'),
         ...getResponsiveProps(),

--- a/packages/vlossom/src/components/vs-file-input/VsFileInput.vue
+++ b/packages/vlossom/src/components/vs-file-input/VsFileInput.vue
@@ -1,73 +1,74 @@
 <template>
-    <vs-responsive :width="width" :grid="grid" v-show="visible">
-        <vs-input-wrapper
-            :id="computedId"
-            :label="label"
-            :dense="dense"
-            :disabled="computedDisabled"
-            :messages="computedMessages"
-            :no-message="noMessage"
-            :required="required"
-            :shake="shake"
+    <vs-input-wrapper
+        v-show="visible"
+        :width="width"
+        :grid="grid"
+        :id="computedId"
+        :label="label"
+        :required="required"
+        :disabled="computedDisabled"
+        :dense="dense"
+        :messages="computedMessages"
+        :no-message="noMessage"
+        :shake="shake"
+    >
+        <template #label v-if="label || $slots['label']">
+            <slot name="label" />
+        </template>
+
+        <div
+            :class="['vs-file-input', colorSchemeClass, classObj, stateClasses]"
+            :style="computedStyleSet"
+            @dragenter.stop="setDragging(true)"
+            @dragleave.stop="setDragging(false)"
+            @drop.stop="setDragging(false)"
         >
-            <template #label v-if="label || $slots['label']">
-                <slot name="label" />
-            </template>
-
-            <div
-                :class="['vs-file-input', colorSchemeClass, classObj, stateClasses]"
-                :style="computedStyleSet"
-                @dragenter.stop="setDragging(true)"
-                @dragleave.stop="setDragging(false)"
-                @drop.stop="setDragging(false)"
-            >
-                <div class="vs-attach-file-icon">
-                    <slot name="icon">
-                        <vs-icon icon="attachFile" :size="dense ? 16 : 18" />
-                    </slot>
-                </div>
-
-                <div class="vs-label-box">
-                    <div :class="['vs-label-wrap', { placeholder: placeholder && !hasValue }]">
-                        <template v-if="dragging">{{ dropPlaceholder }}</template>
-                        <template v-else-if="placeholder && !hasValue">{{ placeholder }}</template>
-                        <template v-else-if="hasValue">{{ fileLabel }}</template>
-                    </div>
-                </div>
-
-                <input
-                    ref="fileInputRef"
-                    class="vs-file-input-ref"
-                    :id="computedId"
-                    type="file"
-                    :name="name"
-                    :disabled="computedDisabled"
-                    :readonly="computedReadonly"
-                    :required="required"
-                    :multiple="multiple"
-                    :accept="accept"
-                    :aria-label="ariaLabel"
-                    @change.stop="updateValue($event)"
-                    @focus.stop="onFocus"
-                    @blur.stop="onBlur"
-                />
-
-                <button
-                    v-if="!noClear && hasValue && !computedReadonly && !computedDisabled"
-                    class="vs-clear-button"
-                    aria-hidden="true"
-                    tabindex="-1"
-                    @click.stop="onClear()"
-                >
-                    <vs-icon icon="close" :size="dense ? 14 : 16" />
-                </button>
+            <div class="vs-attach-file-icon">
+                <slot name="icon">
+                    <vs-icon icon="attachFile" :size="dense ? 16 : 18" />
+                </slot>
             </div>
 
-            <template #messages v-if="!noMessage">
-                <slot name="messages" />
-            </template>
-        </vs-input-wrapper>
-    </vs-responsive>
+            <div class="vs-label-box">
+                <div :class="['vs-label-wrap', { placeholder: placeholder && !hasValue }]">
+                    <template v-if="dragging">{{ dropPlaceholder }}</template>
+                    <template v-else-if="placeholder && !hasValue">{{ placeholder }}</template>
+                    <template v-else-if="hasValue">{{ fileLabel }}</template>
+                </div>
+            </div>
+
+            <input
+                ref="fileInputRef"
+                class="vs-file-input-ref"
+                :id="computedId"
+                type="file"
+                :name="name"
+                :disabled="computedDisabled"
+                :readonly="computedReadonly"
+                :required="required"
+                :multiple="multiple"
+                :accept="accept"
+                :aria-label="ariaLabel"
+                @change.stop="updateValue($event)"
+                @focus.stop="onFocus"
+                @blur.stop="onBlur"
+            />
+
+            <button
+                v-if="!noClear && hasValue && !computedReadonly && !computedDisabled"
+                class="vs-clear-button"
+                aria-hidden="true"
+                tabindex="-1"
+                @click.stop="onClear()"
+            >
+                <vs-icon icon="close" :size="dense ? 14 : 16" />
+            </button>
+        </div>
+
+        <template #messages v-if="!noMessage">
+            <slot name="messages" />
+        </template>
+    </vs-input-wrapper>
 </template>
 
 <script lang="ts">
@@ -75,7 +76,6 @@ import { computed, defineComponent, PropType, Ref, ref, toRefs } from 'vue';
 import { useColorScheme, useStyleSet, getResponsiveProps, getInputProps, useInput, useStateClass } from '@/composables';
 import { VsComponent, type ColorScheme } from '@/declaration';
 import VsInputWrapper from '@/components/vs-input-wrapper/VsInputWrapper.vue';
-import VsResponsive from '@/components/vs-responsive/VsResponsive.vue';
 import { VsIcon } from '@/icons';
 
 import type { InputValueType, VsFileInputStyleSet } from './types';
@@ -83,7 +83,7 @@ import type { InputValueType, VsFileInputStyleSet } from './types';
 const name = VsComponent.VsFileInput;
 export default defineComponent({
     name,
-    components: { VsInputWrapper, VsResponsive, VsIcon },
+    components: { VsInputWrapper, VsIcon },
     props: {
         ...getInputProps<InputValueType, []>(),
         ...getResponsiveProps(),

--- a/packages/vlossom/src/components/vs-input-wrapper/VsInputWrapper.vue
+++ b/packages/vlossom/src/components/vs-input-wrapper/VsInputWrapper.vue
@@ -1,5 +1,9 @@
 <template>
-    <div class="vs-input-wrapper" :class="{ 'shake-horizontal': needToShake, dense }">
+    <vs-responsive
+        :class="['vs-input-wrapper', { 'shake-horizontal': needToShake, dense }]"
+        :width="width"
+        :grid="grid"
+    >
         <component :is="groupLabel ? 'fieldset' : 'div'">
             <component
                 v-if="label || $slots['label']"
@@ -27,18 +31,21 @@
                 />
             </slot>
         </div>
-    </div>
+    </vs-responsive>
 </template>
 
 <script lang="ts">
 import { PropType, defineComponent, ref, toRefs, watch } from 'vue';
 import { VsComponent, type StateMessage } from '@/declaration';
+import { getResponsiveProps } from '@/composables';
+import VsResponsive from '@/components/vs-responsive/VsResponsive.vue';
 import VsMessage from '@/components/vs-message/VsMessage.vue';
 
 export default defineComponent({
     name: VsComponent.VsInputWrapper,
-    components: { VsMessage },
+    components: { VsResponsive, VsMessage },
     props: {
+        ...getResponsiveProps(),
         dense: { type: Boolean, default: false },
         disabled: { type: Boolean, default: false },
         groupLabel: { type: Boolean, default: false },

--- a/packages/vlossom/src/components/vs-input/VsInput.vue
+++ b/packages/vlossom/src/components/vs-input/VsInput.vue
@@ -1,66 +1,67 @@
 <template>
-    <vs-responsive :width="width" :grid="grid" v-show="visible">
-        <vs-input-wrapper
-            :id="computedId"
-            :label="label"
-            :dense="dense"
-            :disabled="computedDisabled"
-            :messages="computedMessages"
-            :no-message="noMessage"
-            :required="required"
-            :shake="shake"
-        >
-            <template #label v-if="label || $slots['label']">
-                <slot name="label" />
-            </template>
+    <vs-input-wrapper
+        v-show="visible"
+        :width="width"
+        :grid="grid"
+        :id="computedId"
+        :label="label"
+        :required="required"
+        :disabled="computedDisabled"
+        :dense="dense"
+        :messages="computedMessages"
+        :no-message="noMessage"
+        :shake="shake"
+    >
+        <template #label v-if="label || $slots['label']">
+            <slot name="label" />
+        </template>
 
-            <div :class="['vs-input', colorSchemeClass, classObj, stateClasses]" :style="computedStyleSet">
-                <div v-if="$slots['prepend']" class="prepend">
-                    <slot name="prepend" />
-                </div>
-
-                <input
-                    ref="inputRef"
-                    :id="computedId"
-                    :type="type"
-                    :value="inputValue"
-                    :autocomplete="autocomplete ? 'on' : 'off'"
-                    :name="name"
-                    :disabled="computedDisabled"
-                    :readonly="computedReadonly"
-                    :aria-label="ariaLabel"
-                    :aria-required="required"
-                    :placeholder="placeholder"
-                    @input.stop="updateValue($event)"
-                    @focus.stop="onFocus"
-                    @blur.stop="onBlur"
-                    @keyup.enter.stop="onEnter"
-                    @change.stop
-                />
-
-                <button
-                    v-if="!noClear && !computedReadonly && !computedDisabled"
-                    type="button"
-                    class="vs-clear-button"
-                    :class="{ show: inputValue }"
-                    :disabled="!inputValue"
-                    aria-hidden="true"
-                    tabindex="-1"
-                    @click.stop="clearWithFocus()"
-                >
-                    <vs-icon icon="close" :size="dense ? 14 : 16" />
-                </button>
-
-                <div v-if="$slots['append']" class="append">
-                    <slot name="append" />
-                </div>
+        <div :class="['vs-input', colorSchemeClass, classObj, stateClasses]" :style="computedStyleSet">
+            <div v-if="$slots['prepend']" class="prepend">
+                <slot name="prepend" />
             </div>
 
-            <template #messages v-if="!noMessage">
-                <slot name="messages" />
-            </template>
-        </vs-input-wrapper>
-    </vs-responsive>
+            <input
+                ref="inputRef"
+                :id="computedId"
+                :type="type"
+                :value="inputValue"
+                :autocomplete="autocomplete ? 'on' : 'off'"
+                :name="name"
+                :disabled="computedDisabled"
+                :readonly="computedReadonly"
+                :aria-label="ariaLabel"
+                :aria-required="required"
+                :placeholder="placeholder"
+                @input.stop="updateValue($event)"
+                @focus.stop="onFocus"
+                @blur.stop="onBlur"
+                @keyup.enter.stop="onEnter"
+                @change.stop
+            />
+
+            <button
+                v-if="!noClear && !computedReadonly && !computedDisabled"
+                type="button"
+                class="vs-clear-button"
+                :class="{ show: inputValue }"
+                :disabled="!inputValue"
+                aria-hidden="true"
+                tabindex="-1"
+                @click.stop="clearWithFocus()"
+            >
+                <vs-icon icon="close" :size="dense ? 14 : 16" />
+            </button>
+
+            <div v-if="$slots['append']" class="append">
+                <slot name="append" />
+            </div>
+        </div>
+
+        <template #messages v-if="!noMessage">
+            <slot name="messages" />
+        </template>
+    </vs-input-wrapper>
 </template>
 
 <script lang="ts">
@@ -75,11 +76,10 @@ import {
     useStateClass,
 } from '@/composables';
 import { VsComponent, StringModifiers, type ColorScheme } from '@/declaration';
-import { useVsInputRules } from './vs-input-rules';
 import VsInputWrapper from '@/components/vs-input-wrapper/VsInputWrapper.vue';
-import VsResponsive from '@/components/vs-responsive/VsResponsive.vue';
 import { VsIcon } from '@/icons';
 import { InputType } from './types';
+import { useVsInputRules } from './vs-input-rules';
 
 import type { InputValueType, VsInputStyleSet } from './types';
 import { utils } from '@/utils';
@@ -87,7 +87,7 @@ import { utils } from '@/utils';
 const name = VsComponent.VsInput;
 export default defineComponent({
     name,
-    components: { VsInputWrapper, VsResponsive, VsIcon },
+    components: { VsInputWrapper, VsIcon },
     props: {
         ...getInputProps<InputValueType, []>(),
         ...getResponsiveProps(),

--- a/packages/vlossom/src/components/vs-radio-set/VsRadioSet.vue
+++ b/packages/vlossom/src/components/vs-radio-set/VsRadioSet.vue
@@ -1,57 +1,58 @@
 <template>
-    <vs-responsive :width="width" :grid="grid" v-show="visible">
-        <vs-input-wrapper
-            :label="label"
-            :dense="dense"
-            :disabled="computedDisabled"
-            :messages="computedMessages"
-            :no-message="noMessage"
-            :required="required"
-            :shake="shake"
-            group-label
-        >
-            <template #label v-if="label || $slots['label']">
-                <slot name="label" />
-            </template>
+    <vs-input-wrapper
+        v-show="visible"
+        :width="width"
+        :grid="grid"
+        :label="label"
+        :required="required"
+        :disabled="computedDisabled"
+        :dense="dense"
+        :messages="computedMessages"
+        :no-message="noMessage"
+        :shake="shake"
+        group-label
+    >
+        <template #label v-if="label || $slots['label']">
+            <slot name="label" />
+        </template>
 
-            <div :class="['vs-radio-set', { vertical }]" :style="radioSetStyleSet">
-                <vs-radio-node
-                    v-for="(option, index) in options"
-                    :key="getOptionValue(option)"
-                    ref="radioRefs"
-                    class="vs-radio-item"
-                    :color-scheme="computedColorScheme"
-                    :style-set="radioStyleSet"
-                    :checked="isChecked(option)"
-                    :dense="dense"
-                    :disabled="computedDisabled"
-                    :id="`${computedId}-${optionIds[index]}`"
-                    :label="getOptionLabel(option)"
-                    :name="name"
-                    :readonly="computedReadonly"
-                    :required="required"
-                    :state="computedState"
-                    :value="getOptionValue(option)"
-                    @toggle="onToggle(option)"
-                    @focus="onFocus(option, $event)"
-                    @blur="onBlur(option, $event)"
-                >
-                    <template #label v-if="$slots['radio-label']">
-                        <slot
-                            name="radio-label"
-                            :option="option"
-                            :value="getOptionValue(option)"
-                            :label="getOptionLabel(option)"
-                        />
-                    </template>
-                </vs-radio-node>
-            </div>
+        <div :class="['vs-radio-set', { vertical }]" :style="radioSetStyleSet">
+            <vs-radio-node
+                v-for="(option, index) in options"
+                :key="getOptionValue(option)"
+                ref="radioRefs"
+                class="vs-radio-item"
+                :color-scheme="computedColorScheme"
+                :style-set="radioStyleSet"
+                :checked="isChecked(option)"
+                :dense="dense"
+                :disabled="computedDisabled"
+                :id="`${computedId}-${optionIds[index]}`"
+                :label="getOptionLabel(option)"
+                :name="name"
+                :readonly="computedReadonly"
+                :required="required"
+                :state="computedState"
+                :value="getOptionValue(option)"
+                @toggle="onToggle(option)"
+                @focus="onFocus(option, $event)"
+                @blur="onBlur(option, $event)"
+            >
+                <template #label v-if="$slots['radio-label']">
+                    <slot
+                        name="radio-label"
+                        :option="option"
+                        :value="getOptionValue(option)"
+                        :label="getOptionLabel(option)"
+                    />
+                </template>
+            </vs-radio-node>
+        </div>
 
-            <template #messages v-if="!noMessage">
-                <slot name="messages" />
-            </template>
-        </vs-input-wrapper>
-    </vs-responsive>
+        <template #messages v-if="!noMessage">
+            <slot name="messages" />
+        </template>
+    </vs-input-wrapper>
 </template>
 
 <script lang="ts">
@@ -68,7 +69,6 @@ import {
 import { VsComponent, type ColorScheme } from '@/declaration';
 import { utils } from '@/utils';
 import VsInputWrapper from '@/components/vs-input-wrapper/VsInputWrapper.vue';
-import VsResponsive from '@/components/vs-responsive/VsResponsive.vue';
 import { VsRadioNode } from '@/nodes';
 
 import type { VsRadioSetStyleSet } from './types';
@@ -76,7 +76,7 @@ import type { VsRadioStyleSet } from '@/components/vs-radio/types';
 
 export default defineComponent({
     name: VsComponent.VsRadioSet,
-    components: { VsInputWrapper, VsResponsive, VsRadioNode },
+    components: { VsInputWrapper, VsRadioNode },
     props: {
         ...getInputProps<any[], ['ariaLabel', 'noClear', 'placeholder']>('ariaLabel', 'noClear', 'placeholder'),
         ...getInputOptionProps(),

--- a/packages/vlossom/src/components/vs-radio/VsRadio.vue
+++ b/packages/vlossom/src/components/vs-radio/VsRadio.vue
@@ -1,48 +1,49 @@
 <template>
-    <vs-responsive :width="width" :grid="grid" v-show="visible">
-        <vs-input-wrapper
-            :id="radioLabel ? '' : computedId"
-            :label="label"
+    <vs-input-wrapper
+        v-show="visible"
+        :width="width"
+        :grid="grid"
+        :id="radioLabel ? '' : computedId"
+        :label="label"
+        :required="required"
+        :disabled="computedDisabled"
+        :dense="dense"
+        :messages="computedMessages"
+        :no-message="noMessage"
+        :shake="shake"
+    >
+        <template #label v-if="label || $slots['label']">
+            <slot name="label" />
+        </template>
+
+        <vs-radio-node
+            ref="radioRef"
+            :color-scheme="computedColorScheme"
+            :style-set="computedStyleSet"
+            :aria-label="ariaLabel"
+            :checked="isChecked"
             :dense="dense"
             :disabled="computedDisabled"
-            :messages="computedMessages"
-            :no-message="noMessage"
+            :id="computedId"
+            :label="radioLabel"
+            :name="name"
+            :readonly="computedReadonly"
             :required="required"
-            :shake="shake"
+            :state="computedState"
+            :value="radioValue"
+            @toggle="onToggle"
+            @focus="onFocus"
+            @blur="onBlur"
         >
-            <template #label v-if="label || $slots['label']">
-                <slot name="label" />
+            <template #label v-if="$slots['radio-label']">
+                <slot name="radio-label" />
             </template>
+        </vs-radio-node>
 
-            <vs-radio-node
-                ref="radioRef"
-                :color-scheme="computedColorScheme"
-                :style-set="computedStyleSet"
-                :aria-label="ariaLabel"
-                :checked="isChecked"
-                :dense="dense"
-                :disabled="computedDisabled"
-                :id="computedId"
-                :label="radioLabel"
-                :name="name"
-                :readonly="computedReadonly"
-                :required="required"
-                :state="computedState"
-                :value="radioValue"
-                @toggle="onToggle"
-                @focus="onFocus"
-                @blur="onBlur"
-            >
-                <template #label v-if="$slots['radio-label']">
-                    <slot name="radio-label" />
-                </template>
-            </vs-radio-node>
-
-            <template #messages v-if="!noMessage">
-                <slot name="messages" />
-            </template>
-        </vs-input-wrapper>
-    </vs-responsive>
+        <template #messages v-if="!noMessage">
+            <slot name="messages" />
+        </template>
+    </vs-input-wrapper>
 </template>
 
 <script lang="ts">
@@ -51,14 +52,13 @@ import { useColorScheme, useStyleSet, getResponsiveProps, getInputProps, useInpu
 import { VsComponent, type ColorScheme } from '@/declaration';
 import { utils } from '@/utils';
 import VsInputWrapper from '@/components/vs-input-wrapper/VsInputWrapper.vue';
-import VsResponsive from '@/components/vs-responsive/VsResponsive.vue';
 import { VsRadioNode } from '@/nodes';
 
 import type { VsRadioStyleSet } from './types';
 
 export default defineComponent({
     name: VsComponent.VsRadio,
-    components: { VsInputWrapper, VsResponsive, VsRadioNode },
+    components: { VsInputWrapper, VsRadioNode },
     props: {
         ...getInputProps<any, ['placeholder', 'noClear']>('placeholder', 'noClear'),
         ...getResponsiveProps(),

--- a/packages/vlossom/src/components/vs-switch/VsSwitch.vue
+++ b/packages/vlossom/src/components/vs-switch/VsSwitch.vue
@@ -1,56 +1,57 @@
 <template>
-    <vs-responsive :width="width" :grid="grid" v-show="visible">
-        <vs-input-wrapper
-            :id="computedId"
-            :label="label"
-            :dense="dense"
-            :disabled="computedDisabled"
-            :messages="computedMessages"
-            :no-message="noMessage"
-            :required="required"
-            :shake="shake"
+    <vs-input-wrapper
+        v-show="visible"
+        :width="width"
+        :grid="grid"
+        :id="computedId"
+        :label="label"
+        :required="required"
+        :disabled="computedDisabled"
+        :dense="dense"
+        :messages="computedMessages"
+        :no-message="noMessage"
+        :shake="shake"
+    >
+        <template #label v-if="label || $slots['label']">
+            <slot name="label" />
+        </template>
+
+        <div
+            :class="[
+                'vs-switch',
+                colorSchemeClass,
+                { checked: isChecked, disabled: computedDisabled, readonly: computedReadonly, dense },
+            ]"
+            :style="computedStyleSet"
         >
-            <template #label v-if="label || $slots['label']">
-                <slot name="label" />
-            </template>
+            <input
+                type="checkbox"
+                ref="switchRef"
+                class="vs-switch-input"
+                :id="computedId"
+                :name="name"
+                :disabled="computedDisabled || computedReadonly"
+                :checked="isChecked"
+                :value="convertToString(trueValue)"
+                :aria-label="ariaLabel"
+                :aria-required="required"
+                @focus.stop="onFocus"
+                @blur.stop="onBlur"
+            />
 
-            <div
-                :class="[
-                    'vs-switch',
-                    colorSchemeClass,
-                    { checked: isChecked, disabled: computedDisabled, readonly: computedReadonly, dense },
-                ]"
-                :style="computedStyleSet"
-            >
-                <input
-                    type="checkbox"
-                    ref="switchRef"
-                    class="vs-switch-input"
-                    :id="computedId"
-                    :name="name"
-                    :disabled="computedDisabled || computedReadonly"
-                    :checked="isChecked"
-                    :value="convertToString(trueValue)"
-                    :aria-label="ariaLabel"
-                    :aria-required="required"
-                    @focus.stop="onFocus"
-                    @blur.stop="onBlur"
-                />
-
-                <div :class="['vs-switch-button', stateClasses]" @click.stop="onClick">
-                    <span class="vs-status-label" data-value="true" v-show="isChecked">
-                        {{ trueLabel }}
-                    </span>
-                    <span class="vs-status-label" data-value="false" v-show="!isChecked">
-                        {{ falseLabel }}
-                    </span>
-                </div>
+            <div :class="['vs-switch-button', stateClasses]" @click.stop="onClick">
+                <span class="vs-status-label" data-value="true" v-show="isChecked">
+                    {{ trueLabel }}
+                </span>
+                <span class="vs-status-label" data-value="false" v-show="!isChecked">
+                    {{ falseLabel }}
+                </span>
             </div>
-            <template #messages v-if="!noMessage">
-                <slot name="messages" />
-            </template>
-        </vs-input-wrapper>
-    </vs-responsive>
+        </div>
+        <template #messages v-if="!noMessage">
+            <slot name="messages" />
+        </template>
+    </vs-input-wrapper>
 </template>
 
 <script lang="ts">
@@ -64,16 +65,14 @@ import {
     useValueMatcher,
     useStateClass,
 } from '@/composables';
-import { utils } from '@/utils';
 import { ColorScheme, VsComponent } from '@/declaration';
-import VsResponsive from '@/components/vs-responsive/VsResponsive.vue';
+import { utils } from '@/utils';
 
 import type { VsSwitchStyleSet } from './types';
 
 const name = VsComponent.VsSwitch;
 export default defineComponent({
     name,
-    components: { VsResponsive },
     props: {
         ...getInputProps<any, ['noClear', 'placeholder']>('noClear', 'placeholder'),
         ...getResponsiveProps(),

--- a/packages/vlossom/src/components/vs-textarea/VsTextarea.vue
+++ b/packages/vlossom/src/components/vs-textarea/VsTextarea.vue
@@ -1,44 +1,45 @@
 <template>
-    <vs-responsive :width="width" :grid="grid" v-show="visible">
-        <vs-input-wrapper
+    <vs-input-wrapper
+        v-show="visible"
+        :width="width"
+        :grid="grid"
+        :id="computedId"
+        :label="label"
+        :required="required"
+        :disabled="computedDisabled"
+        :dense="dense"
+        :messages="computedMessages"
+        :no-message="noMessage"
+        :shake="shake"
+    >
+        <template #label v-if="label || $slots['label']">
+            <slot name="label" />
+        </template>
+
+        <textarea
+            ref="textareaRef"
+            :class="['vs-textarea', colorSchemeClass, classObj, stateClasses]"
+            :style="computedStyleSet"
             :id="computedId"
-            :label="label"
-            :dense="dense"
+            :value="inputValue"
+            :name="name"
             :disabled="computedDisabled"
-            :messages="computedMessages"
-            :no-message="noMessage"
-            :required="required"
-            :shake="shake"
-        >
-            <template #label v-if="label || $slots['label']">
-                <slot name="label" />
-            </template>
+            :readonly="computedReadonly"
+            :aria-label="ariaLabel"
+            :aria-required="required"
+            :autocomplete="autocomplete ? 'on' : 'off'"
+            :placeholder="placeholder"
+            @input.stop="updateValue($event)"
+            @focus.stop="onFocus"
+            @blur.stop="onBlur"
+            @keyup.enter.stop="onEnter"
+            @change.stop
+        />
 
-            <textarea
-                ref="textareaRef"
-                :class="['vs-textarea', colorSchemeClass, classObj, stateClasses]"
-                :style="computedStyleSet"
-                :id="computedId"
-                :value="inputValue"
-                :name="name"
-                :disabled="computedDisabled"
-                :readonly="computedReadonly"
-                :aria-label="ariaLabel"
-                :aria-required="required"
-                :autocomplete="autocomplete ? 'on' : 'off'"
-                :placeholder="placeholder"
-                @input.stop="updateValue($event)"
-                @focus.stop="onFocus"
-                @blur.stop="onBlur"
-                @keyup.enter.stop="onEnter"
-                @change.stop
-            />
-
-            <template #messages v-if="!noMessage">
-                <slot name="messages" />
-            </template>
-        </vs-input-wrapper>
-    </vs-responsive>
+        <template #messages v-if="!noMessage">
+            <slot name="messages" />
+        </template>
+    </vs-input-wrapper>
 </template>
 
 <script lang="ts">
@@ -53,17 +54,16 @@ import {
     useStateClass,
 } from '@/composables';
 import { VsComponent, StringModifiers, type ColorScheme } from '@/declaration';
-import { useVsTextareaRules } from './vs-textarea-rules';
-import VsInputWrapper from '@/components/vs-input-wrapper/VsInputWrapper.vue';
-import VsResponsive from '@/components/vs-responsive/VsResponsive.vue';
 import { utils } from '@/utils';
+import VsInputWrapper from '@/components/vs-input-wrapper/VsInputWrapper.vue';
+import { useVsTextareaRules } from './vs-textarea-rules';
 
 import type { InputValueType, VsTextareaStyleSet } from './types';
 
 const name = VsComponent.VsTextarea;
 export default defineComponent({
     name,
-    components: { VsInputWrapper, VsResponsive },
+    components: { VsInputWrapper },
     props: {
         ...getInputProps<InputValueType, ['noClear']>('noClear'),
         ...getResponsiveProps(),


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Feature (feat)

## Summary
vs-input-wrapper에 vs-responsive를 적용합니다

## Description
- 각 input-component가 vs-responsive를 가지지 않아도 됩니다
- component를 감싸는 wrapper가 하나 줄어듭니다

<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
