### PR TITLE
fix(VsLabelValue): modify flex-basis when container query applied

### DIFF
--- a/packages/vlossom/src/components/vs-label-value/VsLabelValue.scss
+++ b/packages/vlossom/src/components/vs-label-value/VsLabelValue.scss
@@ -79,6 +79,7 @@
             padding: 0.8rem 1.2rem;
 
             &.label {
+                flex-basis: auto;
                 border-right: none;
                 border-bottom: var(--vs-label-value-border, 1px solid var(--vs-line-color));
             }


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary

- style-set으로 설정한 labelWidth가 container 크기가 작아져 flex-direction이 바뀌었을 때도 flex-basis로 적용되는 이슈가 있어서 이를 수정합니다.
