### PR TITLE
fix(VsModalView): fix transition

### DIFF
--- a/packages/vlossom/src/components/vs-modal/VsModalNode.scss
+++ b/packages/vlossom/src/components/vs-modal/VsModalNode.scss
@@ -82,8 +82,6 @@
     }
 }
 
-
-
 @container (min-width: 640px) {
     .vs-modal-node .vs-modal-wrap .vs-modal-contents {
         padding: var(--vs-modal-padding, 2.2rem 2.8rem);

--- a/packages/vlossom/src/components/vs-modal/VsModalNode.scss
+++ b/packages/vlossom/src/components/vs-modal/VsModalNode.scss
@@ -82,23 +82,7 @@
     }
 }
 
-.modal-enter-active .vs-modal-dimmed,
-.modal-leave-active .vs-modal-dimmed,
-.modal-enter-active .vs-modal-wrap,
-.modal-leave-active .vs-modal-wrap {
-    transition: all 0.2s;
-}
 
-.modal-enter-from .vs-modal-dimmed,
-.modal-leave-to .vs-modal-dimmed {
-    opacity: 0;
-}
-
-.modal-enter-from .vs-modal-wrap,
-.modal-leave-to .vs-modal-wrap {
-    transform: translate(-50%, -50%) scale(0.95);
-    opacity: 0;
-}
 
 @container (min-width: 640px) {
     .vs-modal-node .vs-modal-wrap .vs-modal-contents {

--- a/packages/vlossom/src/components/vs-modal/VsModalNode.vue
+++ b/packages/vlossom/src/components/vs-modal/VsModalNode.vue
@@ -1,7 +1,6 @@
 <template>
     <div :class="['vs-modal-node', colorSchemeClass, { 'vs-dimmed': dimmed }]" :style="computedStyleSet">
         <div v-if="dimmed" class="vs-modal-dimmed" aria-hidden="true" @click.stop="onClickDimmed" />
-        <Transition name="modal" :duration="MODAL_DURATION">
             <vs-focus-trap ref="focusTrapRef" :focus-lock="focusLock" :initial-focus-ref="initialFocusRef">
                 <div
                     :class="['vs-modal-wrap', hasSpecifiedSize ? '' : size]"
@@ -26,13 +25,12 @@
                     </div>
                 </div>
             </vs-focus-trap>
-        </Transition>
     </div>
 </template>
 
 <script lang="ts">
 import { computed, defineComponent, PropType, toRefs, watch } from 'vue';
-import { Size, SIZES, VsComponent, MODAL_DURATION, SizeProp, VS_OVERLAY_CLOSE } from '@/declaration';
+import { Size, SIZES, VsComponent, SizeProp, VS_OVERLAY_CLOSE } from '@/declaration';
 import { useColorScheme, useOverlay, useStyleSet } from '@/composables';
 import { VsModalStyleSet } from './types';
 import { getOverlayProps } from '@/models';
@@ -109,6 +107,7 @@ export default defineComponent({
                 },
             };
         });
+
         const { overlayId, isOpen, close } = useOverlay(id, initialOpen, scrollLock, computedCallbacks, escClose);
 
         const hasHeader = computed(() => !!slots['header']);
