### PR TITLE
fix(VsModal): use modal-plugin at vs-modal component

### DIFF
--- a/packages/vlossom/src/components/vs-content-renderer/VsContentRenderer.vue
+++ b/packages/vlossom/src/components/vs-content-renderer/VsContentRenderer.vue
@@ -9,7 +9,7 @@ import { Component, defineComponent, PropType, toRaw } from 'vue';
 export default defineComponent({
     name: 'VsContentRenderer',
     props: {
-        content: { type: [String, Object] as PropType<string | Component>, required: true },
+        content: { type: [String, Object, Function] as PropType<string | Component>, required: true },
     },
     setup() {
         return { toRaw };

--- a/packages/vlossom/src/components/vs-drawer/VsDrawer.vue
+++ b/packages/vlossom/src/components/vs-drawer/VsDrawer.vue
@@ -137,7 +137,7 @@ export default defineComponent({
         });
 
         const initialOpen = open.value || modelValue.value;
-        const needScrollLock = computed(() => dimmed.value && fixed.value);
+        const scrollLock = computed(() => dimmed.value && fixed.value);
         const computedCallbacks = computed(() => {
             return {
                 ...callbacks.value,
@@ -149,7 +149,7 @@ export default defineComponent({
                 },
             };
         });
-        const { isOpen, close } = useOverlay(id, initialOpen, needScrollLock, computedCallbacks, escClose);
+        const { isOpen, close } = useOverlay(id, initialOpen, scrollLock, computedCallbacks, escClose);
 
         // only for vs-layout children
         const { getDefaultLayoutProvide } = useLayout();

--- a/packages/vlossom/src/components/vs-modal/VsModal.vue
+++ b/packages/vlossom/src/components/vs-modal/VsModal.vue
@@ -61,7 +61,6 @@ export default defineComponent({
         });
 
         watch(isOpen, (open) => {
-            console.log('isOpen', open);
             if (open) {
                 modalPlugin.open({
                     component: slots.default as string | Component,

--- a/packages/vlossom/src/components/vs-modal/VsModalNode.scss
+++ b/packages/vlossom/src/components/vs-modal/VsModalNode.scss
@@ -2,17 +2,12 @@
 @use '@/styles/mixin' as *;
 
 .vs-modal-node {
-    position: fixed;
+    position: absolute;
     top: 0;
     left: 0;
     width: 100%;
     height: 100%;
     z-index: var(--vs-modal-zIndex, var(--vs-modal-z-index));
-    pointer-events: none;
-
-    &.vs-has-container {
-        position: absolute;
-    }
 
     &.vs-dimmed {
         pointer-events: auto;

--- a/packages/vlossom/src/components/vs-modal/VsModalNode.vue
+++ b/packages/vlossom/src/components/vs-modal/VsModalNode.vue
@@ -1,8 +1,5 @@
 <template>
-    <div
-        :class="['vs-modal-node', colorSchemeClass, { 'vs-has-container': !fixed, 'vs-dimmed': dimmed }]"
-        :style="computedStyleSet"
-    >
+    <div :class="['vs-modal-node', colorSchemeClass, { 'vs-dimmed': dimmed }]" :style="computedStyleSet">
         <div v-if="dimmed" class="vs-modal-dimmed" aria-hidden="true" @click.stop="onClickDimmed" />
         <Transition name="modal" :duration="MODAL_DURATION">
             <vs-focus-trap ref="focusTrapRef" :focus-lock="focusLock" :initial-focus-ref="initialFocusRef">

--- a/packages/vlossom/src/components/vs-modal/VsModalNode.vue
+++ b/packages/vlossom/src/components/vs-modal/VsModalNode.vue
@@ -32,7 +32,7 @@
 
 <script lang="ts">
 import { computed, defineComponent, PropType, toRefs, watch } from 'vue';
-import { Size, SIZES, VsComponent, MODAL_DURATION, SizeProp } from '@/declaration';
+import { Size, SIZES, VsComponent, MODAL_DURATION, SizeProp, VS_OVERLAY_CLOSE } from '@/declaration';
 import { useColorScheme, useOverlay, useStyleSet } from '@/composables';
 import { VsModalStyleSet } from './types';
 import { getOverlayProps } from '@/models';
@@ -100,18 +100,16 @@ export default defineComponent({
         });
 
         const initialOpen = true;
-        const needScrollLock = computed(() => dimmed.value && fixed.value);
-        function onCloseModal() {
-            store.modal.remove(overlayId.value);
-        }
-        const { overlayId, isOpen, close } = useOverlay(
-            id,
-            initialOpen,
-            needScrollLock,
-            callbacks,
-            escClose,
-            onCloseModal,
-        );
+        const scrollLock = computed(() => dimmed.value && fixed.value);
+        const computedCallbacks = computed(() => {
+            return {
+                ...callbacks.value,
+                [VS_OVERLAY_CLOSE]: () => {
+                    store.modal.remove(overlayId.value);
+                },
+            };
+        });
+        const { overlayId, isOpen, close } = useOverlay(id, initialOpen, scrollLock, computedCallbacks, escClose);
 
         const hasHeader = computed(() => !!slots['header']);
         const headerId = computed(() => `vs-modal-header-${overlayId.value}`);

--- a/packages/vlossom/src/components/vs-modal/VsModalView.scss
+++ b/packages/vlossom/src/components/vs-modal/VsModalView.scss
@@ -1,0 +1,12 @@
+.vs-modal-view {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+
+    &.vs-modal-fixed {
+        position: fixed;
+    }
+}

--- a/packages/vlossom/src/components/vs-modal/VsModalView.vue
+++ b/packages/vlossom/src/components/vs-modal/VsModalView.vue
@@ -1,28 +1,30 @@
 <template>
-    <vs-modal-node
-        v-for="modal in modals"
-        :key="modal.id"
-        :color-scheme="modal.colorScheme"
-        :style-set="modal.styleSet"
-        :container="container"
-        :dim-close="modal.dimClose"
-        :dimmed="modal.dimmed"
-        :esc-close="modal.escClose"
-        :focus-lock="modal.focusLock"
-        :hide-scroll="modal.hideScroll"
-        :id="modal.id"
-        :initial-focus-ref="modal.initialFocusRef"
-        :size="modal.size"
-        :callbacks="modal.callbacks"
-    >
-        <template #header v-if="modal.header">
-            <vs-content-renderer :content="modal.header" />
-        </template>
-        <vs-content-renderer v-if="modal.component" :content="modal.component" />
-        <template #footer v-if="modal.footer">
-            <vs-content-renderer :content="modal.footer" />
-        </template>
-    </vs-modal-node>
+    <div class="vs-modal-view" :class="{ 'vs-modal-fixed': isFixed }" :id="wrapperId">
+        <vs-modal-node
+            v-for="modal in modals"
+            :key="modal.id"
+            :color-scheme="modal.colorScheme"
+            :style-set="modal.styleSet"
+            :container="container"
+            :dim-close="modal.dimClose"
+            :dimmed="modal.dimmed"
+            :esc-close="modal.escClose"
+            :focus-lock="modal.focusLock"
+            :hide-scroll="modal.hideScroll"
+            :id="modal.id"
+            :initial-focus-ref="modal.initialFocusRef"
+            :size="modal.size"
+            :callbacks="modal.callbacks"
+        >
+            <template #header v-if="modal.header">
+                <vs-content-renderer :content="modal.header" />
+            </template>
+            <vs-content-renderer v-if="modal.component" :content="modal.component" />
+            <template #footer v-if="modal.footer">
+                <vs-content-renderer :content="modal.footer" />
+            </template>
+        </vs-modal-node>
+    </div>
 </template>
 
 <script lang="ts">
@@ -45,7 +47,13 @@ export default defineComponent({
 
         const { getRenderedContent } = useContentRenderer();
 
-        return { modals, getRenderedContent };
+        const wrapperId = computed(() => `vs-modal-${container.value.replace('#', '').replace('.', '')}`);
+
+        const isFixed = computed(() => container.value === 'body');
+
+        return { modals, getRenderedContent, wrapperId, isFixed };
     },
 });
 </script>
+
+<style lang="scss" src="./VsModalView.scss" />

--- a/packages/vlossom/src/components/vs-modal/VsModalView.vue
+++ b/packages/vlossom/src/components/vs-modal/VsModalView.vue
@@ -32,7 +32,7 @@ import { computed, defineComponent, toRefs } from 'vue';
 import { store } from '@/stores';
 import { useContentRenderer } from '@/composables';
 import VsModalNode from '@/components/vs-modal/VsModalNode.vue';
-import VsContentRenderer from './../vs-content-renderer/VsContentRenderer.vue';
+import VsContentRenderer from '@/components/vs-content-renderer/VsContentRenderer.vue';
 
 export default defineComponent({
     props: {

--- a/packages/vlossom/src/components/vs-toast/VsToastView.vue
+++ b/packages/vlossom/src/components/vs-toast/VsToastView.vue
@@ -1,5 +1,5 @@
 <template>
-    <div v-if="hasToast" class="vs-toast-view" :id="wrapperId" :class="{ 'vs-toast-fixed': isFixed }">
+    <div v-if="hasToast" class="vs-toast-view" :class="{ 'vs-toast-fixed': isFixed }" :id="wrapperId">
         <div
             v-for="[key, toasts] in Object.entries(toastsByPosition)"
             :key="key"

--- a/packages/vlossom/src/composables/overlay-composable.ts
+++ b/packages/vlossom/src/composables/overlay-composable.ts
@@ -7,10 +7,9 @@ import { useBodyScroll } from './scroll-lock-composable';
 export function useOverlay(
     id: Ref<string>,
     initialOpen: boolean,
-    needScrollLock: Ref<boolean>,
+    scrollLock: Ref<boolean>,
     callbacks: Ref<OverlayCallbacks> = ref({}),
     escClose: Ref<boolean>,
-    onClose?: () => void,
 ) {
     const innerId = utils.string.createID();
     const overlayId = computed(() => id.value || innerId);
@@ -43,7 +42,7 @@ export function useOverlay(
         isOpen,
         (o) => {
             if (o) {
-                if (needScrollLock.value) {
+                if (scrollLock.value) {
                     bodyScroll.lock();
                 }
 
@@ -51,10 +50,9 @@ export function useOverlay(
             } else {
                 closing.value = true;
                 store.overlay.remove(overlayId.value);
-                onClose?.();
 
                 setTimeout(() => {
-                    if (needScrollLock.value) {
+                    if (scrollLock.value) {
                         bodyScroll.unlock();
                     }
 

--- a/packages/vlossom/src/stores/overlay-callback-store.ts
+++ b/packages/vlossom/src/stores/overlay-callback-store.ts
@@ -44,13 +44,11 @@ export class OverlayCallbackStore {
     }
 
     pop(...args: any[]) {
-        const popped = this.overlays.pop();
-        if (!popped) {
-            return;
-        }
-        const [poppedId] = popped;
-        this.run(poppedId, VS_OVERLAY_CLOSE, ...args);
-        return this.run(poppedId, 'close', ...args);
+        const [targetId] = this.overlays[this.overlays.length - 1];
+        this.run(targetId, VS_OVERLAY_CLOSE, ...args);
+        const result = this.run(targetId, 'close', ...args);
+        this.overlays.pop();
+        return result;
     }
 
     remove(id: string, ...args: any[]) {

--- a/packages/vlossom/src/stores/overlay-callback-store.ts
+++ b/packages/vlossom/src/stores/overlay-callback-store.ts
@@ -58,13 +58,11 @@ export class OverlayCallbackStore {
         if (index === -1) {
             return;
         }
-        const [popped] = this.overlays.splice(index, 1);
-        if (!popped) {
-            return;
-        }
-        const [poppedId] = popped;
-        this.run(poppedId, VS_OVERLAY_CLOSE, ...args);
-        return this.run(poppedId, 'close', ...args);
+        const [targetId] = this.overlays[index];
+        this.run(targetId, VS_OVERLAY_CLOSE, ...args);
+        const result = this.run(targetId, 'close', ...args);
+        this.overlays.splice(index, 1);
+        return result;
     }
 
     clear(...args: any[]) {


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary
vs-modal이 modal plugin을 이용해서 render하도록 변경합니다

## Description
- vs-modal-view에 wrapper를 두고, 해당 wrapper에 modal들이 mount 되도록 변경합니다
- vs-modal에서 vs-node를 직접 이용하지 않고, modal plugin을 이용하도록 변경합니다
- modal plugin을 이용하면 기존 confirm이나 plugin 간에 위계를 공유하기 때문에 우선순위 문제가 사라집니다

<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
