### PR TITLE
fix(input-components): change background color from transparent to --vs-no-color

### DIFF
--- a/packages/vlossom/src/components/vs-file-input/VsFileInput.scss
+++ b/packages/vlossom/src/components/vs-file-input/VsFileInput.scss
@@ -8,7 +8,7 @@ $file-input-height-dense: var(--vs-file-input-height, var(--vs-input-comp-height
     display: flex;
     align-items: center;
     overflow: hidden;
-    background-color: var(--vs-file-input-backgroundColor, transparent);
+    background-color: var(--vs-file-input-backgroundColor, var(--vs-area-bg));
     border: var(--vs-file-input-border, 1px solid var(--vs-line-color));
     border-radius: var(--vs-file-input-borderRadius, calc(var(--vs-radius-ratio) * var(--vs-radius)));
     height: $file-input-height;
@@ -105,7 +105,7 @@ $file-input-height-dense: var(--vs-file-input-height, var(--vs-input-comp-height
     }
 
     &.vs-dragging {
-        background-color: var(--vs-file-input-dragBackgroundColor, transparent);
+        background-color: var(--vs-file-input-dragBackgroundColor, var(--vs-area-bg));
     }
 
     &.vs-readonly {

--- a/packages/vlossom/src/components/vs-file-input/VsFileInput.scss
+++ b/packages/vlossom/src/components/vs-file-input/VsFileInput.scss
@@ -8,7 +8,7 @@ $file-input-height-dense: var(--vs-file-input-height, var(--vs-input-comp-height
     display: flex;
     align-items: center;
     overflow: hidden;
-    background-color: var(--vs-file-input-backgroundColor, var(--vs-area-bg));
+    background-color: var(--vs-file-input-backgroundColor, var(--vs-no-color));
     border: var(--vs-file-input-border, 1px solid var(--vs-line-color));
     border-radius: var(--vs-file-input-borderRadius, calc(var(--vs-radius-ratio) * var(--vs-radius)));
     height: $file-input-height;
@@ -105,7 +105,7 @@ $file-input-height-dense: var(--vs-file-input-height, var(--vs-input-comp-height
     }
 
     &.vs-dragging {
-        background-color: var(--vs-file-input-dragBackgroundColor, var(--vs-area-bg));
+        background-color: var(--vs-file-input-dragBackgroundColor, var(--vs-no-color));
     }
 
     &.vs-readonly {

--- a/packages/vlossom/src/components/vs-input/VsInput.scss
+++ b/packages/vlossom/src/components/vs-input/VsInput.scss
@@ -5,7 +5,7 @@
     display: flex;
     align-items: center;
     overflow: hidden;
-    background-color: var(--vs-input-backgroundColor, var(--vs-area-bg));
+    background-color: var(--vs-input-backgroundColor, var(--vs-no-color));
     border: var(--vs-input-border, solid 1px var(--vs-line-color));
     border-radius: var(--vs-input-borderRadius, calc(var(--vs-radius-ratio) * var(--vs-radius)));
     height: var(--vs-input-height, var(--vs-input-comp-height));

--- a/packages/vlossom/src/components/vs-input/VsInput.scss
+++ b/packages/vlossom/src/components/vs-input/VsInput.scss
@@ -5,7 +5,7 @@
     display: flex;
     align-items: center;
     overflow: hidden;
-    background-color: var(--vs-input-backgroundColor, transparent);
+    background-color: var(--vs-input-backgroundColor, var(--vs-area-bg));
     border: var(--vs-input-border, solid 1px var(--vs-line-color));
     border-radius: var(--vs-input-borderRadius, calc(var(--vs-radius-ratio) * var(--vs-radius)));
     height: var(--vs-input-height, var(--vs-input-comp-height));

--- a/packages/vlossom/src/components/vs-select/VsSelect.scss
+++ b/packages/vlossom/src/components/vs-select/VsSelect.scss
@@ -5,7 +5,7 @@
     justify-content: space-between;
     align-items: center;
     flex-wrap: nowrap;
-    background-color: var(--vs-select-backgroundColor, var(--vs-area-bg));
+    background-color: var(--vs-select-backgroundColor, var(--vs-no-color));
     border: var(--vs-select-border, 1px solid var(--vs-line-color));
     min-height: var(--vs-select-height, var(--vs-input-comp-height));
     border-radius: var(--vs-select-borderRadius, calc(var(--vs-radius-ratio) * var(--vs-radius)));

--- a/packages/vlossom/src/components/vs-select/VsSelect.scss
+++ b/packages/vlossom/src/components/vs-select/VsSelect.scss
@@ -5,7 +5,7 @@
     justify-content: space-between;
     align-items: center;
     flex-wrap: nowrap;
-    background-color: var(--vs-select-backgroundColor, transparent);
+    background-color: var(--vs-select-backgroundColor, var(--vs-area-bg));
     border: var(--vs-select-border, 1px solid var(--vs-line-color));
     min-height: var(--vs-select-height, var(--vs-input-comp-height));
     border-radius: var(--vs-select-borderRadius, calc(var(--vs-radius-ratio) * var(--vs-radius)));

--- a/packages/vlossom/src/components/vs-textarea/VsTextarea.scss
+++ b/packages/vlossom/src/components/vs-textarea/VsTextarea.scss
@@ -11,8 +11,8 @@
     font-size: var(--vs-textarea-fontSize, var(--vs-font-size));
     border: var(--vs-textarea-border, solid 1px var(--vs-line-color));
     border-radius: var(--vs-textarea-borderRadius, calc(var(--vs-radius-ratio) * var(--vs-radius)));
-    padding: 0.6rem;
-    resize: vertical;
+    padding: var(--vs-textarea-padding, 0.6rem 1.2rem);
+    resize: var(--vs-textarea-resize, vertical);
 
     &.vs-dense {
         font-size: var(--vs-textarea-fontSize, var(--vs-font-size-sm));

--- a/packages/vlossom/src/components/vs-textarea/VsTextarea.scss
+++ b/packages/vlossom/src/components/vs-textarea/VsTextarea.scss
@@ -6,7 +6,7 @@
     overflow: hidden;
     width: 100%;
     height: var(--vs-textarea-height, 10rem);
-    background-color: var(--vs-textarea-backgroundColor, var(--vs-area-bg));
+    background-color: var(--vs-textarea-backgroundColor, var(--vs-no-color));
     color: var(--vs-textarea-fontColor, var(--vs-font-color));
     font-size: var(--vs-textarea-fontSize, var(--vs-font-size));
     border: var(--vs-textarea-border, solid 1px var(--vs-line-color));

--- a/packages/vlossom/src/components/vs-textarea/VsTextarea.scss
+++ b/packages/vlossom/src/components/vs-textarea/VsTextarea.scss
@@ -6,7 +6,7 @@
     overflow: hidden;
     width: 100%;
     height: var(--vs-textarea-height, 10rem);
-    background-color: var(--vs-textarea-backgroundColor, transparent);
+    background-color: var(--vs-textarea-backgroundColor, var(--vs-area-bg));
     color: var(--vs-textarea-fontColor, var(--vs-font-color));
     font-size: var(--vs-textarea-fontSize, var(--vs-font-size));
     border: var(--vs-textarea-border, solid 1px var(--vs-line-color));

--- a/packages/vlossom/src/components/vs-textarea/types.ts
+++ b/packages/vlossom/src/components/vs-textarea/types.ts
@@ -7,4 +7,6 @@ export interface VsTextareaStyleSet {
     fontColor?: string;
     fontSize?: string;
     height?: string;
+    padding?: string;
+    resize?: string;
 }


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary
- input components background-color 수정: vs-input, vs-file-input, vs-select, vs-textarea의 background-color를 `--vs-no-color`로 수정합니다.
- vs-textarea style-set 추가: `padding`, `resize` property를 추가합니다.