### PR TITLE
fix(VsTable): modify the width defined in the table header to be applied as max-width

### DIFF
--- a/packages/vlossom/src/components/vs-table/VsTable.vue
+++ b/packages/vlossom/src/components/vs-table/VsTable.vue
@@ -250,7 +250,7 @@ export default defineComponent({
                 return {};
             }
             const gridColumns = headers.value.map((h) => {
-                return h.width || 'minmax(20rem, 1fr)';
+                return h.width ? `minmax(5rem, ${h.width})` : 'minmax(20rem, 1fr)';
             });
             if (hasSelectable.value) {
                 gridColumns.unshift('3.4rem');

--- a/packages/vlossom/src/components/vs-table/VsTable.vue
+++ b/packages/vlossom/src/components/vs-table/VsTable.vue
@@ -250,7 +250,7 @@ export default defineComponent({
                 return {};
             }
             const gridColumns = headers.value.map((h) => {
-                return h.width ? `minmax(5rem, ${h.width})` : 'minmax(20rem, 1fr)';
+                return h.width ? `minmax(5rem, ${h.width})` : 'minmax(5rem, 1fr)';
             });
             if (hasSelectable.value) {
                 gridColumns.unshift('3.4rem');


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary

- Table Header에 정의된 width가 고정 width가 아닌 max-width로 적용되도록 수정합니다
  - 화면 크기가 충분할 때는 max-width를 따르며, 화면 크기가 작으면 최소 5rem의 column width를 확보함
