### PR TITLE
fix(grid): change BreakPoint base to xs, fix grid-template-columns

### DIFF
--- a/packages/vlossom/src/components/vs-checkbox-set/stories/VsCheckboxSet.stories.ts
+++ b/packages/vlossom/src/components/vs-checkbox-set/stories/VsCheckboxSet.stories.ts
@@ -141,7 +141,7 @@ export const Grid: Story = {
             return { args };
         },
         template: `
-            <vs-container>
+            <vs-container grid>
                 <vs-checkbox-set v-bind="args" />
                 <vs-checkbox-set v-bind="args" />
             </vs-container>

--- a/packages/vlossom/src/components/vs-checkbox/stories/VsCheckbox.stories.ts
+++ b/packages/vlossom/src/components/vs-checkbox/stories/VsCheckbox.stories.ts
@@ -209,7 +209,7 @@ export const Grid: Story = {
             return { args };
         },
         template: `
-            <vs-container>
+            <vs-container grid>
                 <vs-checkbox v-bind="args" />
                 <vs-checkbox v-bind="args" />
             </vs-container>

--- a/packages/vlossom/src/components/vs-container/VsContainer.scss
+++ b/packages/vlossom/src/components/vs-container/VsContainer.scss
@@ -7,6 +7,6 @@
     &.grid {
         // for grid css
         display: grid;
-        grid-template-columns: repeat(12, 1fr);
+        grid-template-columns: repeat(12, minmax(0, 1fr));
     }
 }

--- a/packages/vlossom/src/components/vs-file-input/stories/VsFileInput.stories.ts
+++ b/packages/vlossom/src/components/vs-file-input/stories/VsFileInput.stories.ts
@@ -161,7 +161,7 @@ export const Grid: Story = {
             return { args };
         },
         template: `
-            <vs-container>
+            <vs-container grid>
                 <vs-file-input v-bind="args" />
                 <vs-file-input v-bind="args" />
             </vs-container>

--- a/packages/vlossom/src/components/vs-input/stories/VsInput.stories.ts
+++ b/packages/vlossom/src/components/vs-input/stories/VsInput.stories.ts
@@ -10,6 +10,7 @@ import {
 import { UIState } from '@/declaration';
 import { VsIcon } from '@/icons';
 import { InputType } from './../types';
+import VsContainer from '@/components/vs-container/VsContainer.vue';
 import VsInput from './../VsInput.vue';
 
 import type { Meta, StoryObj } from '@storybook/vue3';
@@ -207,6 +208,42 @@ export const Append: Story = {
     },
     parameters: {
         chromatic: chromaticParameters.theme,
+    },
+};
+
+export const Width: Story = {
+    render: (args: any) => ({
+        components: { VsInput, VsContainer },
+        setup() {
+            return { args };
+        },
+        template: `
+            <vs-container>
+                <vs-input v-bind="args" />
+                <vs-input v-bind="args" />
+            </vs-container>
+        `,
+    }),
+    args: {
+        width: { sm: '200px', md: '300px', lg: '400px', xl: '500px' },
+    },
+};
+
+export const Grid: Story = {
+    render: (args: any) => ({
+        components: { VsInput, VsContainer },
+        setup() {
+            return { args };
+        },
+        template: `
+            <vs-container grid>
+                <vs-input v-bind="args" />
+                <vs-input v-bind="args" />
+            </vs-container>
+        `,
+    }),
+    args: {
+        grid: { sm: 6, md: 4, lg: 3 },
     },
 };
 

--- a/packages/vlossom/src/components/vs-radio-set/stories/VsRadioSet.stories.ts
+++ b/packages/vlossom/src/components/vs-radio-set/stories/VsRadioSet.stories.ts
@@ -144,7 +144,7 @@ export const Grid: Story = {
             return { args };
         },
         template: `
-            <vs-container>
+            <vs-container grid>
                 <vs-radio-set v-bind="args" />
                 <vs-radio-set v-bind="args" />
             </vs-container>

