### PR TITLE
fix(VsImage): add skeleton props (215719)

### DIFF
--- a/packages/vlossom/src/components/vs-image/VsImage.vue
+++ b/packages/vlossom/src/components/vs-image/VsImage.vue
@@ -1,11 +1,11 @@
 <template>
     <div class="vs-image" ref="vsImageRef" :style="computedStyleSet">
         <vs-skeleton
-            v-if="isLoading"
+            v-if="skeleton && isLoading"
             class="vs-image-skeleton"
             :style="{ width: 'var(--vs-image-width)', height: 'var(--vs-image-height)' }"
         >
-            <slot name="loading" />
+            <slot name="skeleton" />
         </vs-skeleton>
         <img
             :class="['vs-image-tag', { 'vs-hidden': isLoading }]"
@@ -37,6 +37,7 @@ export default defineComponent({
         alt: { type: String, default: '' },
         fallback: { type: String, default: '' },
         lazy: { type: Boolean, default: false },
+        skeleton: { type: Boolean, default: false },
         src: { type: String, required: true, default: '' },
     },
     emits: ['error'],


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary
vs-image skeleton을 기본값으로 하지 않고, props로 설정하도록 변경

## Description
- vs-image에 skeleton props를 추가합니다
- 기존 loading으로 되어 있던 slot name을 skeleton으로 변경합니다

<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
