### PR TITLE
fix(VsInput): change input type prop as union type

### DIFF
--- a/packages/vlossom/src/components/index.ts
+++ b/packages/vlossom/src/components/index.ts
@@ -46,7 +46,7 @@ export { default as VsImage } from './vs-image/VsImage.vue';
 export { default as VsIndexItem } from './vs-index-view/VsIndexItem.vue';
 export { default as VsIndexView } from './vs-index-view/VsIndexView.vue';
 
-export { InputType, type VsInputStyleSet } from './vs-input/types';
+export type { InputType, VsInputStyleSet } from './vs-input/types';
 export { default as VsInput } from './vs-input/VsInput.vue';
 
 export { default as VsInputWrapper } from './vs-input-wrapper/VsInputWrapper.vue';

--- a/packages/vlossom/src/components/vs-divider/VsDivider.scss
+++ b/packages/vlossom/src/components/vs-divider/VsDivider.scss
@@ -30,7 +30,7 @@ $divider-border: var(--vs-divider-border, 1px solid var(--vs-primary-comp-bg));
 }
 
 @container (max-width: 768px) {
-    .vs-divider.vs-vertical.vs-responsive {
+    .vs-divider.vs-vertical.vs-divider-responsive {
         @include vs-divider-horizontal;
     }
 }

--- a/packages/vlossom/src/components/vs-divider/VsDivider.vue
+++ b/packages/vlossom/src/components/vs-divider/VsDivider.vue
@@ -28,7 +28,7 @@ export default defineComponent({
         const classObj = computed(() => ({
             'vs-horizontal': !vertical.value,
             'vs-vertical': vertical.value,
-            'vs-responsive': responsive.value,
+            'vs-divider-responsive': responsive.value,
         }));
 
         return {

--- a/packages/vlossom/src/components/vs-divider/__tests__/vs-divider.test.ts
+++ b/packages/vlossom/src/components/vs-divider/__tests__/vs-divider.test.ts
@@ -57,7 +57,7 @@ describe('vs-divider', () => {
 
             //then
             expect(wrapper.classes('vs-vertical')).toBe(true);
-            expect(wrapper.classes('vs-responsive')).toBe(true);
+            expect(wrapper.classes('vs-divider-responsive')).toBe(true);
         });
     });
 });

