### PR TITLE
fix(index-selector): change next available index

### DIFF
--- a/packages/vlossom/src/components/vs-tabs/__tests__/vs-tabs.test.ts
+++ b/packages/vlossom/src/components/vs-tabs/__tests__/vs-tabs.test.ts
@@ -259,7 +259,7 @@ describe('vs-tabs', () => {
                 expect(wrapper.vm.selectedIndex).toEqual(2);
             });
 
-            it('tabs의 길이가 바뀌었을 때 index가 선택 가능하지 않으면 다음 선택 가능한 index가 선택된다', async () => {
+            it('tabs의 길이가 바뀌었을 때 index가 선택 가능하지 않으면 아무것도 선택되지 않는다', async () => {
                 // given
                 const wrapper = mount(VsTabs, {
                     props: {
@@ -270,10 +270,10 @@ describe('vs-tabs', () => {
                 });
 
                 // when
-                await wrapper.setProps({ tabs: ['tab6', 'tab7', 'tab8', 'tab9'] });
+                await wrapper.setProps({ tabs: ['tab6', 'tab7', 'tab8'] });
 
                 // then
-                expect(wrapper.vm.selectedIndex).toEqual(0);
+                expect(wrapper.vm.selectedIndex).toEqual(-1);
             });
 
             it('첫번째 탭이 disabled 상태이면 선택 가능한 첫번째 탭으로 index를 보정한다', async () => {

--- a/packages/vlossom/src/composables/__tests__/index-selector-composable.test.ts
+++ b/packages/vlossom/src/composables/__tests__/index-selector-composable.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { ref } from 'vue';
 import { useIndexSelector } from './../index-selector-composable';
 
@@ -71,6 +71,31 @@ describe('index-selector-composable', () => {
             // then
             expect(findNextActivedIndex(1)).toBe(3);
         });
+
+        it('targetIndex 이후에 선택 가능한 index가 없으면 -1을 반환한다', () => {
+            // given
+            const disabled = ref([3, 4]);
+            const { findNextActivedIndex } = useIndexSelector(list, disabled);
+
+            // then
+            expect(findNextActivedIndex(3)).toBe(-1);
+        });
+
+        it('targetIndex가 list의 마지막 index보다 크면 -1을 반환한다', () => {
+            // given
+            const { findNextActivedIndex } = useIndexSelector(list);
+
+            // then
+            expect(findNextActivedIndex(5)).toBe(-1);
+        });
+
+        it('targetIndex가 -1보다 작으면 -1을 반환한다', () => {
+            // given
+            const { findNextActivedIndex } = useIndexSelector(list);
+
+            // then
+            expect(findNextActivedIndex(-2)).toBe(-1);
+        });
     });
 
     describe('findPreviousActivedIndex', () => {
@@ -91,6 +116,32 @@ describe('index-selector-composable', () => {
 
             // then
             expect(findPreviousActivedIndex(2)).toBe(0);
+        });
+
+        it('targetIndex 이전에 선택 가능한 index가 없으면 -1을 반환한다', () => {
+            // given
+            const disabled = ref([0, 1]);
+            const { findPreviousActivedIndex } = useIndexSelector(list, disabled);
+
+            // then
+            expect(findPreviousActivedIndex(1)).toBe(-1);
+        });
+
+        it('targetIndex가 list의 마지막 index보다 크면 -1을 반환한다', () => {
+            // given
+            const disabled = ref([0, 1, 2, 3, 4]); // 모든 index가 disabled인 경우
+            const { findPreviousActivedIndex } = useIndexSelector(list, disabled);
+
+            // then
+            expect(findPreviousActivedIndex(5)).toBe(-1);
+        });
+
+        it('targetIndex가 -1보다 작으면 -1을 반환한다', () => {
+            // given
+            const { findPreviousActivedIndex } = useIndexSelector(list);
+
+            // then
+            expect(findPreviousActivedIndex(-2)).toBe(-1);
         });
     });
 
@@ -228,6 +279,114 @@ describe('index-selector-composable', () => {
 
             // then
             expect(isRightEdge.value).toBe(true);
+        });
+    });
+
+    describe('handleKeydown', () => {
+        it('ArrowLeft 키를 누르면 이전 활성화된 index로 이동한다', () => {
+            // given
+            const { handleKeydown, selectIndex } = useIndexSelector(list);
+            selectIndex(2);
+
+            // when
+            const event = { code: 'ArrowLeft', preventDefault: vi.fn() } as unknown as KeyboardEvent;
+            handleKeydown(event);
+
+            // then
+            expect(event.preventDefault).toHaveBeenCalled();
+        });
+
+        it('ArrowRight 키를 누르면 다음 활성화된 index로 이동한다', () => {
+            // given
+            const { handleKeydown, selectIndex } = useIndexSelector(list);
+            selectIndex(2);
+
+            // when
+            const event = { code: 'ArrowRight', preventDefault: vi.fn() } as unknown as KeyboardEvent;
+            handleKeydown(event);
+
+            // then
+            expect(event.preventDefault).toHaveBeenCalled();
+        });
+
+        it('Home 키를 누르면 첫 번째 활성화된 index로 이동한다', () => {
+            // given
+            const { handleKeydown, selectIndex } = useIndexSelector(list);
+            selectIndex(2);
+
+            // when
+            const event = { code: 'Home', preventDefault: vi.fn() } as unknown as KeyboardEvent;
+            handleKeydown(event);
+
+            // then
+            expect(event.preventDefault).toHaveBeenCalled();
+        });
+
+        it('End 키를 누르면 마지막 활성화된 index로 이동한다', () => {
+            // given
+            const { handleKeydown, selectIndex } = useIndexSelector(list);
+            selectIndex(2);
+
+            // when
+            const event = { code: 'End', preventDefault: vi.fn() } as unknown as KeyboardEvent;
+            handleKeydown(event);
+
+            // then
+            expect(event.preventDefault).toHaveBeenCalled();
+        });
+
+        it('왼쪽 끝에서 ArrowLeft 키를 누르면 아무 동작도 하지 않는다', () => {
+            // given
+            const { handleKeydown, selectIndex } = useIndexSelector(list);
+            selectIndex(0);
+
+            // when
+            const event = { code: 'ArrowLeft', preventDefault: vi.fn() } as unknown as KeyboardEvent;
+            handleKeydown(event);
+
+            // then
+            expect(event.preventDefault).not.toHaveBeenCalled();
+        });
+
+        it('오른쪽 끝에서 ArrowRight 키를 누르면 아무 동작도 하지 않는다', () => {
+            // given
+            const { handleKeydown, selectIndex } = useIndexSelector(list);
+            selectIndex(4);
+
+            // when
+            const event = { code: 'ArrowRight', preventDefault: vi.fn() } as unknown as KeyboardEvent;
+            handleKeydown(event);
+
+            // then
+            expect(event.preventDefault).not.toHaveBeenCalled();
+        });
+
+        it('disabled된 index가 있을 때 Home 키를 누르면 첫 번째 활성화된 index로 이동한다', () => {
+            // given
+            const disabled = ref([0, 1]);
+            const { handleKeydown, selectIndex } = useIndexSelector(list, disabled);
+            selectIndex(3);
+
+            // when
+            const event = { code: 'Home', preventDefault: vi.fn() } as unknown as KeyboardEvent;
+            handleKeydown(event);
+
+            // then
+            expect(event.preventDefault).toHaveBeenCalled();
+        });
+
+        it('disabled된 index가 있을 때 End 키를 누르면 마지막 활성화된 index로 이동한다', () => {
+            // given
+            const disabled = ref([3, 4]);
+            const { handleKeydown, selectIndex } = useIndexSelector(list, disabled);
+            selectIndex(1);
+
+            // when
+            const event = { code: 'End', preventDefault: vi.fn() } as unknown as KeyboardEvent;
+            handleKeydown(event);
+
+            // then
+            expect(event.preventDefault).toHaveBeenCalled();
         });
     });
 });

--- a/packages/vlossom/src/composables/index-selector-composable.ts
+++ b/packages/vlossom/src/composables/index-selector-composable.ts
@@ -1,10 +1,11 @@
 import { computed, ref, Ref } from 'vue';
+import { INVALID_INDEX } from '@/declaration/constants';
 
 export function useIndexSelector(list: Ref<string[]>, disabled: Ref<number[]> = ref([])) {
     const selectedIndex = ref(0);
 
     const isLeftEdge = computed(() => {
-        if (selectedIndex.value === -1) {
+        if (selectedIndex.value === INVALID_INDEX) {
             return true;
         }
         const targetDisabled = disabled.value.filter((i) => i >= 0 && i < selectedIndex.value);
@@ -12,7 +13,7 @@ export function useIndexSelector(list: Ref<string[]>, disabled: Ref<number[]> = 
     });
 
     const isRightEdge = computed(() => {
-        if (selectedIndex.value === -1) {
+        if (selectedIndex.value === INVALID_INDEX) {
             return true;
         }
         const targetDisabled = disabled.value.filter((i) => i > selectedIndex.value);
@@ -32,29 +33,41 @@ export function useIndexSelector(list: Ref<string[]>, disabled: Ref<number[]> = 
     }
 
     function findNextActivedIndex(targetIndex: number): number {
-        const tabsLength = list.value.length;
-        for (let i = targetIndex; i < tabsLength + targetIndex; i++) {
-            const index = i % tabsLength;
-            if (!isDisabled(index)) {
-                return index;
+        if (targetIndex < 0 || targetIndex >= list.value.length) {
+            return INVALID_INDEX;
+        }
+
+        if (!isDisabled(targetIndex)) {
+            return targetIndex;
+        }
+
+        for (let i = targetIndex + 1; i < list.value.length; i++) {
+            if (!isDisabled(i)) {
+                return i;
             }
         }
-        return targetIndex;
+        return INVALID_INDEX;
     }
 
     function findPreviousActivedIndex(targetIndex: number): number {
-        const tabsLength = list.value.length;
-        for (let i = targetIndex; i > targetIndex - tabsLength; i--) {
-            const index = (i + tabsLength) % tabsLength;
-            if (!isDisabled(index)) {
-                return index;
+        if (targetIndex < 0 || targetIndex >= list.value.length) {
+            return INVALID_INDEX;
+        }
+
+        if (!isDisabled(targetIndex)) {
+            return targetIndex;
+        }
+
+        for (let i = targetIndex - 1; i >= 0; i--) {
+            if (!isDisabled(i)) {
+                return i;
             }
         }
-        return targetIndex;
+        return INVALID_INDEX;
     }
 
     function getInitialIndex(index: number): number {
-        return index === -1 ? -1 : findNextActivedIndex(index);
+        return index === INVALID_INDEX ? INVALID_INDEX : findNextActivedIndex(index);
     }
 
     function selectIndex(index: number) {
@@ -62,7 +75,7 @@ export function useIndexSelector(list: Ref<string[]>, disabled: Ref<number[]> = 
         const isOutOfRange = index < 0 || index > tabsLength - 1;
         const isAllDisabled = disabled.value.length === tabsLength;
         if (isOutOfRange || isAllDisabled || isDisabled(index)) {
-            selectedIndex.value = -1;
+            selectedIndex.value = INVALID_INDEX;
             return;
         }
 

--- a/packages/vlossom/src/declaration/constants.ts
+++ b/packages/vlossom/src/declaration/constants.ts
@@ -54,3 +54,5 @@ export const DRAWER_SIZE = {
     lg: '60%',
     xl: '80%',
 };
+
+export const INVALID_INDEX = -1;


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary
vs-tabs나 vs-stepper가 사용하고 있는 index-selector-composable에서 다음 index를 가져오는 로직을 변경합니다.
기존에는 순환하는 형태로 구현되어 있어서 다음 index가 범위를 넘어서는 경우에 엉뚱한 index로 가는 경우가 있었음.
수정 후에는 범위를 벗어나는 경우에 -1로 선택(무선택 상태)하도록 수정함

<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
