### PR TITLE
fix(VsCheckboxNode): replace checkbox node icon with clip-path

### DIFF
--- a/packages/vlossom/playground/App.vue
+++ b/packages/vlossom/playground/App.vue
@@ -2,10 +2,11 @@
     <vs-layout>
         <vs-header
             class="header"
-            position="fixed"
+            fixed
             primary
-            height="60px"
+            height="72px"
             :style-set="{ backgroundColor: 'black', fontColor: 'white' }"
+            :style="{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }"
         >
             <div class="logo">
                 <vs-image src="/assets/vlossom-logo.png" :style-set="{ height: '40px', width: '40px' }" />
@@ -21,8 +22,9 @@
         <vs-footer
             class="footer"
             :style-set="{ backgroundColor: 'black', fontColor: '#dfdfdf' }"
-            height="30px"
-            position="fixed"
+            height="40px"
+            fixed
+            :style="{ display: 'flex', justifyContent: 'center', alignItems: 'center' }"
         >
             <span>&copy; {{ currentYear }} Vlossom</span>
         </vs-footer>

--- a/packages/vlossom/src/components/vs-table/VsTable.vue
+++ b/packages/vlossom/src/components/vs-table/VsTable.vue
@@ -28,6 +28,7 @@
                             :id="utils.string.createID()"
                             type="checkbox"
                             :color-scheme="computedColorScheme"
+                            :indeterminate="!isSelectedAll && selectedItems.length > 0"
                             :checked="isSelectedAll"
                             aria-label="select-all"
                             @toggle="onToggleCheck"

