### PR TITLE
fix: change index.d.ts module name

### DIFF
--- a/packages/vlossom/package.json
+++ b/packages/vlossom/package.json
@@ -35,8 +35,7 @@
         "chromatic": "chromatic --build-script-name build-storybook:chromatic --exit-zero-on-changes"
     },
     "files": [
-        "dist",
-        "src"
+        "dist"
     ],
     "main": "./dist/vlossom.umd.js",
     "module": "./dist/vlossom.es.js",

--- a/packages/vlossom/src/index.ts
+++ b/packages/vlossom/src/index.ts
@@ -1,7 +1,7 @@
 import './styles/index.scss';
 import type { Vlossom } from './vlossom-framework';
 
-declare module 'vue' {
+declare module '@vue/runtime-core' {
     interface ComponentCustomProperties {
         $vs: Vlossom;
     }


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary
vue module declare의 이름을 변경합니다

## Description
- declare module 'vue' -> declare module '@vue/runtime-core'
- files에서 src를 내보내지 않게 합니다

<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
