### PR TITLE
ci: update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,6 @@ jobs:
                   package-name: vlossom
                   path: packages/vlossom
                   changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"chore","section":"Miscellaneous","hidden":false}]'
-                  prerelease: true
-                  versioning-strategy: prerelease
             - name: Checkout Repository
               uses: actions/checkout@v4
               if: ${{ steps.release.outputs['packages/vlossom--release_created'] }}


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] CI (ci)

## Summary

- vlossom pre-release를 종료하고 정식 release 버전을 올리기 위해 prerelease 옵션을 제거합니다. 