### PR TITLE
feat(input-components): apply cursor styles to readonly and disabled states

### DIFF
--- a/packages/vlossom/src/components/vs-checkbox/VsCheckboxNode.scss
+++ b/packages/vlossom/src/components/vs-checkbox/VsCheckboxNode.scss
@@ -129,7 +129,6 @@ $checkbox-size: var(--vs-checkbox-node-checkboxSize, 2rem);
 
     &.vs-disabled {
         @include disabled;
-        cursor: default;
     }
 
     &.vs-readonly {

--- a/packages/vlossom/src/components/vs-input/VsInput.scss
+++ b/packages/vlossom/src/components/vs-input/VsInput.scss
@@ -68,6 +68,10 @@
         @include disabled;
     }
 
+    &.vs-readonly {
+        @include readonly;
+    }
+
     &.vs-state-box {
         @include state-box;
     }

--- a/packages/vlossom/src/components/vs-textarea/VsTextarea.scss
+++ b/packages/vlossom/src/components/vs-textarea/VsTextarea.scss
@@ -1,35 +1,38 @@
 @use '@/styles/mixin' as *;
 
 .vs-textarea {
-    position: relative;
-    display: flex;
-    overflow: hidden;
-    width: 100%;
-    height: var(--vs-textarea-height, 10rem);
-    background-color: var(--vs-textarea-backgroundColor, var(--vs-no-color));
-    color: var(--vs-textarea-fontColor, var(--vs-font-color));
-    font-size: var(--vs-textarea-fontSize, var(--vs-font-size));
-    border: var(--vs-textarea-border, solid 1px var(--vs-line-color));
-    border-radius: var(--vs-textarea-borderRadius, calc(var(--vs-radius-ratio) * var(--vs-radius)));
-    padding: var(--vs-textarea-padding, 0.6rem 1.2rem);
-    resize: var(--vs-textarea-resize, vertical);
+    textarea {
+        position: relative;
+        display: flex;
+        overflow: hidden;
+        width: 100%;
+        height: var(--vs-textarea-height, 10rem);
+        background-color: var(--vs-textarea-backgroundColor, var(--vs-no-color));
+        color: var(--vs-textarea-fontColor, var(--vs-font-color));
+        font-size: var(--vs-textarea-fontSize, var(--vs-font-size));
+        border: var(--vs-textarea-border, solid 1px var(--vs-line-color));
+        border-radius: var(--vs-textarea-borderRadius, calc(var(--vs-radius-ratio) * var(--vs-radius)));
+        padding: var(--vs-textarea-padding, 0.6rem 1.2rem);
+        resize: var(--vs-textarea-resize, vertical);
 
-    &.vs-dense {
-        font-size: var(--vs-textarea-fontSize, var(--vs-font-size-sm));
+        &.vs-dense {
+            font-size: var(--vs-textarea-fontSize, var(--vs-font-size-sm));
+        }
+
+        &.vs-state-box {
+            @include state-box;
+        }
+
+        &:focus-within {
+            @include focus-outline;
+        }
     }
+
     &.vs-disabled {
         @include disabled;
     }
 
     &.vs-readonly {
         @include readonly;
-    }
-
-    &.vs-state-box {
-        @include state-box;
-    }
-
-    &:focus-within {
-        @include focus-outline;
     }
 }

--- a/packages/vlossom/src/components/vs-textarea/VsTextarea.scss
+++ b/packages/vlossom/src/components/vs-textarea/VsTextarea.scss
@@ -21,6 +21,10 @@
         @include disabled;
     }
 
+    &.vs-readonly {
+        @include readonly;
+    }
+
     &.vs-state-box {
         @include state-box;
     }

--- a/packages/vlossom/src/components/vs-textarea/VsTextarea.vue
+++ b/packages/vlossom/src/components/vs-textarea/VsTextarea.vue
@@ -16,25 +16,25 @@
             <slot name="label" />
         </template>
 
-        <textarea
-            ref="textareaRef"
-            :class="['vs-textarea', colorSchemeClass, classObj, stateClasses]"
-            :style="computedStyleSet"
-            :id="computedId"
-            :value="inputValue"
-            :name="name"
-            :disabled="computedDisabled"
-            :readonly="computedReadonly"
-            :aria-label="ariaLabel"
-            :aria-required="required"
-            :autocomplete="autocomplete ? 'on' : 'off'"
-            :placeholder="placeholder"
-            @input.stop="updateValue($event)"
-            @focus.stop="onFocus"
-            @blur.stop="onBlur"
-            @keyup.enter.stop="onEnter"
-            @change.stop
-        />
+        <div :class="['vs-textarea', colorSchemeClass, classObj, stateClasses]" :style="computedStyleSet">
+            <textarea
+                ref="textareaRef"
+                :id="computedId"
+                :value="inputValue"
+                :name="name"
+                :disabled="computedDisabled"
+                :readonly="computedReadonly"
+                :aria-label="ariaLabel"
+                :aria-required="required"
+                :autocomplete="autocomplete ? 'on' : 'off'"
+                :placeholder="placeholder"
+                @input.stop="updateValue($event)"
+                @focus.stop="onFocus"
+                @blur.stop="onBlur"
+                @keyup.enter.stop="onEnter"
+                @change.stop
+            />
+        </div>
 
         <template #messages v-if="!noMessage">
             <slot name="messages" />

--- a/packages/vlossom/src/styles/mixin.scss
+++ b/packages/vlossom/src/styles/mixin.scss
@@ -11,13 +11,17 @@
 @mixin disabled {
     opacity: 0.5;
     filter: grayscale(0.7);
-    pointer-events: none;
-    cursor: default;
+    cursor: not-allowed;
+    * {
+        pointer-events: none;
+    }
 }
 
 @mixin readonly {
-    pointer-events: none;
-    cursor: default;
+    cursor: not-allowed;
+    * {
+        pointer-events: none;
+    }
 }
 
 @mixin hide-scroll {


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Feature (feat)

## Summary

input components가 `disabled` 혹은 `readonly`인 경우, 커서 스타일을 적용합니다.