### PR TITLE
fix(VsFlexLayout): remove flex layout body inner

### DIFF
--- a/packages/vlossom/src/components/vs-flex-layout/VsFlexLayout.scss
+++ b/packages/vlossom/src/components/vs-flex-layout/VsFlexLayout.scss
@@ -17,10 +17,6 @@
         overflow: auto;
         flex: 1;
 
-        .vs-flex-layout-body-inner {
-            position: relative;
-            overflow: auto;
-        }
         &.vs-hide-scroll {
             @include hide-scroll;
         }

--- a/packages/vlossom/src/components/vs-flex-layout/VsFlexLayout.vue
+++ b/packages/vlossom/src/components/vs-flex-layout/VsFlexLayout.vue
@@ -5,9 +5,7 @@
         </div>
 
         <div :class="['vs-flex-layout-body', { 'vs-hide-scroll': hideScroll }]">
-            <div class="vs-flex-layout-body-inner">
-                <slot />
-            </div>
+            <slot />
         </div>
 
         <div v-if="$slots['footer']" class="vs-flex-layout-footer">


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary
vs-flex-layout에 불필요한 wrapper를 제거합니다

## Description
- body 안에 inner div가 있어서 slot contents의 height 100%가 제대로 적용되지 않기 때문에 제거함

<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
