### PR TITLE
feat(style-set): add `VsFlexContainerStyleSet` interface for nested flex container

### DIFF
--- a/packages/vlossom/src/declaration/types.ts
+++ b/packages/vlossom/src/declaration/types.ts
@@ -56,6 +56,13 @@ export interface VsBoxStyleSet {
     padding?: string;
 }
 
+export interface VsFlexContainerStyleSet {
+    flexDirection?: string;
+    flexWrap?: string;
+    alignItems?: string;
+    justifyContent?: string;
+}
+
 export interface VsTextStyleSet {
     fontColor?: string;
     fontSize?: string;

--- a/packages/vlossom/src/declaration/types.ts
+++ b/packages/vlossom/src/declaration/types.ts
@@ -56,7 +56,7 @@ export interface VsBoxStyleSet {
     padding?: string;
 }
 
-export interface VsFlexContainerStyleSet {
+export interface VsFlexStyleSet {
     flexDirection?: string;
     flexWrap?: string;
     alignItems?: string;


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Feature (feat)

## Summary

자주 사용하는 Flex Container의 Style Set을 정의합니다. 

#359 PR 작업에 추가되는 `verticalAlign` 속성과 같이 주먹구구로 Flex Container의 전용 속성들을 전달하지 않고, styleSet으로 정의하고 적용하기 위한 목적이 있습니다.