### PR TITLE
fix(VsModalNode): modify default size to fit the content size

### DIFF
--- a/packages/vlossom/src/components/vs-modal/VsModal.vue
+++ b/packages/vlossom/src/components/vs-modal/VsModal.vue
@@ -23,7 +23,6 @@ export default defineComponent({
         container: { type: String, default: 'body' },
         size: {
             type: [String, Number, Object] as PropType<SizeProp | { width?: SizeProp; height?: SizeProp }>,
-            default: 'md',
         },
         // v-model
         modelValue: { type: Boolean, default: false },

--- a/packages/vlossom/src/components/vs-modal/VsModalNode.scss
+++ b/packages/vlossom/src/components/vs-modal/VsModalNode.scss
@@ -49,7 +49,7 @@
             flex-direction: column;
             width: fit-content;
             height: fit-content;
-            max-width: 100%; // 기본값 설정
+            max-width: 100%;
             max-height: 100%;
             padding: var(--vs-modal-padding, 1.8rem 2.4rem);
             color: var(--vs-modal-fontColor, var(--vs-font-color));

--- a/packages/vlossom/src/components/vs-modal/VsModalNode.scss
+++ b/packages/vlossom/src/components/vs-modal/VsModalNode.scss
@@ -47,6 +47,10 @@
         }
 
         .vs-modal-contents {
+            position: relative;
+            display: flex;
+            flex-direction: column;
+            overflow: auto;
             width: fit-content;
             height: fit-content;
             padding: var(--vs-modal-padding, 1.8rem 2.4rem);

--- a/packages/vlossom/src/components/vs-modal/VsModalNode.scss
+++ b/packages/vlossom/src/components/vs-modal/VsModalNode.scss
@@ -49,7 +49,6 @@
         .vs-modal-contents {
             width: fit-content;
             height: fit-content;
-
             padding: var(--vs-modal-padding, 1.8rem 2.4rem);
             color: var(--vs-modal-fontColor, var(--vs-font-color));
             font-size: var(--vs-modal-fontSize, var(--vs-font-size));

--- a/packages/vlossom/src/components/vs-modal/VsModalNode.scss
+++ b/packages/vlossom/src/components/vs-modal/VsModalNode.scss
@@ -28,17 +28,15 @@
         top: 50%;
         left: 50%;
         transform: translate(-50%, -50%);
-        min-width: var(--vs-modal-width-xs);
-        min-height: var(--vs-modal-height-xs);
-        width: 100%;
-        height: 100%;
-        max-width: var(--vs-modal-width);
-        max-height: var(--vs-modal-height);
+        display: block;
+        overflow: auto;
+        width: var(--vs-modal-width, fit-content);
+        height: var(--vs-modal-height, fit-content);
+
         background-color: var(--vs-modal-backgroundColor, var(--vs-area-bg));
         box-shadow: var(--vs-modal-boxShadow, var(--vs-area-shadow-outer));
         border-radius: var(--vs-modal-borderRadius, calc(var(--vs-radius-ratio) * var(--vs-radius)));
         pointer-events: auto;
-        container-type: inline-size;
 
         // size
         @each $size in $sizes {
@@ -49,12 +47,9 @@
         }
 
         .vs-modal-contents {
-            position: relative;
-            display: flex;
-            flex-direction: column;
-            overflow: auto;
-            width: 100%;
-            height: 100%;
+            width: fit-content;
+            height: fit-content;
+
             padding: var(--vs-modal-padding, 1.8rem 2.4rem);
             color: var(--vs-modal-fontColor, var(--vs-font-color));
             font-size: var(--vs-modal-fontSize, var(--vs-font-size));

--- a/packages/vlossom/src/components/vs-modal/VsModalNode.scss
+++ b/packages/vlossom/src/components/vs-modal/VsModalNode.scss
@@ -28,11 +28,8 @@
         top: 50%;
         left: 50%;
         transform: translate(-50%, -50%);
-        display: block;
-        overflow: auto;
         width: var(--vs-modal-width, fit-content);
         height: var(--vs-modal-height, fit-content);
-
         background-color: var(--vs-modal-backgroundColor, var(--vs-area-bg));
         box-shadow: var(--vs-modal-boxShadow, var(--vs-area-shadow-outer));
         border-radius: var(--vs-modal-borderRadius, calc(var(--vs-radius-ratio) * var(--vs-radius)));
@@ -50,9 +47,10 @@
             position: relative;
             display: flex;
             flex-direction: column;
-            overflow: auto;
             width: fit-content;
             height: fit-content;
+            max-width: 100%; // 기본값 설정
+            max-height: 100%;
             padding: var(--vs-modal-padding, 1.8rem 2.4rem);
             color: var(--vs-modal-fontColor, var(--vs-font-color));
             font-size: var(--vs-modal-fontSize, var(--vs-font-size));
@@ -71,6 +69,8 @@
             .vs-modal-body {
                 position: relative;
                 flex: auto;
+                overflow: auto;
+                max-height: 100%;
             }
         }
     }

--- a/packages/vlossom/src/components/vs-modal/VsModalNode.vue
+++ b/packages/vlossom/src/components/vs-modal/VsModalNode.vue
@@ -47,7 +47,6 @@ export default defineComponent({
         container: { type: String, default: 'body' },
         size: {
             type: [String, Number, Object] as PropType<SizeProp | { width?: SizeProp; height?: SizeProp }>,
-            default: 'md',
         },
     },
     setup(props, { slots }) {
@@ -55,14 +54,16 @@ export default defineComponent({
 
         const { colorSchemeClass } = useColorScheme(name, colorScheme);
 
-        const { computedStyleSet: modalStyleSet } = useStyleSet<VsModalStyleSet>(name, styleSet);
+        const { computedStyleSet: modalStyleSet } = useStyleSet<VsModalStyleSet>(VsComponent.VsModal, styleSet);
 
         const fixed = computed(() => container.value === 'body');
 
         const hasSpecifiedSize = computed(() => size.value && !SIZES.includes(size.value as Size));
         const sizeStyle = computed(() => {
+            if (!size.value) {
+                return {};
+            }
             const style: { [key: string]: string } = {};
-
             if (typeof size.value === 'object') {
                 const { width = 'md', height = 'md' } = size.value;
 


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary
- modal의 사이즈가 `vs-modal-content`의 사이즈를 따라가도록 수정합니다
- VsModalStyleSet에 설정한 값이 VsModalNode에 반영되지 않는 버그를 수정합니다