### PR TITLE
fix(VsTable):  fix bugs that has an incorrect value in the check box for the selected item

### DIFF
--- a/packages/vlossom/src/components/vs-table/VsTable.vue
+++ b/packages/vlossom/src/components/vs-table/VsTable.vue
@@ -27,7 +27,7 @@
                             class="vs-table-select vs-select-all"
                             type="checkbox"
                             :color-scheme="computedColorScheme"
-                            :indeterminate="!isSelectedAll && selectedItems.length > 0"
+                            :indeterminate="isIndeterminate"
                             :checked="isSelectedAll"
                             aria-label="select-all"
                             @toggle="onToggleCheck"
@@ -59,7 +59,7 @@
                     :tr-style="trStyle"
                     v-model:is-selected-all="isSelectedAll"
                     v-model:total-items-length="totalItemsLength"
-                    @change:selected-items="emitSelectedItems"
+                    @change:selected-items="onChangeSelectedItems"
                     @change:paged-items="emitPagedItems"
                     @change:total-items="emitTotalItems"
                     @click-row="emitClickRow"
@@ -210,21 +210,27 @@ export default defineComponent({
         const { computedStyleSet } = useStyleSet<VsTableStyleSet>(name, styleSet);
 
         const headerSlots = computed(() => {
-            return Object.keys(slots).reduce((acc, slotName) => {
-                if (slotName.startsWith('header-')) {
-                    acc[slotName] = slots[slotName];
-                }
-                return acc;
-            }, {} as { [key: string]: any });
+            return Object.keys(slots).reduce(
+                (acc, slotName) => {
+                    if (slotName.startsWith('header-')) {
+                        acc[slotName] = slots[slotName];
+                    }
+                    return acc;
+                },
+                {} as { [key: string]: any },
+            );
         });
 
         const itemSlots = computed(() => {
-            return Object.keys(slots).reduce((acc, slotName) => {
-                if (slotName.startsWith('item-') || slotName === 'expand') {
-                    acc[slotName] = slots[slotName];
-                }
-                return acc;
-            }, {} as { [key: string]: any });
+            return Object.keys(slots).reduce(
+                (acc, slotName) => {
+                    if (slotName.startsWith('item-') || slotName === 'expand') {
+                        acc[slotName] = slots[slotName];
+                    }
+                    return acc;
+                },
+                {} as { [key: string]: any },
+            );
         });
 
         const innerSearchText = ref('');
@@ -263,6 +269,7 @@ export default defineComponent({
         });
 
         const isSelectedAll = ref(false);
+        const isIndeterminate = ref(false);
 
         function onToggleCheck(check: boolean) {
             isSelectedAll.value = check;
@@ -291,7 +298,7 @@ export default defineComponent({
 
         watch(innerPage, (p: number) => {
             isSelectedAll.value = false;
-            emitSelectedItems([]);
+            emit('update:selectedItems', []);
             emit('update:page', p);
         });
 
@@ -311,7 +318,7 @@ export default defineComponent({
 
         watch(innerItemsPerPage, (p: number) => {
             isSelectedAll.value = false;
-            emitSelectedItems([]);
+            emit('update:selectedItems', []);
             emit('update:itemsPerPage', p);
         });
 
@@ -330,8 +337,9 @@ export default defineComponent({
 
         useTableParams(innerPage, innerItemsPerPage, sortTypes, computedSearchText, ctx);
 
-        function emitSelectedItems(items: any[]) {
-            emit('update:selectedItems', items);
+        function onChangeSelectedItems(selectedItems: any[]) {
+            isIndeterminate.value = selectedItems.length > 0 ? true : false;
+            emit('update:selectedItems', selectedItems);
         }
 
         function emitPagedItems(items: any[]) {
@@ -361,6 +369,7 @@ export default defineComponent({
             sortTypes,
             hasExpand,
             isSelectedAll,
+            isIndeterminate,
             utils,
             innerSearchText,
             updateInnerSearchText,
@@ -371,7 +380,7 @@ export default defineComponent({
             canDrag,
             hasSelectable,
             onToggleCheck,
-            emitSelectedItems,
+            onChangeSelectedItems,
             emitPagedItems,
             emitTotalItems,
             emitClickRow,

--- a/packages/vlossom/src/components/vs-table/VsTableBody.vue
+++ b/packages/vlossom/src/components/vs-table/VsTableBody.vue
@@ -167,7 +167,7 @@ export default defineComponent({
                 if (!map.has(object)) {
                     map.set(object, utils.string.createID());
                 }
-                return String(map.get(object));
+                return map.get(object);
             };
         })();
 

--- a/packages/vlossom/src/components/vs-table/VsTableBody.vue
+++ b/packages/vlossom/src/components/vs-table/VsTableBody.vue
@@ -32,7 +32,7 @@
                         :checked="isSelected(element.id)"
                         aria-label="select"
                         :disabled="loading"
-                        @toggle="(e) => toggleSelect(e, element.id)"
+                        @toggle="(check: boolean) => toggleSelect(check, element.id)"
                     />
                 </template>
                 <template v-for="(_, name) in $slots" #[name]="slotData">
@@ -161,11 +161,21 @@ export default defineComponent({
         } = toRefs(props);
         const { emit } = ctx;
 
+        const uniqueObjectId = (() => {
+            const map = new WeakMap();
+            return (object: object) => {
+                if (!map.has(object)) {
+                    map.set(object, utils.string.createID());
+                }
+                return String(map.get(object));
+            };
+        })();
+
         const innerItems: Ref<any[]> = ref([]);
         const innerTableItems: ComputedRef<TableItem[]> = computed(() => {
             const itemArr = innerItems.value || [];
             return itemArr.map((item: any) => {
-                return { id: utils.string.createID(), data: item };
+                return { id: uniqueObjectId(item), data: item };
             });
         });
 


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary

1. `draggable: true` 이고 `selectable: true`인 table에 선택된 item이 있을 때, drag event가 발생하면 선택된 item의 checkbox 값이 false가 되는 현상 수정 (224077)
- 원인 : item에 할당된 id가 drag할 때마다 다시 생성됨
- 해결 : item의 id가 object마다 unique한 값을 갖도록 수정 (drag 해서 위치가 바뀌더라도 같은 data를 참조하고 있으면 id가 유지됨)
  - reference: https://stackoverflow.com/questions/1997661/unique-object-identifier-in-javascript 

2. 선택된 item이 있을 때 table header의 checkbox가 indeterminate 상태를 표현하도록 수정
