### PR TITLE
fix(scroll): fix modal scroll lock bug

### DIFF
--- a/packages/vlossom/src/plugins/modal-plugin/modal-plugin.ts
+++ b/packages/vlossom/src/plugins/modal-plugin/modal-plugin.ts
@@ -15,8 +15,6 @@ export const modalPlugin: ModalPlugin = {
             return '';
         }
 
-        store.modal.push({ ...options, id });
-
         const { appendOverlayDom } = useOverlayDom();
         const overlay = appendOverlayDom(containerElement, `vs-modal-overlay-${container.replace('#', '')}`, {
             width: '100%',
@@ -27,6 +25,8 @@ export const modalPlugin: ModalPlugin = {
         const modalView = h(VsModalView, { container });
         modalView.appContext = getApp()._context;
         render(modalView, overlay);
+
+        store.modal.push({ ...options, id });
 
         return id;
     },


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary
modal push 시점이 앞쪽에 있어서 lock 조건이 제대로 초기화 되지 않는 버그 때문에 modal push 위치를 변경합니다.

## Description

<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