@@ -128,7 +127,6 @@ export default defineComponent({
         return {
             colorSchemeClass,
             computedStyleSet,
-            MODAL_DURATION,
             onClickDimmed,
             hasHeader,
             headerId,

--- a/packages/vlossom/src/components/vs-modal/VsModalView.scss
+++ b/packages/vlossom/src/components/vs-modal/VsModalView.scss
@@ -10,3 +10,21 @@
         position: fixed;
     }
 }
+
+.modal-enter-active .vs-modal-dimmed,
+.modal-leave-active .vs-modal-dimmed,
+.modal-enter-active .vs-modal-wrap,
+.modal-leave-active .vs-modal-wrap {
+    transition: all 0.2s;
+}
+
+.modal-enter-from .vs-modal-dimmed,
+.modal-leave-to .vs-modal-dimmed {
+    opacity: 0;
+}
+
+.modal-enter-from .vs-modal-wrap,
+.modal-leave-to .vs-modal-wrap {
+    transform: translate(-50%, -50%) scale(0.95);
+    opacity: 0;
+}

--- a/packages/vlossom/src/components/vs-modal/VsModalView.vue
+++ b/packages/vlossom/src/components/vs-modal/VsModalView.vue
@@ -1,29 +1,31 @@
 <template>
     <div class="vs-modal-view" :class="{ 'vs-modal-fixed': isFixed }" :id="wrapperId">
-        <vs-modal-node
-            v-for="modal in modals"
-            :key="modal.id"
-            :color-scheme="modal.colorScheme"
-            :style-set="modal.styleSet"
-            :container="container"
-            :dim-close="modal.dimClose"
-            :dimmed="modal.dimmed"
-            :esc-close="modal.escClose"
-            :focus-lock="modal.focusLock"
-            :hide-scroll="modal.hideScroll"
-            :id="modal.id"
-            :initial-focus-ref="modal.initialFocusRef"
-            :size="modal.size"
-            :callbacks="modal.callbacks"
-        >
-            <template #header v-if="modal.header">
-                <vs-content-renderer :content="modal.header" />
-            </template>
-            <vs-content-renderer v-if="modal.component" :content="modal.component" />
-            <template #footer v-if="modal.footer">
-                <vs-content-renderer :content="modal.footer" />
-            </template>
-        </vs-modal-node>
+        <TransitionGroup name="modal" :duration="MODAL_DURATION">
+            <vs-modal-node
+                v-for="modal in modals"
+                :key="modal.id"
+                :color-scheme="modal.colorScheme"
+                :style-set="modal.styleSet"
+                :container="container"
+                :dim-close="modal.dimClose"
+                :dimmed="modal.dimmed"
+                :esc-close="modal.escClose"
+                :focus-lock="modal.focusLock"
+                :hide-scroll="modal.hideScroll"
+                :id="modal.id"
+                :initial-focus-ref="modal.initialFocusRef"
+                :size="modal.size"
+                :callbacks="modal.callbacks"
+            >
+                <template #header v-if="modal.header">
+                    <vs-content-renderer :content="modal.header" />
+                </template>
+                <vs-content-renderer v-if="modal.component" :content="modal.component" />
+                <template #footer v-if="modal.footer">
+                    <vs-content-renderer :content="modal.footer" />
+                </template>
+            </vs-modal-node>
+        </TransitionGroup>
     </div>
 </template>
 
@@ -31,6 +33,8 @@
 import { computed, defineComponent, toRefs } from 'vue';
 import { store } from '@/stores';
 import { useContentRenderer } from '@/composables';
+import { MODAL_DURATION } from '@/declaration';
+
 import VsModalNode from '@/components/vs-modal/VsModalNode.vue';
 import VsContentRenderer from '@/components/vs-content-renderer/VsContentRenderer.vue';
 
@@ -51,7 +55,7 @@ export default defineComponent({
 
         const isFixed = computed(() => container.value === 'body');
 
-        return { modals, getRenderedContent, wrapperId, isFixed };
+        return { modals, getRenderedContent, wrapperId, isFixed, MODAL_DURATION };
     },
 });
 </script>

--- a/packages/vlossom/src/components/vs-modal/VsModalView.vue
+++ b/packages/vlossom/src/components/vs-modal/VsModalView.vue
@@ -11,7 +11,6 @@
                 :dimmed="modal.dimmed"
                 :esc-close="modal.escClose"
                 :focus-lock="modal.focusLock"
-                :hide-scroll="modal.hideScroll"
                 :id="modal.id"
                 :initial-focus-ref="modal.initialFocusRef"
                 :size="modal.size"
@@ -35,6 +34,7 @@ import { store } from '@/stores';
 import { useContentRenderer, useScrollLock } from '@/composables';
 import VsModalNode from '@/components/vs-modal/VsModalNode.vue';
 import VsContentRenderer from '@/components/vs-content-renderer/VsContentRenderer.vue';
+import { MODAL_DURATION } from '@/declaration';
 
 export default defineComponent({
     props: {
@@ -73,7 +73,7 @@ export default defineComponent({
             }
         });
 
-        return { modals, getRenderedContent, wrapperId, isFixed };
+        return { modals, getRenderedContent, wrapperId, isFixed, MODAL_DURATION };
     },
 });
 </script>


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)


## Summary

- VsModal 구현 방법이 바뀌었으므로 transition 이 정상 작동하도록 수정합니다.
  - VsModalNode에서 `<Transition/>`을 제거하고  VsModalView에 `<TransitionGroup/>`을 추가. transition 관련 scss를 VsModalView.scss로 옮김