--- a/packages/vlossom/src/components/vs-radio/stories/VsRadio.stories.ts
+++ b/packages/vlossom/src/components/vs-radio/stories/VsRadio.stories.ts
@@ -141,7 +141,7 @@ export const Grid: Story = {
             return { args };
         },
         template: `
-            <vs-container>
+            <vs-container grid>
                 <vs-radio v-bind="args" name="grid" radio-value="test1" />
                 <vs-radio v-bind="args" name="grid" radio-value="test2" />
             </vs-container>

--- a/packages/vlossom/src/components/vs-select/stories/VsSelect.stories.ts
+++ b/packages/vlossom/src/components/vs-select/stories/VsSelect.stories.ts
@@ -231,7 +231,7 @@ export const Grid: Story = {
             return { args };
         },
         template: `
-            <vs-container>
+            <vs-container grid>
                 <vs-select v-bind="args" />
                 <vs-select v-bind="args" />
             </vs-container>

--- a/packages/vlossom/src/components/vs-textarea/stories/VsTextarea.stories.ts
+++ b/packages/vlossom/src/components/vs-textarea/stories/VsTextarea.stories.ts
@@ -141,7 +141,7 @@ export const Grid: Story = {
             return { args };
         },
         template: `
-            <vs-container>
+            <vs-container grid>
                 <vs-textarea v-bind="args" />
                 <vs-textarea v-bind="args" />
             </vs-container>

--- a/packages/vlossom/src/composables/__tests__/responsive-composable.test.ts
+++ b/packages/vlossom/src/composables/__tests__/responsive-composable.test.ts
@@ -24,7 +24,7 @@ describe('responsive-composable (useResponsive)', () => {
 
         describe('각 breakpoints에 해당하는 class와 style이 적용된다', () => {
             it('모든 breakpoints에 width 값이 설정되어 있는 경우', () => {
-                const width = ref({ xl: '100px', lg: '150px', md: '200px', sm: '250px', base: '300px' });
+                const width = ref({ xl: '100px', lg: '150px', md: '200px', sm: '250px', xs: '300px' });
                 const grid = ref({});
                 const { responsiveClasses, responsiveStyles } = useResponsive(width, grid);
 
@@ -36,7 +36,7 @@ describe('responsive-composable (useResponsive)', () => {
                     'vs-width-xl',
                 ]);
                 expect(responsiveStyles.value).toEqual({
-                    '--vs-width-base': '300px',
+                    '--vs-width-xs': '300px',
                     '--vs-width-sm': '250px',
                     '--vs-width-md': '200px',
                     '--vs-width-lg': '150px',
@@ -61,7 +61,7 @@ describe('responsive-composable (useResponsive)', () => {
     describe('grid', () => {
         it('모든 breakpoints에 grid 값이 설정되어 있는 경우', () => {
             const width = ref(null);
-            const grid = ref({ xl: 1, lg: 2, md: 3, sm: 4, base: 6 });
+            const grid = ref({ xl: 1, lg: 2, md: 3, sm: 4, xs: 6 });
             const { responsiveClasses, responsiveStyles } = useResponsive(width, grid);
 
             expect(responsiveClasses.value).toEqual([
@@ -72,7 +72,7 @@ describe('responsive-composable (useResponsive)', () => {
                 'vs-grid-xl',
             ]);
             expect(responsiveStyles.value).toEqual({
-                '--vs-grid-base': '6',
+                '--vs-grid-xs': '6',
                 '--vs-grid-sm': '4',
                 '--vs-grid-md': '3',
                 '--vs-grid-lg': '2',

--- a/packages/vlossom/src/composables/responsive-composable.ts
+++ b/packages/vlossom/src/composables/responsive-composable.ts
@@ -78,9 +78,9 @@ export function useResponsive(
         const styles: Record<string, string> = {};
         if (hasValue(width.value)) {
             if (utils.object.isPlainObject(width.value)) {
-                const { base, sm, md, lg, xl } = width.value;
+                const { xs, sm, md, lg, xl } = width.value;
                 const widthStyles = {
-                    ...(hasValue(base) && { ['--vs-width-base']: utils.string.convertToStringSize(base) }),
+                    ...(hasValue(xs) && { ['--vs-width-xs']: utils.string.convertToStringSize(xs) }),
                     ...(hasValue(sm) && { ['--vs-width-sm']: utils.string.convertToStringSize(sm) }),
                     ...(hasValue(md) && { ['--vs-width-md']: utils.string.convertToStringSize(md) }),
                     ...(hasValue(lg) && { ['--vs-width-lg']: utils.string.convertToStringSize(lg) }),
@@ -95,9 +95,9 @@ export function useResponsive(
 
         if (hasValue(grid.value)) {
             if (utils.object.isPlainObject(grid.value)) {
-                const { base, sm, md, lg, xl } = grid.value;
+                const { xs, sm, md, lg, xl } = grid.value;
                 const gridStyles = {
-                    ...(hasValue(base) && { ['--vs-grid-base']: base?.toString() }),
+                    ...(hasValue(xs) && { ['--vs-grid-xs']: xs?.toString() }),
                     ...(hasValue(sm) && { ['--vs-grid-sm']: sm?.toString() }),
                     ...(hasValue(md) && { ['--vs-grid-md']: md?.toString() }),
                     ...(hasValue(lg) && { ['--vs-grid-lg']: lg?.toString() }),
@@ -106,7 +106,7 @@ export function useResponsive(
                 Object.assign(styles, gridStyles);
             } else {
                 const gridStyles = {
-                    '--vs-grid-base': grid.value?.toString(),
+                    '--vs-grid-xs': grid.value?.toString(),
                 };
                 Object.assign(styles, gridStyles);
             }

--- a/packages/vlossom/src/declaration/types.ts
+++ b/packages/vlossom/src/declaration/types.ts
@@ -86,7 +86,7 @@ export interface VlossomOptions {
 }
 
 export interface Breakpoints {
-    base?: string | number;
+    xs?: string | number;
     sm?: string | number;
     md?: string | number;
     lg?: string | number;

--- a/packages/vlossom/src/styles/mixin.scss
+++ b/packages/vlossom/src/styles/mixin.scss
@@ -30,12 +30,12 @@
 }
 
 @mixin responsive {
-    $width-base: var(--vs-width-base);
+    $width-xs: var(--vs-width-xs);
     $width-sm: var(--vs-width-sm);
     $width-md: var(--vs-width-md);
     $width-lg: var(--vs-width-lg);
     $width-xl: var(--vs-width-xl);
-    $grid-base: var(--vs-grid-base);
+    $grid-xs: var(--vs-grid-xs);
     $grid-sm: var(--vs-grid-sm);
     $grid-md: var(--vs-grid-md);
     $grid-lg: var(--vs-grid-lg);
@@ -43,8 +43,8 @@
 
     .vs-response {
         box-sizing: border-box;
-        width: $width-base;
-        grid-column-start: span $grid-base;
+        width: $width-xs;
+        grid-column-start: span $grid-xs;
     }
 
     @container (min-width: 480px) {

--- a/packages/vlossom/src/styles/variables.scss
+++ b/packages/vlossom/src/styles/variables.scss
@@ -14,8 +14,8 @@ $variables: (
     radius-xl: 1rem,
 
     // responsive
-    grid-base: 12,
-    width-base: 100%,
+    grid-xs: 12,
+    width-xs: 100%,
     responsive-xl: 1200px,
     responsive-lg: 992px,
     responsive-md: 768px,


### PR DESCRIPTION
## Type of PR (check all applicable)
-   [x] Fix Bug (fix)

## Summary
- 베이스 `BreakPoint`의 명칭을 `base`에서 `xs`로 변경합니다
- `vs-container`에서 `grid-template-columns`의 반복단위를 `1fr`에서 `minmax(0, 1fr)`로 변경합니다
- input component들의 Grid 스토리에서, vs-container에 `grid` props가 누락되어 있었으므로 이를 수정합니다.
