### PR TITLE
fix(vlossom-framework): add string type on VsComponent style option

### DIFF
--- a/packages/vlossom/src/composables/color-scheme-composable.ts
+++ b/packages/vlossom/src/composables/color-scheme-composable.ts
@@ -4,7 +4,7 @@ import { store } from '@/stores';
 import type { Ref } from 'vue';
 import type { ColorScheme, VsComponent } from '@/declaration';
 
-export function useColorScheme(component: VsComponent, colorScheme: Ref<ColorScheme | undefined>) {
+export function useColorScheme(component: VsComponent | string, colorScheme: Ref<ColorScheme | undefined>) {
     const computedColorScheme = computed(
         () => colorScheme.value || store.option.getGlobalColorScheme(component) || undefined,
     );

--- a/packages/vlossom/src/composables/style-set-composable.ts
+++ b/packages/vlossom/src/composables/style-set-composable.ts
@@ -4,7 +4,7 @@ import { store } from '@/stores';
 import { VsComponent } from '@/declaration';
 
 export function useStyleSet<T extends { [key: string]: any }>(
-    component: VsComponent,
+    component: VsComponent | string,
     styleSet: Ref<string | T | undefined>,
     additionalStyleSet?: Ref<T>,
 ) {

--- a/packages/vlossom/src/declaration/types.ts
+++ b/packages/vlossom/src/declaration/types.ts
@@ -44,7 +44,9 @@ import type { VsComponent } from './enums';
 
 export type ColorScheme = (typeof COLORS)[number];
 
-export type GlobalColorScheme = { default?: ColorScheme } & { [key in VsComponent]?: ColorScheme };
+export type GlobalColorScheme = { default?: ColorScheme } & { [key in VsComponent]?: ColorScheme } & {
+    [key: string]: ColorScheme;
+};
 
 export interface VsBoxStyleSet {
     backgroundColor?: string;
@@ -54,8 +56,7 @@ export interface VsBoxStyleSet {
     padding?: string;
 }
 
-export interface StyleSet {
-    // components
+export interface VsComponentStyleSet {
     VsAccordion?: { [key: string]: VsAccordionStyleSet };
     VsAvatar?: { [key: string]: VsAvatarStyleSet };
     VsBlock?: { [key: string]: VsBlockStyleSet };
@@ -96,6 +97,7 @@ export interface StyleSet {
     VsTooltip?: { [key: string]: VsTooltipStyleSet };
 }
 
+export type StyleSet = VsComponentStyleSet & { [key: string]: { [key: string]: any } };
 export interface VlossomOptions {
     components?: VsComponent[];
     colorScheme?: GlobalColorScheme;

--- a/packages/vlossom/src/stores/option-store.ts
+++ b/packages/vlossom/src/stores/option-store.ts
@@ -31,7 +31,7 @@ export class OptionStore {
         this.state.globalColorScheme = colorScheme;
     }
 
-    getGlobalColorScheme(component: VsComponent) {
+    getGlobalColorScheme(component: VsComponent | string) {
         return this.state.globalColorScheme[component] || this.state.globalColorScheme.default;
     }
 
@@ -57,7 +57,7 @@ export class OptionStore {
         });
     }
 
-    getStyleSet(component: VsComponent, styleSetName: string) {
+    getStyleSet(component: VsComponent | string, styleSetName: string) {
         return this.state.styleSets[component as keyof StyleSet]?.[styleSetName];
     }
 }


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary
style set과 color scheme이 component 이름을 string으로도 받을 수 있게 변경합니다

<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
