### PR TITLE
fix(scroll-lock): prevent to add padding on touch device(browser)

### DIFF
--- a/packages/vlossom/src/composables/scroll-lock-composable.ts
+++ b/packages/vlossom/src/composables/scroll-lock-composable.ts
@@ -1,41 +1,75 @@
 import { ref } from 'vue';
 import { SCROLLBAR_WIDTH } from '@/declaration';
+import { utils } from '@/utils';
+
+interface ScrollLockState {
+    overflow: string;
+    paddingRight: string;
+    paddingBottom: string;
+}
 
 export function useScrollLock(element: HTMLElement | null) {
-    const originalOverflow = ref('');
-    const originalPaddingRight = ref('0');
-    const originalPaddingBottom = ref('0');
+    const originalState = ref<ScrollLockState>({
+        overflow: '',
+        paddingRight: '0',
+        paddingBottom: '0',
+    });
+    const isNotTouchDevice = !(utils.dom.isBrowser() && utils.device.isTouchDevice());
+
+    function saveOriginalState() {
+        if (!element) {
+            return;
+        }
+
+        originalState.value = {
+            overflow: element.style.overflow,
+            paddingRight: element.style.paddingRight,
+            paddingBottom: element.style.paddingBottom,
+        };
+    }
+
+    function applyScrollLockStyles() {
+        if (!element) {
+            return;
+        }
+
+        element.style.overflow = 'hidden';
+
+        if (isNotTouchDevice) {
+            if (element.scrollHeight >= element.clientHeight) {
+                element.style.paddingRight = SCROLLBAR_WIDTH;
+            }
+            if (element.scrollWidth >= element.clientWidth) {
+                element.style.paddingBottom = SCROLLBAR_WIDTH;
+            }
+        }
+    }
+
+    function restoreOriginalState() {
+        if (!element) {
+            return;
+        }
+
+        element.style.overflow = originalState.value.overflow;
+        element.style.paddingRight = originalState.value.paddingRight;
+        element.style.paddingBottom = originalState.value.paddingBottom;
+    }
 
     function lock() {
         if (!element) {
             return;
         }
-        setTimeout(() => {
-            originalOverflow.value = element.style.overflow;
-            originalPaddingRight.value = element.style.paddingRight;
-            originalPaddingBottom.value = element.style.paddingBottom;
 
-            if (element.scrollHeight >= element.clientHeight) {
-                element.style.paddingRight = SCROLLBAR_WIDTH;
-            }
-
-            if (element.scrollWidth >= element.clientWidth) {
-                element.style.paddingBottom = SCROLLBAR_WIDTH;
-            }
-
-            element.style.overflow = 'hidden';
-        }, 10);
+        saveOriginalState();
+        requestAnimationFrame(applyScrollLockStyles);
     }
 
     function unlock() {
         if (!element) {
             return;
         }
-        setTimeout(() => {
-            element.style.overflow = originalOverflow.value;
-            element.style.paddingRight = originalPaddingRight.value;
-            element.style.paddingBottom = originalPaddingBottom.value;
-        }, 10);
+
+        requestAnimationFrame(restoreOriginalState);
     }
 
     return {

--- a/packages/vlossom/src/utils/device.ts
+++ b/packages/vlossom/src/utils/device.ts
@@ -1,0 +1,10 @@
+export const deviceUtil = {
+    isTouchDevice: () => {
+        return (
+            'ontouchstart' in window ||
+            navigator.maxTouchPoints > 0 ||
+            (navigator as any).msMaxTouchPoints > 0 ||
+            window.matchMedia('(pointer: coarse)').matches
+        );
+    },
+};

--- a/packages/vlossom/src/utils/index.ts
+++ b/packages/vlossom/src/utils/index.ts
@@ -1,4 +1,5 @@
 import { clipboardUtil } from './clipboard';
+import { deviceUtil } from './device';
 import { domUtil } from './dom';
 import { functionUtil } from './function';
 import { logUtil } from './log';
@@ -8,6 +9,7 @@ import { stringUtil } from './string';
 
 export const utils = {
     clipboard: clipboardUtil,
+    device: deviceUtil,
     dom: domUtil,
     log: logUtil,
     function: functionUtil,


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary
터치 기기에서 scroll lock 할 때 padding을 더하는 로직을 막습니다

## Description
- 모바일 터치 기기들이 쓰는 브라우저는 스크롤 스타일을 바꿀 수 없기 때문에 scroll lock에서 스크롤 사이즈만큼 padding을 더해주는 동작이 필요 없음
- setTimeout으로 다음 DOM 업데이트 기다리지 않고, requestAnimationFrame 사용
- util에 isTouchDevice 추가

<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