--- a/packages/vlossom/src/components/vs-input/VsInput.vue
+++ b/packages/vlossom/src/components/vs-input/VsInput.vue
@@ -104,7 +104,7 @@ export default defineComponent({
             default: Number.MIN_SAFE_INTEGER,
             validator: (value: number | string) => utils.props.checkValidNumber(name, 'min', value),
         },
-        type: { type: String as PropType<InputType>, default: InputType.Text },
+        type: { type: String as PropType<InputType>, default: 'text' },
         // v-model
         modelValue: {
             type: [String, Number] as PropType<InputValueType>,
@@ -159,7 +159,7 @@ export default defineComponent({
 
         const { requiredCheck, maxCheck, minCheck } = useVsInputRules(required, max, min, type);
 
-        const isNumberInput = computed(() => type.value === InputType.Number);
+        const isNumberInput = computed(() => type.value === 'number');
 
         function convertValue(v: InputValueType | undefined): InputValueType {
             if (v === undefined || v === null || v === '') {
@@ -257,7 +257,6 @@ export default defineComponent({
             classObj,
             colorSchemeClass,
             computedStyleSet,
-            InputType,
             inputValue,
             updateValue,
             inputRef,

--- a/packages/vlossom/src/components/vs-input/__tests__/vs-input.test.ts
+++ b/packages/vlossom/src/components/vs-input/__tests__/vs-input.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from 'vitest';
 import { mount } from '@vue/test-utils';
 import { nextTick } from 'vue';
 import { UIState } from '@/declaration';
-import { InputType } from './../types';
 import VsInput from './../VsInput.vue';
 
 function mountComponent() {
@@ -100,7 +99,7 @@ describe('vs-input', () => {
                     props: {
                         modelValue: 123,
                         'onUpdate:modelValue': (e) => wrapper.setProps({ modelValue: e }),
-                        type: InputType.Number,
+                        type: 'number',
                     },
                 });
 
@@ -114,7 +113,7 @@ describe('vs-input', () => {
                     props: {
                         modelValue: 8008,
                         'onUpdate:modelValue': (e) => wrapper.setProps({ modelValue: e }),
-                        type: InputType.Number,
+                        type: 'number',
                     },
                 });
 
@@ -131,7 +130,7 @@ describe('vs-input', () => {
                     props: {
                         modelValue: 5000,
                         'onUpdate:modelValue': (e) => wrapper.setProps({ modelValue: e }),
-                        type: InputType.Number,
+                        type: 'number',
                     },
                 });
 
@@ -148,7 +147,7 @@ describe('vs-input', () => {
                     props: {
                         modelValue: '123',
                         'onUpdate:modelValue': (e) => wrapper.setProps({ modelValue: e }),
-                        type: InputType.Number,
+                        type: 'number',
                     },
                 });
 
@@ -438,7 +437,7 @@ describe('vs-input', () => {
                 props: {
                     modelValue: 0,
                     'onUpdate:modelValue': (e) => wrapper.setProps({ modelValue: e }),
-                    type: InputType.Number,
+                    type: 'number',
                     max: 3,
                 },
             });
@@ -459,7 +458,7 @@ describe('vs-input', () => {
                 props: {
                     modelValue: 4,
                     'onUpdate:modelValue': (e) => wrapper.setProps({ modelValue: e }),
-                    type: InputType.Number,
+                    type: 'number',
                     min: 3,
                 },
             });

--- a/packages/vlossom/src/components/vs-input/stories/VsInput.chromatic.stories.ts
+++ b/packages/vlossom/src/components/vs-input/stories/VsInput.chromatic.stories.ts
@@ -1,7 +1,6 @@
 import { colorScheme, getMetaArguments, state } from '@/storybook';
 import { UIState } from '@/declaration';
 import { VsIcon } from '@/icons';
-import { InputType } from './../types';
 import VsInput from './../VsInput.vue';
 
 import type { Meta, StoryObj } from '@storybook/vue3';
@@ -67,7 +66,7 @@ const meta: Meta<typeof VsInput> = {
         colorScheme,
         type: {
             control: 'radio',
-            options: Object.values(InputType),
+            options: ['email', 'number', 'password', 'search', 'tel', 'text', 'url'],
         },
         state,
     },

--- a/packages/vlossom/src/components/vs-input/stories/VsInput.stories.ts
+++ b/packages/vlossom/src/components/vs-input/stories/VsInput.stories.ts
@@ -9,7 +9,6 @@ import {
 } from '@/storybook';
 import { UIState } from '@/declaration';
 import { VsIcon } from '@/icons';
-import { InputType } from './../types';
 import VsContainer from '@/components/vs-container/VsContainer.vue';
 import VsInput from './../VsInput.vue';
 
@@ -33,7 +32,7 @@ const meta: Meta<typeof VsInput> = {
         colorScheme,
         type: {
             control: 'radio',
-            options: Object.values(InputType),
+            options: ['email', 'number', 'password', 'search', 'tel', 'text', 'url'],
         },
         state,
     },
@@ -132,7 +131,7 @@ export const Type: Story = {
     render: () => ({
         components: { VsInput },
         setup() {
-            const types = Object.values(InputType);
+            const types = ['email', 'number', 'password', 'search', 'tel', 'text', 'url'];
 
             return { types };
         },

--- a/packages/vlossom/src/components/vs-input/types.ts
+++ b/packages/vlossom/src/components/vs-input/types.ts
@@ -1,14 +1,6 @@
 export type InputValueType = string | number | null;
 
-export enum InputType {
-    Email = 'email',
-    Number = 'number',
-    Password = 'password',
-    Search = 'search',
-    Tel = 'tel',
-    Text = 'text',
-    Url = 'url',
-}
+export type InputType = 'email' | 'number' | 'password' | 'search' | 'tel' | 'text' | 'url';
 
 export interface VsInputStyleSet {
     appendBackgroundColor?: string;

--- a/packages/vlossom/src/components/vs-input/vs-input-rules.ts
+++ b/packages/vlossom/src/components/vs-input/vs-input-rules.ts
@@ -17,11 +17,11 @@ export function useVsInputRules(
 
     function maxCheck(v: InputValueType) {
         const limit = Number(max.value);
-        if (type.value === InputType.Number && typeof v === 'number' && v > limit) {
+        if (type.value === 'number' && typeof v === 'number' && v > limit) {
             return 'max value: ' + max.value;
         }
 
-        if (type.value !== InputType.Number && typeof v === 'string' && v.length > limit) {
+        if (type.value !== 'number' && typeof v === 'string' && v.length > limit) {
             return 'max length: ' + max.value;
         }
 
@@ -30,11 +30,11 @@ export function useVsInputRules(
 
     function minCheck(v: InputValueType) {
         const limit = Number(min.value);
-        if (type.value === InputType.Number && typeof v === 'number' && v < limit) {
+        if (type.value === 'number' && typeof v === 'number' && v < limit) {
             return 'min value: ' + min.value;
         }
 
-        if (type.value !== InputType.Number && typeof v === 'string' && v.length < limit) {
+        if (type.value !== 'number' && typeof v === 'string' && v.length < limit) {
             return 'min length: ' + min.value;
         }
 


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary
vs-input에 있는 type props를 enum이 아닌 union type으로 정의합니다

<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
