### PR TITLE
style(VsDivider): set default vertical height value to 100%

### DIFF
--- a/packages/vlossom/src/components/vs-divider/VsDivider.scss
+++ b/packages/vlossom/src/components/vs-divider/VsDivider.scss
@@ -15,6 +15,7 @@ $divider-border: var(--vs-divider-border, 1px solid var(--vs-primary-comp-bg));
     margin: var(--vs-divider-marginVertical, 0 1.2rem);
     border-top: 0;
     border-left: $divider-border;
+    vertical-align: top;
 }
 
 .vs-divider {

--- a/packages/vlossom/src/components/vs-divider/VsDivider.scss
+++ b/packages/vlossom/src/components/vs-divider/VsDivider.scss
@@ -11,7 +11,7 @@ $divider-border: var(--vs-divider-border, 1px solid var(--vs-primary-comp-bg));
 @mixin vs-divider-vertical {
     display: inline-block;
     width: 0;
-    height: var(--vs-divider-verticalHeight, 2rem);
+    height: var(--vs-divider-verticalHeight, 100%);
     margin: var(--vs-divider-marginVertical, 0 1.2rem);
     border-top: 0;
     border-left: $divider-border;


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Style (style)

## Summary

- `VsDivider` 컴퍼넌트의 vertical height 값이 100%를 기본으로 설정되도록 변경합니다.
- vertical divider가 border를 bottom-to-top으로 그리는 것을 top-to-bottom으로 그리도록 변경하였습니다.