### PR TITLE
fix(VsTable): add drag event

### DIFF
--- a/packages/vlossom/package-lock.json
+++ b/packages/vlossom/package-lock.json
@@ -28,6 +28,7 @@
                 "@storybook/vue3": "^8.4.3",
                 "@storybook/vue3-vite": "^8.4.3",
                 "@types/node": "^20.17.6",
+                "@types/sortablejs": "^1.15.8",
                 "@vitejs/plugin-vue": "^5.2.0",
                 "@vitest/coverage-v8": "^2.1.5",
                 "@vue/test-utils": "^2.4.6",
@@ -3708,6 +3709,12 @@
                 "@types/prop-types": "*",
                 "csstype": "^3.0.2"
             }
+        },
+        "node_modules/@types/sortablejs": {
+            "version": "1.15.8",
+            "resolved": "https://registry.npmjs.org/@types/sortablejs/-/sortablejs-1.15.8.tgz",
+            "integrity": "sha512-b79830lW+RZfwaztgs1aVPgbasJ8e7AXtZYHTELNXZPsERt4ymJdjV4OccDbHQAvHrCcFpbF78jkm0R6h/pZVg==",
+            "dev": true
         },
         "node_modules/@types/stack-utils": {
             "version": "2.0.3",

--- a/packages/vlossom/package.json
+++ b/packages/vlossom/package.json
@@ -70,6 +70,7 @@
         "@storybook/vue3": "^8.4.3",
         "@storybook/vue3-vite": "^8.4.3",
         "@types/node": "^20.17.6",
+        "@types/sortablejs": "^1.15.8",
         "@vitejs/plugin-vue": "^5.2.0",
         "@vitest/coverage-v8": "^2.1.5",
         "@vue/test-utils": "^2.4.6",

--- a/packages/vlossom/src/components/vs-table/VsTable.vue
+++ b/packages/vlossom/src/components/vs-table/VsTable.vue
@@ -347,7 +347,7 @@ export default defineComponent({
         }
 
         function emitDrag(evt: SortableEvent) {
-            emit('drag', { oldIndex: evt.oldIndex, newIndex: evt.newIndex });
+            emit('drag', evt);
         }
 
         return {

--- a/packages/vlossom/src/components/vs-table/VsTable.vue
+++ b/packages/vlossom/src/components/vs-table/VsTable.vue
@@ -63,6 +63,7 @@
                     @change:paged-items="emitPagedItems"
                     @change:total-items="emitTotalItems"
                     @click-row="emitClickRow"
+                    @drag="emitDrag"
                 >
                     <template v-for="(_, name) in itemSlots" #[name]="slotData">
                         <slot :name="name" v-bind="slotData || {}" />
@@ -113,6 +114,7 @@ import VsSelect from '@/components/vs-select/VsSelect.vue';
 import { VsCheckboxNode } from '@/nodes';
 
 import type { VsTableStyleSet, TableHeader, TableRow, TableFilter, SortType } from './types';
+import type { SortableEvent } from 'sortablejs';
 
 const name = VsComponent.VsTable;
 export default defineComponent({
@@ -177,6 +179,7 @@ export default defineComponent({
     },
     emits: [
         'clickRow',
+        'drag',
         'update',
         'update:itemsPerPage',
         'update:page',
@@ -343,6 +346,10 @@ export default defineComponent({
             emit('clickRow', rowItem, rowIndex);
         }
 
+        function emitDrag(evt: SortableEvent) {
+            emit('drag', { oldIndex: evt.oldIndex, newIndex: evt.newIndex });
+        }
+
         return {
             computedColorScheme,
             colorSchemeClass,
@@ -368,6 +375,7 @@ export default defineComponent({
             emitPagedItems,
             emitTotalItems,
             emitClickRow,
+            emitDrag,
             // expose
             expand,
         };

--- a/packages/vlossom/src/components/vs-table/VsTableBody.vue
+++ b/packages/vlossom/src/components/vs-table/VsTableBody.vue
@@ -6,6 +6,7 @@
         item-key="id"
         handle=".vs-handle"
         :disabled="!draggable || loading"
+        @update="emitDrag"
     >
         <template #item="{ element, index }">
             <vs-table-body-row
@@ -83,6 +84,7 @@ import { utils } from '@/utils';
 
 import type { ColorScheme } from '@/declaration';
 import type { TableHeader, TableItem, TableFilter, SortType, TableRow } from './types';
+import type { SortableEvent } from 'sortablejs';
 
 export default defineComponent({
     name: 'VsTableBody',
@@ -130,6 +132,7 @@ export default defineComponent({
     },
     emits: [
         'clickRow',
+        'drag',
         'toggleExpand',
         'change:selectedItems',
         'change:totalItems',
@@ -238,6 +241,10 @@ export default defineComponent({
             return { id: utils.string.createID(), data: item };
         });
 
+        function emitDrag(evt: SortableEvent) {
+            emit('drag', evt);
+        }
+
         return {
             computedTableItems,
             dummyTableItems,
@@ -247,6 +254,7 @@ export default defineComponent({
             isExpanded,
             toggleExpand,
             emitClickRow,
+            emitDrag,
             // expose
             expand,
         };


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary

- draggable에서 event 발생 시 해당 이벤트 객체를 `drag`라는 이름의 커스텀 이벤트로 emit해주는 기능을 추가합니다