### PR TITLE
fix(VsTabs): change tabs watch

### DIFF
--- a/packages/vlossom/src/components/vs-tabs/VsTabs.vue
+++ b/packages/vlossom/src/components/vs-tabs/VsTabs.vue
@@ -177,9 +177,12 @@ export default defineComponent({
             window.removeEventListener('resize', calculateScrollCount);
         });
 
-        watch(tabs, () => {
-            selectTab(findNextActivedIndex(0));
-        });
+        watch(
+            () => tabs.value.length,
+            () => {
+                selectTab(findNextActivedIndex(selectedIndex.value));
+            },
+        );
 
         watch(selectedIndex, (index: number) => {
             scrollTo(index);

--- a/packages/vlossom/src/components/vs-tabs/__tests__/vs-tabs.test.ts
+++ b/packages/vlossom/src/components/vs-tabs/__tests__/vs-tabs.test.ts
@@ -225,14 +225,52 @@ describe('vs-tabs', () => {
         });
 
         describe('tabs 변경됐을 때', () => {
-            it('첫번쨰 탭으로 index를 보정한다', async () => {
+            it('tabs의 길이가 바뀌지 않으면 index가 그대로 유지된다', async () => {
                 // given
                 const wrapper = mount(VsTabs, {
-                    props: { tabs },
+                    props: {
+                        tabs,
+                        modelValue: 2,
+                        'onUpdate:modelValue': (e: number) => wrapper.setProps({ modelValue: e }),
+                    },
+                });
+
+                // when
+                await wrapper.setProps({ tabs: ['tab6', 'tab7', 'tab8', 'tab9', 'tab10'] });
+
+                // then
+                expect(wrapper.vm.selectedIndex).toEqual(2);
+            });
+
+            it('tabs의 길이가 바뀌어도 현재 index가 선택 가능하면 index가 유지된다', async () => {
+                // given
+                const wrapper = mount(VsTabs, {
+                    props: {
+                        tabs,
+                        modelValue: 2,
+                        'onUpdate:modelValue': (e: number) => wrapper.setProps({ modelValue: e }),
+                    },
                 });
 
                 // when
                 await wrapper.setProps({ tabs: ['tab6', 'tab7', 'tab8'] });
+
+                // then
+                expect(wrapper.vm.selectedIndex).toEqual(2);
+            });
+
+            it('tabs의 길이가 바뀌었을 때 index가 선택 가능하지 않으면 다음 선택 가능한 index가 선택된다', async () => {
+                // given
+                const wrapper = mount(VsTabs, {
+                    props: {
+                        tabs,
+                        modelValue: 4,
+                        'onUpdate:modelValue': (e: number) => wrapper.setProps({ modelValue: e }),
+                    },
+                });
+
+                // when
+                await wrapper.setProps({ tabs: ['tab6', 'tab7', 'tab8', 'tab9'] });
 
                 // then
                 expect(wrapper.vm.selectedIndex).toEqual(0);


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary
vs-tabs에서 tab이 바뀌었을 때 index 처리 방식을 바꿉니다

## Description
- tabs 변경이 있어도 index를 유지하는 방향으로 변경합니다
- tabs의 길이를 watch 해서 tabs object에 변경이 있어도 반응하지 않도록 수정합니다

<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
