### PR TITLE
feat(VsTooltip): change margin type string, number

### DIFF
--- a/packages/vlossom/src/components/vs-tooltip/VsTooltip.vue
+++ b/packages/vlossom/src/components/vs-tooltip/VsTooltip.vue
@@ -74,7 +74,7 @@ export default defineComponent({
         disabled: { type: Boolean, default: false },
         enterDelay: { type: Number, default: 100 },
         leaveDelay: { type: Number, default: 100 },
-        margin: { type: Number, default: 5 },
+        margin: { type: [String, Number], default: 5 },
         placement: {
             type: String as PropType<Exclude<Placement, 'middle'>>,
             default: 'top',
@@ -122,7 +122,8 @@ export default defineComponent({
                     appear({
                         placement: placement.value,
                         align: align.value,
-                        margin: margin.value,
+                        margin:
+                            typeof margin.value === 'string' ? Number(margin.value.replace('px', '')) : margin.value,
                     });
                 });
             } else if (isVisible.value) {


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Feature (feat)

## Summary
vs-tooltip margin type을 string도 받을 수 있도록 변경

## Description
- 전체적으로 size를 전달했을 때 number, string 변환하는 로직이 필요한 것 같긴 함
- margin을 anchor-position 에서 처리할게 아닌 것 같긴 한데 고민 필요함

<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
