### PR TITLE
fix(type): extend StateMessage state type

### DIFF
--- a/packages/vlossom/src/declaration/types.ts
+++ b/packages/vlossom/src/declaration/types.ts
@@ -118,8 +118,8 @@ export interface Breakpoints {
 
 export type UIState = 'idle' | 'success' | 'info' | 'error' | 'warning' | 'selected';
 
-export interface StateMessage {
-    state: UIState;
+export interface StateMessage<T extends string = UIState> {
+    state: T;
     text: string;
 }
 


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary
StateMessage가 UIState로 고정되어 있어서 string type으로 바로 할당할 수 없는 이슈가 있어서 type을 UIState를 확장하는 string으로 수정

<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
