### PR TITLE
fix(VsDrawer): add overflow hidden

### DIFF
--- a/packages/vlossom/src/components/vs-drawer/VsDrawer.scss
+++ b/packages/vlossom/src/components/vs-drawer/VsDrawer.scss
@@ -12,6 +12,7 @@ $drawer-border: var(--vs-drawer-border, 1px solid var(--vs-line-color));
     z-index: var(--vs-drawer-zIndex);
     color: var(--vs-font-color);
     pointer-events: none;
+    overflow: hidden;
 
     &.vs-dimmed {
         pointer-events: auto;
@@ -25,10 +26,6 @@ $drawer-border: var(--vs-drawer-border, 1px solid var(--vs-line-color));
         height: 100%;
         opacity: 1;
         background-color: var(--vs-dimmed-background-color);
-    }
-
-    .vs-drawer-hidden {
-        overflow: hidden;
     }
 
     .vs-drawer-wrap {

--- a/packages/vlossom/src/components/vs-drawer/VsDrawer.scss
+++ b/packages/vlossom/src/components/vs-drawer/VsDrawer.scss
@@ -27,6 +27,10 @@ $drawer-border: var(--vs-drawer-border, 1px solid var(--vs-line-color));
         background-color: var(--vs-dimmed-background-color);
     }
 
+    .vs-drawer-hidden {
+        overflow: hidden;
+    }
+
     .vs-drawer-wrap {
         position: absolute;
         display: flex;

--- a/packages/vlossom/src/components/vs-drawer/VsDrawer.vue
+++ b/packages/vlossom/src/components/vs-drawer/VsDrawer.vue
@@ -8,21 +8,16 @@
         >
             <div v-if="dimmed" class="vs-drawer-dimmed" aria-hidden="true" @click.stop="onClickDimmed" />
             <vs-focus-trap ref="focusTrapRef" :focus-lock="focusLock" :initial-focus-ref="initialFocusRef">
-                <div :class="['vs-drawer-overflow', { 'vs-drawer-hidden': isOverflowHidden }]">
-                    <div
-                        :class="['vs-drawer-wrap', `vs-${placement}`, hasSpecifiedSize ? '' : size]"
-                        :style="layoutStyles"
-                    >
-                        <header v-if="$slots['header']" class="vs-drawer-header">
-                            <slot name="header" />
-                        </header>
-                        <div :class="['vs-drawer-body', { 'vs-hide-scroll': hideScroll }]">
-                            <slot />
-                        </div>
-                        <footer v-if="$slots['footer']" class="vs-drawer-footer">
-                            <slot name="footer" />
-                        </footer>
+                <div :class="['vs-drawer-wrap', `vs-${placement}`, hasSpecifiedSize ? '' : size]" :style="layoutStyles">
+                    <header v-if="$slots['header']" class="vs-drawer-header">
+                        <slot name="header" />
+                    </header>
+                    <div :class="['vs-drawer-body', { 'vs-hide-scroll': hideScroll }]">
+                        <slot />
                     </div>
+                    <footer v-if="$slots['footer']" class="vs-drawer-footer">
+                        <slot name="footer" />
+                    </footer>
                 </div>
             </vs-focus-trap>
         </div>
@@ -156,11 +151,7 @@ export default defineComponent({
                 },
             };
         });
-        const { isOpen, open, close, closing } = useOverlay(id, computedCallbacks, escClose);
-
-        const isOverflowHidden = computed(() => {
-            return !isOpen.value && !closing.value;
-        });
+        const { isOpen, open, close } = useOverlay(id, computedCallbacks, escClose);
 
         // only for vs-layout children
         const { getDefaultLayoutProvide } = useLayout();
@@ -260,7 +251,6 @@ export default defineComponent({
             focusTrapRef,
             layoutStyles,
             drawerRef,
-            isOverflowHidden,
         };
     },
 });

--- a/packages/vlossom/src/components/vs-drawer/VsDrawer.vue
+++ b/packages/vlossom/src/components/vs-drawer/VsDrawer.vue
@@ -8,16 +8,21 @@
         >
             <div v-if="dimmed" class="vs-drawer-dimmed" aria-hidden="true" @click.stop="onClickDimmed" />
             <vs-focus-trap ref="focusTrapRef" :focus-lock="focusLock" :initial-focus-ref="initialFocusRef">
-                <div :class="['vs-drawer-wrap', `vs-${placement}`, hasSpecifiedSize ? '' : size]" :style="layoutStyles">
-                    <header v-if="$slots['header']" class="vs-drawer-header">
-                        <slot name="header" />
-                    </header>
-                    <div :class="['vs-drawer-body', { 'vs-hide-scroll': hideScroll }]">
-                        <slot />
+                <div :class="['vs-drawer-overflow', { 'vs-drawer-hidden': isOverflowHidden }]">
+                    <div
+                        :class="['vs-drawer-wrap', `vs-${placement}`, hasSpecifiedSize ? '' : size]"
+                        :style="layoutStyles"
+                    >
+                        <header v-if="$slots['header']" class="vs-drawer-header">
+                            <slot name="header" />
+                        </header>
+                        <div :class="['vs-drawer-body', { 'vs-hide-scroll': hideScroll }]">
+                            <slot />
+                        </div>
+                        <footer v-if="$slots['footer']" class="vs-drawer-footer">
+                            <slot name="footer" />
+                        </footer>
                     </div>
-                    <footer v-if="$slots['footer']" class="vs-drawer-footer">
-                        <slot name="footer" />
-                    </footer>
                 </div>
             </vs-focus-trap>
         </div>
@@ -151,7 +156,11 @@ export default defineComponent({
                 },
             };
         });
-        const { isOpen, open, close } = useOverlay(id, computedCallbacks, escClose);
+        const { isOpen, open, close, closing } = useOverlay(id, computedCallbacks, escClose);
+
+        const isOverflowHidden = computed(() => {
+            return !isOpen.value && !closing.value;
+        });
 
         // only for vs-layout children
         const { getDefaultLayoutProvide } = useLayout();
@@ -251,6 +260,7 @@ export default defineComponent({
             focusTrapRef,
             layoutStyles,
             drawerRef,
+            isOverflowHidden,
         };
     },
 });

--- a/packages/vlossom/src/components/vs-layout/VsLayout.scss
+++ b/packages/vlossom/src/components/vs-layout/VsLayout.scss
@@ -2,7 +2,6 @@
     position: relative;
     width: 100%;
     height: 100%;
-    overflow: hidden;
     color: var(--vs-font-color);
     transition: padding 0.3s;
 }


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary
vs-drawer에 overflow: hidden을 추가해서 drawer가 자체적으로 overflow를 숨기도록 합니다.

## Description
- vs-layout에 있는 overflow hidden은 제거합니다

<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
