### PR TITLE
fix(VsModal): not unmounting component when leaving Story

### DIFF
--- a/packages/vlossom/src/components/vs-modal/stories/VsModal.chromatic.stories.ts
+++ b/packages/vlossom/src/components/vs-modal/stories/VsModal.chromatic.stories.ts
@@ -1,10 +1,11 @@
 import { size, colorScheme } from '@/storybook';
 import { userEvent, within } from '@storybook/test';
-import { reactive } from 'vue';
+import { onUnmounted, reactive } from 'vue';
 import VsModal from './../VsModal.vue';
 import VsButton from '@/components/vs-button/VsButton.vue';
 import { ModalCloseButton, containerStyle } from './constants';
 import { SIZES } from '@/declaration';
+import { useVlossom } from '@/vlossom-framework';
 
 import type { Meta, StoryObj } from '@storybook/vue3';
 
@@ -14,11 +15,16 @@ const meta: Meta<typeof VsModal> = {
     render: (args: any) => ({
         components: { VsModal, ModalCloseButton, VsButton },
         setup() {
+            const vlossom = useVlossom();
             const isOpens = reactive([...Array(6).fill(false)]);
 
             function onClick(idx: number) {
                 isOpens[idx] = true;
             }
+
+            onUnmounted(() => {
+                vlossom.modal.clear();
+            });
 
             return { args, SIZES, isOpens, onClick, containerStyle };
         },

--- a/packages/vlossom/src/components/vs-modal/stories/VsModal.stories.ts
+++ b/packages/vlossom/src/components/vs-modal/stories/VsModal.stories.ts
@@ -1,11 +1,12 @@
 import { size, colorScheme } from '@/storybook';
-import { ref } from 'vue';
+import { onUnmounted, ref } from 'vue';
 import VsModal from './../VsModal.vue';
 import VsButton from '@/components/vs-button/VsButton.vue';
 import VsInput from '@/components/vs-input/VsInput.vue';
 import { ModalCloseButton, containerStyle } from './constants';
 
 import type { Meta, StoryObj } from '@storybook/vue3';
+import { useVlossom } from '@/vlossom-framework';
 
 const meta: Meta<typeof VsModal> = {
     title: 'Components/Layout Components/VsModal',
@@ -13,7 +14,12 @@ const meta: Meta<typeof VsModal> = {
     render: (args: any) => ({
         components: { VsModal, ModalCloseButton, VsButton },
         setup() {
+            const vlossom = useVlossom();
             const isOpen = ref(false);
+
+            onUnmounted(() => {
+                vlossom.modal.clear();
+            });
 
             return { args, isOpen };
         },


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary

- vs-modal, storybook chromatic Default Story에서 벗어날 때, 모달이 삭제되지 않는 이슈를 수정합니다.
   - VsModal Story unmount 시, 모달을 clear합니다.