### PR TITLE
fix(VsImage): apply vs-skeleton on vs-image

### DIFF
--- a/packages/vlossom/src/components/vs-image/VsImage.scss
+++ b/packages/vlossom/src/components/vs-image/VsImage.scss
@@ -1,12 +1,20 @@
 .vs-image {
     position: relative;
 
-    .vs-image {
-        width: var(--vs-image-width, 100%);
-        height: var(--vs-image-height, 100%);
+    .vs-image-tag {
+        position: relative;
+        width: var(--vs-image-width);
+        height: var(--vs-image-height);
         border: var(--vs-image-border, none);
         border-radius: var(--vs-image-borderRadius, 0);
         object-fit: var(--vs-image-objectFit, contain);
+
+        &.vs-hidden {
+            position: absolute;
+            top: 0;
+            left: 0;
+            opacity: 0;
+        }
     }
 
     .vs-alt-text {

--- a/packages/vlossom/src/components/vs-image/VsImage.vue
+++ b/packages/vlossom/src/components/vs-image/VsImage.vue
@@ -1,7 +1,20 @@
 <template>
     <div class="vs-image" ref="vsImageRef" :style="computedStyleSet">
-        <img class="vs-image" :src="computedSrc" :alt="alt" @error.stop="onImageError" />
-        <span class="vs-alt-text" v-if="isNoImage">{{ alt }}</span>
+        <vs-skeleton
+            v-if="isLoading"
+            class="vs-image-skeleton"
+            :style="{ width: 'var(--vs-image-width)', height: 'var(--vs-image-height)' }"
+        >
+            <slot name="loading" />
+        </vs-skeleton>
+        <img
+            :class="['vs-image-tag', { 'vs-hidden': isLoading }]"
+            :src="computedSrc"
+            :alt="alt"
+            @load.stop="onImageLoad"
+            @error.stop="onImageError"
+        />
+        <span class="vs-alt-text" v-if="!isLoading && isNoImage">{{ alt }}</span>
     </div>
 </template>
 
@@ -11,12 +24,14 @@ import { useStyleSet } from '@/composables';
 import { useIntersectionObserver } from '@vueuse/core';
 import { VsComponent } from '@/declaration';
 import NO_IMAGE from '@/assets/no-image.png';
+import VsSkeleton from './../vs-skeleton/VsSkeleton.vue';
 
 import type { VsImageStyleSet } from './types';
 
 const name = VsComponent.VsImage;
 export default defineComponent({
     name,
+    components: { VsSkeleton },
     props: {
         styleSet: { type: [String, Object] as PropType<string | VsImageStyleSet> },
         alt: { type: String, default: '' },
@@ -34,6 +49,7 @@ export default defineComponent({
 
         const hasIntersectionObserver = window && window.IntersectionObserver !== undefined;
 
+        const isLoading = ref(true); // check if img tag src is loaded
         const isLoaded = ref(hasIntersectionObserver && lazy.value ? false : true);
         const isFallback = ref(false);
         const isNoImage = ref(false);
@@ -57,12 +73,17 @@ export default defineComponent({
             isNoImage.value = false;
         });
 
+        function onImageLoad() {
+            isLoading.value = false;
+        }
+
         function onImageError() {
             if (!isLoaded.value) {
                 return;
             }
 
             emit('error');
+            isLoading.value = false;
 
             if (fallback.value && !isFallback.value) {
                 isFallback.value = true;
@@ -81,7 +102,7 @@ export default defineComponent({
             });
         }
 
-        return { computedStyleSet, computedSrc, vsImageRef, isNoImage, onImageError };
+        return { computedStyleSet, computedSrc, vsImageRef, isLoading, isNoImage, onImageLoad, onImageError };
     },
 });
 </script>

--- a/packages/vlossom/src/components/vs-image/VsImage.vue
+++ b/packages/vlossom/src/components/vs-image/VsImage.vue
@@ -24,7 +24,7 @@ import { useStyleSet } from '@/composables';
 import { useIntersectionObserver } from '@vueuse/core';
 import { VsComponent } from '@/declaration';
 import NO_IMAGE from '@/assets/no-image.png';
-import VsSkeleton from './../vs-skeleton/VsSkeleton.vue';
+import VsSkeleton from '@/components/vs-skeleton/VsSkeleton.vue';
 
 import type { VsImageStyleSet } from './types';
 

--- a/packages/vlossom/src/components/vs-skeleton/VsSkeleton.scss
+++ b/packages/vlossom/src/components/vs-skeleton/VsSkeleton.scss
@@ -3,13 +3,31 @@
     width: var(--vs-skeleton-width, 100%);
     height: var(--vs-skeleton-height, 100%);
     border-radius: var(--vs-skeleton-borderRadius, calc(var(--vs-radius-ratio) * var(--vs-radius-sm)));
-    background-color: var(--vs-skeleton-backgroundColor, var(--vs-line-color));
-    animation: skeleton-blink 0.6s infinite alternate;
+    overflow: hidden;
+
+    .vs-skeleton-bg {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background-color: var(--vs-skeleton-backgroundColor, var(--vs-line-color));
+        animation: skeleton-blink 0.8s infinite alternate;
+    }
+    .vs-skeleton-inner {
+        position: relative;
+        width: 100%;
+        height: 100%;
+        color: var(--vs-skeleton-color, var(--vs-font-color));
+        display: flex;
+        justify-content: center;
+        align-items: center;
+    }
 }
 
 @keyframes skeleton-blink {
     0% {
-        opacity: 0.1;
+        opacity: 0.15;
     }
 
     100% {

--- a/packages/vlossom/src/components/vs-skeleton/VsSkeleton.vue
+++ b/packages/vlossom/src/components/vs-skeleton/VsSkeleton.vue
@@ -1,6 +1,9 @@
 <template>
     <div :class="['vs-skeleton', colorSchemeClass]" :style="computedStyleSet">
-        <slot />
+        <div class="vs-skeleton-bg" />
+        <div class="vs-skeleton-inner">
+            <slot />
+        </div>
     </div>
 </template>
 

--- a/packages/vlossom/src/components/vs-table/VsTable.scss
+++ b/packages/vlossom/src/components/vs-table/VsTable.scss
@@ -9,12 +9,11 @@ $tableBorder: var(--vs-table-border, 1px solid var(--vs-line-color));
     .vs-table-table {
         min-width: 100%;
         border-spacing: 0 !important;
-        margin-bottom: 0.6rem;
 
         .vs-table-caption {
             caption-side: var(--vs-table-captionSide, bottom);
             text-align: var(--vs-table-captionTextAlign, center);
-            padding: 1rem 0;
+            padding: var(--vs-table-captionPadding, 0.8rem 0);
             color: var(--vs-table-captionFontColor, var(--vs-font-color));
             font-size: var(--vs-table-captionFontSize, var(--vs-font-size-sm));
             font-weight: var(--vs-table-captionFontWeight);
@@ -34,7 +33,7 @@ $tableBorder: var(--vs-table-border, 1px solid var(--vs-line-color));
         }
 
         .vs-table-thead .vs-table-tr {
-            background-color: var(--vs-table-headerBackgroundColor, var(--vs-area-bg-active));
+            background-color: var(--vs-table-headerBackgroundColor, var(--vs-comp-bg));
             border: var(--vs-table-headerBorder, 1px solid var(--vs-line-color));
 
             &.vs-search {
@@ -206,7 +205,8 @@ $tableBorder: var(--vs-table-border, 1px solid var(--vs-line-color));
     align-items: center;
     flex-wrap: wrap;
     gap: 0.5rem;
-    margin-bottom: 0.6rem;
+    margin-top: 0.8rem;
+    margin-bottom: 0.8rem;
 
     .vs-table-pagination-options {
         margin-left: 2rem;
@@ -240,8 +240,6 @@ $tableBorder: var(--vs-table-border, 1px solid var(--vs-line-color));
 
 @container (max-width: 576px) {
     .vs-table.vs-responsive .vs-table-wrap {
-        margin-bottom: 2rem;
-
         .vs-table-table .vs-table-thead .vs-table-tr {
             grid-template-columns: none !important;
             margin-bottom: 0.4rem;

--- a/packages/vlossom/src/components/vs-table/types.ts
+++ b/packages/vlossom/src/components/vs-table/types.ts
@@ -41,6 +41,7 @@ export interface VsTableStyleSet {
     captionFontColor?: string;
     captionFontSize?: string;
     captionFontWeight?: string | number;
+    captionPadding?: string;
     captionSide?: string;
     captionTextAlign?: string;
     fontColor?: string;


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary
vs-image에 vs-skeleton을 적용합니다

## Description
- vs-skeleton을 vs-image loading 중에 보여줍니다
- vs-image에서 img tag는 absolute, opacity 0 상태로 존재하다가 src를 불러오면(load event) 원래 자리에 나타납니다
- vs-skeleton의 slot을 제대로 보여주기 위해서 DOM 구조를 변경합니다
- vs-table의 스타일을 일부 수정합니다

<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