--- a/packages/vlossom/src/icons/icons.ts
+++ b/packages/vlossom/src/icons/icons.ts
@@ -11,21 +11,6 @@ export const iconSvgs = {
             <path d="M382-240 154-468l57-57 171 171 367-367 57 57-424 424Z"/>
         </svg>
 	`,
-    // check_box (fill)
-    checkboxChecked: `
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960">
-            <path d="m424-312 282-282-56-56-226 226-114-114-56 56 170 170ZM200-120q-33 0-56.5-23.5T120-200v-560q0-33 23.5-56.5T200-840h560q33 0 56.5 23.5T840-760v560q0 33-23.5 56.5T760-120H200Z"/>
-        </svg>`,
-    // indeterminate_check_box (fill)
-    checkboxIndeterminate: `
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960">
-            <path d="M280-440h400v-80H280v80Zm-80 320q-33 0-56.5-23.5T120-200v-560q0-33 23.5-56.5T200-840h560q33 0 56.5 23.5T840-760v560q0 33-23.5 56.5T760-120H200Z"/>
-        </svg>`,
-    // check_box_outline_blank
-    checkboxUnchecked: `
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960">
-            <path d="M200-120q-33 0-56.5-23.5T120-200v-560q0-33 23.5-56.5T200-840h560q33 0 56.5 23.5T840-760v560q0 33-23.5 56.5T760-120H200Zm0-80h560v-560H200v560Z"/>
-        </svg>`,
     close: `
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960">
             <path

--- a/packages/vlossom/src/nodes/vs-checkbox-node/VsCheckboxNode.scss
+++ b/packages/vlossom/src/nodes/vs-checkbox-node/VsCheckboxNode.scss
@@ -7,70 +7,87 @@ $checkbox-size: var(--vs-checkbox-node-checkboxSize, 2rem);
     display: flex;
     align-items: center;
     justify-content: flex-start;
-    flex-wrap: nowrap;
-    user-select: none;
     min-height: var(--vs-checkbox-node-height, var(--vs-input-comp-height));
 
-    &.vs-indeterminate {
+    .vs-checkbox-wrap {
+        position: relative;
+        display: flex;
+        justify-content: flex-start;
+        align-items: center;
+        flex-wrap: nowrap;
+        user-select: none;
+
         .vs-checkbox-input {
-            background-color: var(--vs-checkbox-node-checkboxColor, var(--vs-primary-comp-bg));
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            appearance: none;
+            margin: 0;
+            width: $checkbox-size;
+            height: $checkbox-size;
+            border: 0.1rem solid var(--vs-checkbox-node-checkboxColor, var(--vs-primary-comp-bg));
+            border-radius: var(--vs-checkbox-node-borderRadius, calc(var(--vs-radius-ratio) * var(--vs-radius-sm)));
+            cursor: pointer;
+            background-color: transparent;
+
+            &.vs-state-box {
+                @include state-box;
+            }
+
+            &:focus-within {
+                @include focus-outline;
+            }
 
             &:before {
-                clip-path: polygon(0% 38%, 100% 38%, 100% 62%, 0% 62%);
-                background-color: var(--vs-primary-comp-font);
-                transform: scale(1);
+                content: '';
+                display: block;
+                width: calc($checkbox-size * 0.6);
+                height: calc($checkbox-size * 0.6);
+                transform: scale(0);
+                transform-origin: center center;
+                transition: 120ms all linear;
+            }
+        }
+
+        .vs-checkbox-label {
+            user-select: none;
+            padding-left: 0.5rem;
+            cursor: pointer;
+            white-space: nowrap;
+            color: var(--vs-checkbox-node-labelFontColor, var(--vs-font-color));
+            font-size: var(--vs-checkbox-node-labelFontSize, var(--vs-font-size));
+        }
+    }
+
+    &.vs-indeterminate {
+        .vs-checkbox-wrap {
+            .vs-checkbox-input {
+                background-color: var(--vs-checkbox-node-checkboxColor, var(--vs-primary-comp-bg));
+
+                &:before {
+                    clip-path: polygon(0% 38%, 100% 38%, 100% 62%, 0% 62%);
+                    background-color: var(--vs-primary-comp-font);
+                    transform: scale(1);
+                }
             }
         }
     }
 
-    .vs-checkbox-input {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        appearance: none;
-        margin: 0;
-        width: $checkbox-size;
-        height: $checkbox-size;
-        border: 0.1rem solid var(--vs-checkbox-node-checkboxColor, var(--vs-primary-comp-bg));
-        border-radius: var(--vs-checkbox-node-borderRadius, calc(var(--vs-radius-ratio) * var(--vs-radius-sm)));
-        cursor: pointer;
-        background-color: transparent;
+    &.vs-checked {
+        .vs-checkbox-wrap {
+            .vs-checkbox-input {
+                background-color: var(--vs-checkbox-node-checkboxColor, var(--vs-primary-comp-bg));
 
-        &.vs-state-box {
-            @include state-box;
+                &:before {
+                    clip-path: polygon(14% 44%, 0 65%, 50% 100%, 100% 16%, 80% 0%, 43% 62%);
+                    background-color: var(--vs-primary-comp-font);
+                    transform: scale(1) rotate(10deg) translateX(-3%);
+                }
+            }
+            .vs-checkbox-label {
+                color: var(--vs-checkbox-node-selectedLabelFontColor, var(--vs-primary-comp-bg));
+            }
         }
-
-        &:focus-within {
-            @include focus-outline;
-        }
-
-        &:before {
-            content: '';
-            display: block;
-            width: calc($checkbox-size * 0.6);
-            height: calc($checkbox-size * 0.6);
-            transform: scale(0);
-            transform-origin: center center;
-            transition: 120ms all linear;
-        }
-
-        &:checked {
-            background-color: var(--vs-checkbox-node-checkboxColor, var(--vs-primary-comp-bg));
-        }
-        &:checked:before {
-            clip-path: polygon(14% 44%, 0 65%, 50% 100%, 100% 16%, 80% 0%, 43% 62%);
-            background-color: var(--vs-primary-comp-font);
-            transform: scale(1) rotate(10deg) translateX(-3%);
-        }
-    }
-
-    .vs-checkbox-label {
-        user-select: none;
-        padding-left: 0.5rem;
-        cursor: pointer;
-        white-space: nowrap;
-        color: var(--vs-checkbox-node-labelFontColor, var(--vs-font-color));
-        font-size: var(--vs-checkbox-node-labelFontSize, var(--vs-font-size));
     }
 
     &.vs-dense {
@@ -82,12 +99,6 @@ $checkbox-size: var(--vs-checkbox-node-checkboxSize, 2rem);
         }
         .vs-checkbox-label {
             font-size: var(--vs-checkbox-node-labelFontSize, var(--vs-font-size-sm));
-        }
-    }
-
-    &.vs-checked {
-        .vs-checkbox-label {
-            color: var(--vs-checkbox-node-selectedLabelFontColor, var(--vs-primary-comp-bg));
         }
     }
 

--- a/packages/vlossom/src/nodes/vs-checkbox-node/VsCheckboxNode.scss
+++ b/packages/vlossom/src/nodes/vs-checkbox-node/VsCheckboxNode.scss
@@ -1,6 +1,6 @@
 @use '@/styles/mixin' as *;
 
-$checkbox-size: var(--vs-checkbox-node-checkboxSize, 2.4rem);
+$checkbox-size: var(--vs-checkbox-node-checkboxSize, 2rem);
 
 .vs-checkbox-node {
     position: relative;
@@ -9,39 +9,58 @@ $checkbox-size: var(--vs-checkbox-node-checkboxSize, 2.4rem);
     justify-content: flex-start;
     flex-wrap: nowrap;
     user-select: none;
-    height: var(--vs-checkbox-node-height, var(--vs-input-comp-height));
+    min-height: var(--vs-checkbox-node-height, var(--vs-input-comp-height));
 
-    .vs-checkbox-wrap {
-        position: relative;
+    &.vs-indeterminate {
+        .vs-checkbox-input {
+            background-color: var(--vs-checkbox-node-checkboxColor, var(--vs-primary-comp-bg));
+
+            &:before {
+                clip-path: polygon(0% 38%, 100% 38%, 100% 62%, 0% 62%);
+                background-color: var(--vs-primary-comp-font);
+                transform: scale(1);
+            }
+        }
+    }
+
+    .vs-checkbox-input {
         display: flex;
         align-items: center;
-        color: var(--vs-checkbox-node-checkboxColor, var(--vs-primary-comp-bg));
+        justify-content: center;
+        appearance: none;
+        margin: 0;
+        width: $checkbox-size;
+        height: $checkbox-size;
+        border: 0.1rem solid var(--vs-checkbox-node-checkboxColor, var(--vs-primary-comp-bg));
         border-radius: var(--vs-checkbox-node-borderRadius, calc(var(--vs-radius-ratio) * var(--vs-radius-sm)));
-        overflow: hidden;
-
-        .vs-check-icon {
-            width: $checkbox-size;
-            height: $checkbox-size;
-        }
-
-        .vs-checkbox-input {
-            position: absolute;
-            top: 0;
-            left: 0;
-            opacity: 0;
-            width: 100%;
-            height: 100%;
-            cursor: pointer;
-        }
+        cursor: pointer;
+        background-color: transparent;
 
         &.vs-state-box {
             @include state-box;
-            outline-offset: 0;
         }
 
         &:focus-within {
             @include focus-outline;
-            outline-offset: 0;
+        }
+
+        &:before {
+            content: '';
+            display: block;
+            width: calc($checkbox-size * 0.6);
+            height: calc($checkbox-size * 0.6);
+            transform: scale(0);
+            transform-origin: center center;
+            transition: 120ms all linear;
+        }
+
+        &:checked {
+            background-color: var(--vs-checkbox-node-checkboxColor, var(--vs-primary-comp-bg));
+        }
+        &:checked:before {
+            clip-path: polygon(14% 44%, 0 65%, 50% 100%, 100% 16%, 80% 0%, 43% 62%);
+            background-color: var(--vs-primary-comp-font);
+            transform: scale(1) rotate(10deg) translateX(-3%);
         }
     }
 
@@ -55,8 +74,12 @@ $checkbox-size: var(--vs-checkbox-node-checkboxSize, 2.4rem);
     }
 
     &.vs-dense {
-        height: var(--vs-checkbox-node-height, var(--vs-input-comp-height-dense));
+        min-height: var(--vs-checkbox-node-height, var(--vs-input-comp-height-dense));
 
+        .vs-checkbox-input {
+            width: var(--vs-checkbox-node-checkboxSize, 1.8rem);
+            height: var(--vs-checkbox-node-checkboxSize, 1.8rem);
+        }
         .vs-checkbox-label {
             font-size: var(--vs-checkbox-node-labelFontSize, var(--vs-font-size-sm));
         }
@@ -70,6 +93,7 @@ $checkbox-size: var(--vs-checkbox-node-checkboxSize, 2.4rem);
 
     &.vs-disabled {
         @include disabled;
+        cursor: default;
     }
 
     &.vs-readonly {

--- a/packages/vlossom/src/nodes/vs-checkbox-node/VsCheckboxNode.vue
+++ b/packages/vlossom/src/nodes/vs-checkbox-node/VsCheckboxNode.vue
@@ -1,27 +1,22 @@
 <template>
-    <div :class="['vs-checkbox-node', colorSchemeClass, classObj]" :style="computedStyleSet">
-        <div :class="['vs-checkbox-wrap', stateClasses]">
-            <vs-icon class="vs-check-icon" :icon="icon" />
-            <input
-                ref="checkboxRef"
-                type="checkbox"
-                class="vs-checkbox-input"
-                :aria-label="ariaLabel"
-                :id="id"
-                :disabled="disabled || readonly"
-                :name="name"
-                :value="convertToString(value)"
-                :checked="checked"
-                :aria-required="required"
-                @click.prevent.stop="onClick"
-                @focus.stop="onFocus"
-                @blur.stop="onBlur"
-            />
-        </div>
-        <label v-if="label || $slots['label']" :for="id" class="vs-checkbox-label">
+    <label :class="['vs-checkbox-node', colorSchemeClass, classObj]" :for="id" :style="computedStyleSet">
+        <input
+            ref="checkboxRef"
+            type="checkbox"
+            :class="['vs-checkbox-input', stateClasses]"
+            :aria-label="ariaLabel"
+            :id="id"
+            :disabled="disabled || readonly"
+            :name="name"
+            :value="convertToString(value)"
+            :aria-required="required"
+            @focus.stop="onFocus"
+            @blur.stop="onBlur"
+        />
+        <div v-if="label || $slots['label']" class="vs-checkbox-label">
             <slot name="label">{{ label }}</slot>
-        </label>
-    </div>
+        </div>
+    </label>
 </template>
 
 <script lang="ts">
@@ -29,13 +24,11 @@ import { computed, defineComponent, nextTick, PropType, Ref, ref, toRefs, watch 
 import { ColorScheme, UIState, VsNode } from '@/declaration';
 import { useColorScheme, useStateClass, useStyleSet } from '@/composables';
 import { utils } from '@/utils';
-import { VsIcon } from '@/icons';
 import { VsCheckboxNodeStyleSet } from './types';
 
 const name = VsNode.VsCheckboxNode;
 export default defineComponent({
     name,
-    components: { VsIcon },
     props: {
         colorScheme: { type: String as PropType<ColorScheme> },
         styleSet: { type: [String, Object] as PropType<string | VsCheckboxNodeStyleSet> },
@@ -70,24 +63,13 @@ export default defineComponent({
             'vs-dense': dense.value,
             'vs-disabled': disabled.value,
             'vs-readonly': readonly.value,
+            'vs-indeterminate': indeterminate.value,
         }));
 
-        const icon = computed(() => {
-            if (checked.value) {
-                return 'checkboxChecked';
-            }
-
-            if (indeterminate.value) {
-                return 'checkboxIndeterminate';
-            }
-
-            return 'checkboxUnchecked';
-        });
-
-        function onClick(event: Event) {
-            emit('change', event);
-            emit('toggle', !checked.value);
-        }
+        // function onClick(event: Event) {
+        //     emit('change', event);
+        //     emit('toggle', !checked.value);
+        // }
 
         function onFocus(event: FocusEvent) {
             emit('focus', event);
@@ -105,24 +87,22 @@ export default defineComponent({
             checkboxRef.value?.blur();
         }
 
-        watch(
-            checked,
-            (value) => {
-                nextTick(() => {
-                    if (checkboxRef.value) {
-                        checkboxRef.value.checked = value;
-                    }
-                });
-            },
-            { immediate: true },
-        );
+        // watch(
+        //     checked,
+        //     (value) => {
+        //         nextTick(() => {
+        //             if (checkboxRef.value) {
+        //                 checkboxRef.value.checked = value;
+        //             }
+        //         });
+        //     },
+        //     { immediate: true },
+        // );
 
         return {
             checkboxRef,
             colorSchemeClass,
             classObj,
-            icon,
-            onClick,
             onFocus,
             onBlur,
             focus,

--- a/packages/vlossom/src/nodes/vs-checkbox-node/VsCheckboxNode.vue
+++ b/packages/vlossom/src/nodes/vs-checkbox-node/VsCheckboxNode.vue
@@ -1,11 +1,11 @@
 <template>
-    <label :class="['vs-checkbox-node', colorSchemeClass, classObj]" :for="id" :style="computedStyleSet">
+    <label :class="['vs-checkbox-node', colorSchemeClass, classObj]" :for="computedId" :style="computedStyleSet">
         <input
             ref="checkboxRef"
             type="checkbox"
             :class="['vs-checkbox-input', stateClasses]"
             :aria-label="ariaLabel"
-            :id="id"
+            :id="computedId"
             :disabled="disabled || readonly"
             :name="name"
             :value="convertToString(value)"
@@ -20,7 +20,7 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, nextTick, PropType, Ref, ref, toRefs, watch } from 'vue';
+import { computed, defineComponent, PropType, Ref, ref, toRefs } from 'vue';
 import { ColorScheme, UIState, VsNode } from '@/declaration';
 import { useColorScheme, useStateClass, useStyleSet } from '@/composables';
 import { utils } from '@/utils';
@@ -36,7 +36,7 @@ export default defineComponent({
         checked: { type: Boolean, default: false },
         dense: { type: Boolean, default: false },
         disabled: { type: Boolean, default: false },
-        id: { type: String, required: true },
+        id: { type: String, default: '' },
         indeterminate: { type: Boolean, default: false },
         label: { type: String, default: '' },
         name: { type: String, default: '' },
@@ -44,11 +44,13 @@ export default defineComponent({
         required: { type: Boolean, default: false },
         state: { type: String as PropType<UIState>, default: UIState.Idle },
         value: { type: null, default: 'true' },
+        // v-model
+        modelValue: { type: null, default: false },
     },
     emits: ['change', 'toggle', 'focus', 'blur'],
     // expose: ['focus', 'blur'],
     setup(props, { emit }) {
-        const { colorScheme, styleSet, checked, indeterminate, dense, disabled, readonly, state } = toRefs(props);
+        const { colorScheme, styleSet, checked, id, indeterminate, dense, disabled, readonly, state } = toRefs(props);
 
         const { colorSchemeClass } = useColorScheme(name, colorScheme);
 
@@ -65,6 +67,9 @@ export default defineComponent({
             'vs-readonly': readonly.value,
             'vs-indeterminate': indeterminate.value,
         }));
+
+        const innerId = utils.string.createID();
+        const computedId = computed(() => id.value || innerId);
 
         // function onClick(event: Event) {
         //     emit('change', event);
@@ -110,6 +115,7 @@ export default defineComponent({
             convertToString: utils.string.convertToString,
             stateClasses,
             computedStyleSet,
+            computedId,
         };
     },
 });

--- a/packages/vlossom/src/nodes/vs-checkbox-node/VsCheckboxNode.vue
+++ b/packages/vlossom/src/nodes/vs-checkbox-node/VsCheckboxNode.vue
@@ -1,26 +1,30 @@
 <template>
-    <label :class="['vs-checkbox-node', colorSchemeClass, classObj]" :for="computedId" :style="computedStyleSet">
-        <input
-            ref="checkboxRef"
-            type="checkbox"
-            :class="['vs-checkbox-input', stateClasses]"
-            :aria-label="ariaLabel"
-            :id="computedId"
-            :disabled="disabled || readonly"
-            :name="name"
-            :value="convertToString(value)"
-            :aria-required="required"
-            @focus.stop="onFocus"
-            @blur.stop="onBlur"
-        />
-        <div v-if="label || $slots['label']" class="vs-checkbox-label">
-            <slot name="label">{{ label }}</slot>
-        </div>
-    </label>
+    <div :class="['vs-checkbox-node', colorSchemeClass, classObj]" :style="computedStyleSet">
+        <label class="vs-checkbox-wrap" :for="computedId">
+            <input
+                ref="checkboxRef"
+                type="checkbox"
+                :class="['vs-checkbox-input', stateClasses]"
+                :aria-label="ariaLabel"
+                :id="computedId"
+                :disabled="disabled || readonly"
+                :name="name"
+                :value="convertToString(value)"
+                :checked="checked"
+                :aria-required="required"
+                @click.prevent.stop="toggle"
+                @focus.stop="onFocus"
+                @blur.stop="onBlur"
+            />
+            <div v-if="label || $slots['label']" class="vs-checkbox-label">
+                <slot name="label">{{ label }}</slot>
+            </div>
+        </label>
+    </div>
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, PropType, Ref, ref, toRefs } from 'vue';
+import { computed, defineComponent, nextTick, PropType, Ref, ref, toRefs, watch } from 'vue';
 import { ColorScheme, UIState, VsNode } from '@/declaration';
 import { useColorScheme, useStateClass, useStyleSet } from '@/composables';
 import { utils } from '@/utils';
@@ -44,8 +48,6 @@ export default defineComponent({
         required: { type: Boolean, default: false },
         state: { type: String as PropType<UIState>, default: UIState.Idle },
         value: { type: null, default: 'true' },
-        // v-model
-        modelValue: { type: null, default: false },
     },
     emits: ['change', 'toggle', 'focus', 'blur'],
     // expose: ['focus', 'blur'],
@@ -71,10 +73,10 @@ export default defineComponent({
         const innerId = utils.string.createID();
         const computedId = computed(() => id.value || innerId);
 
-        // function onClick(event: Event) {
-        //     emit('change', event);
-        //     emit('toggle', !checked.value);
-        // }
+        function toggle(event: Event) {
+            emit('change', event);
+            emit('toggle', !checked.value);
+        }
 
         function onFocus(event: FocusEvent) {
             emit('focus', event);
@@ -92,17 +94,17 @@ export default defineComponent({
             checkboxRef.value?.blur();
         }
 
-        // watch(
-        //     checked,
-        //     (value) => {
-        //         nextTick(() => {
-        //             if (checkboxRef.value) {
-        //                 checkboxRef.value.checked = value;
-        //             }
-        //         });
-        //     },
-        //     { immediate: true },
-        // );
+        watch(
+            checked,
+            (value) => {
+                nextTick(() => {
+                    if (checkboxRef.value) {
+                        checkboxRef.value.checked = value;
+                    }
+                });
+            },
+            { immediate: true },
+        );
 
         return {
             checkboxRef,
@@ -116,6 +118,7 @@ export default defineComponent({
             stateClasses,
             computedStyleSet,
             computedId,
+            toggle,
         };
     },
 });

--- a/packages/vlossom/src/nodes/vs-checkbox-node/__tests__/vs-checkbox-node.test.ts
+++ b/packages/vlossom/src/nodes/vs-checkbox-node/__tests__/vs-checkbox-node.test.ts
@@ -3,81 +3,15 @@ import { mount } from '@vue/test-utils';
 import VsCheckboxNode from './../VsCheckboxNode.vue';
 
 describe('vs-checkbox-node', () => {
-    describe('icon', () => {
-        it('선택 상태가 아니면 unchecked icon이 표시된다', () => {
-            // given
-            const wrapper = mount(VsCheckboxNode, {
-                props: {
-                    id: 'test',
-                    checked: false,
-                },
-            });
-
-            // then
-            expect(wrapper.find('input').element.checked).toBe(false);
-            expect(wrapper.vm.icon).toBe('checkboxUnchecked');
-        });
-
-        it('선택 상태이면 checked icon이 표시된다', () => {
-            // given
-            const wrapper = mount(VsCheckboxNode, {
-                props: {
-                    id: 'test',
-                    checked: true,
-                },
-            });
-
-            // then
-            expect(wrapper.find('input').element.checked).toBe(true);
-            expect(wrapper.vm.icon).toBe('checkboxChecked');
-        });
-
-        it('indeterminate 상태이면 indeterminate icon이 표시된다', () => {
-            // given
-            const wrapper = mount(VsCheckboxNode, {
-                props: {
-                    id: 'test',
-                    checked: false,
-                    indeterminate: true,
-                },
-            });
-
-            // then
-            expect(wrapper.find('input').element.checked).toBe(false);
-            expect(wrapper.vm.icon).toBe('checkboxIndeterminate');
-        });
-
-        it('indeterminate가 true라도 checked가 true이면 checked icon이 표시된다', () => {
-            // given
-            const wrapper = mount(VsCheckboxNode, {
-                props: {
-                    id: 'test',
-                    checked: true,
-                    indeterminate: true,
-                },
-            });
-
-            // then
-            expect(wrapper.find('input').element.checked).toBe(true);
-            expect(wrapper.vm.icon).toBe('checkboxChecked');
-        });
-    });
-
     it('checked 속성을 설정할 수 있다', async () => {
         // given
-        const wrapper = mount(VsCheckboxNode, {
-            props: {
-                id: 'test',
-                checked: false,
-            },
-        });
+        const wrapper = mount(VsCheckboxNode);
 
         // when
         await wrapper.setProps({ checked: true });
 
         // then
         expect(wrapper.find('input').element.checked).toBe(true);
-        expect(wrapper.vm.icon).toBe('checkboxChecked');
     });
 
     describe('label', () => {
@@ -85,8 +19,6 @@ describe('vs-checkbox-node', () => {
             // given
             const wrapper = mount(VsCheckboxNode, {
                 props: {
-                    id: 'test',
-                    checked: false,
                     label: 'test label',
                 },
             });
@@ -98,10 +30,6 @@ describe('vs-checkbox-node', () => {
         it('label slot에 원하는 내용을 넣을 수 있다', () => {
             // given
             const wrapper = mount(VsCheckboxNode, {
-                props: {
-                    id: 'test',
-                    checked: false,
-                },
                 slots: {
                     label: 'test label',
                 },
@@ -115,12 +43,7 @@ describe('vs-checkbox-node', () => {
     describe('events', () => {
         it('toggle 이벤트를 발생시킬 수 있다', async () => {
             // given
-            const wrapper = mount(VsCheckboxNode, {
-                props: {
-                    id: 'test',
-                    checked: true,
-                },
-            });
+            const wrapper = mount(VsCheckboxNode);
 
             // when
             await wrapper.find('input').trigger('click');
@@ -128,17 +51,11 @@ describe('vs-checkbox-node', () => {
             // then
             expect(wrapper.emitted('change')).toHaveLength(1);
             expect(wrapper.emitted('toggle')).toHaveLength(1);
-            expect(wrapper.emitted('toggle')).toEqual([[false]]);
         });
 
         it('focus 이벤트를 발생시킬 수 있다', async () => {
             // given
-            const wrapper = mount(VsCheckboxNode, {
-                props: {
-                    id: 'test',
-                    checked: false,
-                },
-            });
+            const wrapper = mount(VsCheckboxNode);
 
             // when
             await wrapper.find('input').trigger('focus');
@@ -149,12 +66,7 @@ describe('vs-checkbox-node', () => {
 
         it('blur 이벤트를 발생시킬 수 있다', async () => {
             // given
-            const wrapper = mount(VsCheckboxNode, {
-                props: {
-                    id: 'test',
-                    checked: false,
-                },
-            });
+            const wrapper = mount(VsCheckboxNode);
 
             // when
             await wrapper.find('input').trigger('blur');

--- a/packages/vlossom/src/nodes/vs-radio-node/VsRadioNode.scss
+++ b/packages/vlossom/src/nodes/vs-radio-node/VsRadioNode.scss
@@ -9,12 +9,14 @@ $radio-selected-inset-box-shadow: inset 0 0 0 calc($radio-size / 3) $radio-color
     position: relative;
     display: flex;
     align-items: center;
-    height: var(--vs-radio-node-height, var(--vs-input-comp-height));
+    min-height: var(--vs-radio-node-height, var(--vs-input-comp-height));
 
     .vs-radio-wrap {
         position: relative;
         display: flex;
+        justify-content: flex-start;
         align-items: center;
+        flex-wrap: nowrap;
         user-select: none;
         cursor: pointer;
 
@@ -66,7 +68,7 @@ $radio-selected-inset-box-shadow: inset 0 0 0 calc($radio-size / 3) $radio-color
     }
 
     &.vs-dense {
-        height: var(--vs-rado-height, var(--vs-input-comp-height-dense));
+        min-height: var(--vs-rado-height, var(--vs-input-comp-height-dense));
 
         .vs-radio-label {
             font-size: var(--vs-rado-labelFontSize, var(--vs-font-size-sm));

--- a/packages/vlossom/src/nodes/vs-radio-node/VsRadioNode.vue
+++ b/packages/vlossom/src/nodes/vs-radio-node/VsRadioNode.vue
@@ -1,12 +1,12 @@
 <template>
     <div :class="['vs-radio-node', colorSchemeClass, classObj, stateClasses]" :style="computedStyleSet">
-        <label class="vs-radio-wrap">
+        <label class="vs-radio-wrap" :for="computedId">
             <input
                 ref="radioRef"
                 type="radio"
                 class="vs-radio-input"
                 :aria-label="ariaLabel"
-                :id="id"
+                :id="computedId"
                 :disabled="disabled || readonly"
                 :name="name"
                 :value="convertToString(value)"
@@ -41,7 +41,7 @@ export default defineComponent({
         checked: { type: Boolean, default: false },
         dense: { type: Boolean, default: false },
         disabled: { type: Boolean, default: false },
-        id: { type: String, required: true },
+        id: { type: String, default: '' },
         label: { type: String, default: '' },
         name: { type: String, default: '' },
         readonly: { type: Boolean, default: false },
@@ -52,7 +52,7 @@ export default defineComponent({
     emits: ['change', 'toggle', 'focus', 'blur'],
     // expose: ['focus', 'blur'],
     setup(props, { emit }) {
-        const { colorScheme, styleSet, dense, disabled, readonly, state } = toRefs(props);
+        const { colorScheme, styleSet, dense, disabled, readonly, state, id } = toRefs(props);
 
         const { colorSchemeClass } = useColorScheme(name, colorScheme);
 
@@ -67,6 +67,9 @@ export default defineComponent({
             'vs-disabled': disabled.value,
             'vs-readonly': readonly.value,
         }));
+
+        const innerId = utils.string.createID();
+        const computedId = computed(() => id.value || innerId);
 
         function toggle(event: Event) {
             emit('change', event);
@@ -100,6 +103,7 @@ export default defineComponent({
             colorSchemeClass,
             computedStyleSet,
             stateClasses,
+            computedId,
             convertToString: utils.string.convertToString,
         };
     },


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary
checkbox node에서 svg icon을 제거하고, clip-path로 체크박스를 구현합니다

<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
