### PR TITLE
fix(VsTable): clickRow 이벤트가 버블링되지 않는 버그 수정

### DIFF
--- a/packages/vlossom/src/components/vs-table/VsTable.vue
+++ b/packages/vlossom/src/components/vs-table/VsTable.vue
@@ -62,6 +62,7 @@
                     @change:selected-items="emitSelectedItems"
                     @change:paged-items="emitPagedItems"
                     @change:total-items="emitTotalItems"
+                    @click-row="emitClickRow"
                 >
                     <template v-for="(_, name) in itemSlots" #[name]="slotData">
                         <slot :name="name" v-bind="slotData || {}" />
@@ -174,6 +175,7 @@ export default defineComponent({
         },
     },
     emits: [
+        'clickRow',
         'update',
         'update:itemsPerPage',
         'update:page',
@@ -342,6 +344,10 @@ export default defineComponent({
             emit('update:totalItems', items);
         }
 
+        function emitClickRow(rowItem: any, rowIndex: number) {
+            emit('clickRow', rowItem, rowIndex);
+        }
+
         return {
             colorSchemeClass,
             computedStyleSet,
@@ -365,6 +371,7 @@ export default defineComponent({
             emitSelectedItems,
             emitPagedItems,
             emitTotalItems,
+            emitClickRow,
             // expose
             expand,
         };

--- a/packages/vlossom/src/components/vs-table/VsTableBody.vue
+++ b/packages/vlossom/src/components/vs-table/VsTableBody.vue
@@ -20,7 +20,7 @@
                 :loading="loading"
                 :row-index="index"
                 :tr-style="trStyle"
-                @click="emitRowClick(element, index)"
+                @click="emitClickRow(element, index)"
                 @toggleExpand="toggleExpand"
             >
                 <template #check>
@@ -123,7 +123,7 @@ export default defineComponent({
         totalItemsLength: { type: Number, default: 0 },
     },
     emits: [
-        'rowClick',
+        'clickRow',
         'toggleExpand',
         'change:selectedItems',
         'change:totalItems',
@@ -150,6 +150,7 @@ export default defineComponent({
             innerItemsPerPage,
             totalLength,
         } = toRefs(props);
+        const { emit } = ctx;
 
         const innerItems: Ref<any[]> = ref([]);
         const innerTableItems: ComputedRef<TableItem[]> = computed(() => {
@@ -181,16 +182,16 @@ export default defineComponent({
                     innerItemsPerPage,
                     totalLength,
                 );
-                ctx.emit('update:totalItemsLength', resultTableItems.length);
+                emit('update:totalItemsLength', resultTableItems.length);
                 const resultItems = resultTableItems.map((i) => i.data);
                 const pagedItems = pagination.value ? pagedTableItems.map((i) => i.data) : resultItems;
-                ctx.emit('change:totalItems', resultItems);
-                ctx.emit('change:pagedItems', pagedItems);
+                emit('change:totalItems', resultItems);
+                emit('change:pagedItems', pagedItems);
                 return pagedTableItems;
             },
             set(itemArr: TableItem[]) {
                 innerItems.value = itemArr.map((i) => i.data);
-                ctx.emit('change:totalItems', innerItems.value);
+                emit('change:totalItems', innerItems.value);
             },
         });
 
@@ -222,8 +223,8 @@ export default defineComponent({
             toggleExpand(target.id);
         }
 
-        function emitRowClick(rowItem: any, rowIndex: number) {
-            ctx.emit('rowClick', rowItem, rowIndex);
+        function emitClickRow(rowItem: any, rowIndex: number) {
+            emit('clickRow', rowItem, rowIndex);
         }
 
         // for initial skeleton loading
@@ -239,7 +240,7 @@ export default defineComponent({
             toggleSelect,
             isExpanded,
             toggleExpand,
-            emitRowClick,
+            emitClickRow,
             // expose
             expand,
         };


### PR DESCRIPTION
## Type of PR (check all applicable)
-   [x] Fix Bug (fix)


## Summary
- clickRow 이벤트가 버블링되지 않는 버그를 수정합니다.

## Description
- VsTableBody에서 발생한 이벤트를 VsTable에서 받아서 다시 emit해주도록 수정합니다.
- rowClick -> clickRow로 이벤트 이름을 변경합니다.

