### PR TITLE
fix(VsFileDrop): apply feedback to enhance impact

### DIFF
--- a/packages/vlossom/src/components/vs-file-drop/VsFileDrop.scss
+++ b/packages/vlossom/src/components/vs-file-drop/VsFileDrop.scss
@@ -115,6 +115,17 @@ $file-drop-height-dense: var(--vs-file-drop-height, var(--vs-input-comp-height-d
                         white-space: nowrap;
                         width: 100%;
                         min-width: 0;
+
+                        .vs-file-drop-file-name {
+                            font-size: var(--vs-file-drop-fontSize, var(--vs-font-size));
+                            color: var(--vs-file-drop-fontColor, var(--vs-font-color));
+                        }
+
+                        .vs-file-drop-file-size {
+                            font-size: var(--vs-file-drop-fontSize, var(--vs-font-size-xs));
+                            color: var(--vs-file-drop-fontColor, var(--vs-font-color));
+                            margin-left: 0.5rem;
+                        }
                     }
                 }
             }

--- a/packages/vlossom/src/components/vs-file-drop/VsFileDrop.scss
+++ b/packages/vlossom/src/components/vs-file-drop/VsFileDrop.scss
@@ -44,6 +44,9 @@ $file-drop-height-dense: var(--vs-file-drop-height, var(--vs-input-comp-height-d
 
         &.vs-dragging {
             outline: 0.2rem dashed var(--vs-line-color);
+        }
+
+        &.vs-dragging-shadow {
             background-color: var(--vs-file-drop-dragBackgroundColor, var(--vs-no-color));
             box-shadow: 0 0 0.2rem 0.2rem var(--vs-file-drop-border, var(--vs-line-color)) inset;
         }

--- a/packages/vlossom/src/components/vs-file-drop/VsFileDrop.scss
+++ b/packages/vlossom/src/components/vs-file-drop/VsFileDrop.scss
@@ -29,7 +29,7 @@ $file-drop-height-dense: var(--vs-file-drop-height, var(--vs-input-comp-height-d
         color: var(--vs-file-drop-fontColor, var(--vs-font-color));
         box-sizing: border-box;
 
-        &:focus-within {
+        &:focus-within, &.vs-hover {
             @include focus-outline;
             @include hover-active-lighten;
         }

--- a/packages/vlossom/src/components/vs-file-drop/VsFileDrop.scss
+++ b/packages/vlossom/src/components/vs-file-drop/VsFileDrop.scss
@@ -104,7 +104,15 @@ $file-drop-height-dense: var(--vs-file-drop-height, var(--vs-input-comp-height-d
                 overflow-y: auto;
                 overflow-x: hidden;
 
+                > div {
+                    display: flex;
+                    width: 100%;
+                    min-width: 0;
+                    max-width: 100%;
+                }
+                
                 .vs-chip {
+                    display: flex;
                     width: 100%;
                     min-width: 0;
                     max-width: 100%;

--- a/packages/vlossom/src/components/vs-file-drop/VsFileDrop.scss
+++ b/packages/vlossom/src/components/vs-file-drop/VsFileDrop.scss
@@ -135,7 +135,7 @@ $file-drop-height-dense: var(--vs-file-drop-height, var(--vs-input-comp-height-d
                         }
 
                         .vs-file-drop-file-size {
-                            font-size: var(--vs-file-drop-fontSize, var(--vs-font-size-xs));
+                            font-size: var(--vs-font-size-xs);
                             color: var(--vs-file-drop-fontColor, var(--vs-font-color));
                             margin-left: 0.5rem;
                         }
@@ -152,16 +152,19 @@ $file-drop-height-dense: var(--vs-file-drop-height, var(--vs-input-comp-height-d
                 width: var(--vs-file-drop-width, 100%);
                 height: var(--vs-file-drop-height, auto);
 
+                .vs-icon {
+                    color: var(--vs-file-drop-iconColor, var(--vs-line-color));
+                    margin-top: var(--vs-font-size-xs);
+                }
+
                 span {
                     width: 100%;
+                    margin-top: 0.5rem;
+                    font-size: var(--vs-font-size-xs);
                     text-align: center;
                     overflow: hidden;
                     text-overflow: ellipsis;
                     white-space: nowrap;
-                }
-
-                .vs-icon {
-                    color: var(--vs-file-drop-iconColor, var(--vs-line-color));
                 }
             }
         }

--- a/packages/vlossom/src/components/vs-file-drop/VsFileDrop.scss
+++ b/packages/vlossom/src/components/vs-file-drop/VsFileDrop.scss
@@ -124,6 +124,12 @@ $file-drop-height-dense: var(--vs-file-drop-height, var(--vs-input-comp-height-d
                     width: 100%;
                     min-width: 0;
                     max-width: 100%;
+                    pointer-events: none;
+
+                    .vs-chip-close-button {
+                        pointer-events: auto;
+                    }
+
                     .vs-chip-content {
                         display: block;
                         overflow: hidden;

--- a/packages/vlossom/src/components/vs-file-drop/VsFileDrop.scss
+++ b/packages/vlossom/src/components/vs-file-drop/VsFileDrop.scss
@@ -19,7 +19,7 @@ $file-drop-height-dense: var(--vs-file-drop-height, var(--vs-input-comp-height-d
         width: var(--vs-file-drop-width, 100%);
         height: var(--vs-file-drop-height, auto);
         background-color: var(--vs-file-drop-backgroundColor, var(--vs-no-color));
-        border: var(--vs-file-drop-border, 1px solid var(--vs-line-color));
+        border: var(--vs-file-drop-border, 0.1rem solid var(--vs-line-color));
         border-radius: var(--vs-file-drop-borderRadius, calc(var(--vs-radius-ratio) * var(--vs-radius)));
         font-size: var(--vs-file-drop-fontSize, var(--vs-font-size));
         color: var(--vs-file-drop-fontColor, var(--vs-font-color));
@@ -39,6 +39,7 @@ $file-drop-height-dense: var(--vs-file-drop-height, var(--vs-input-comp-height-d
         }
 
         &.vs-dragging {
+            outline: 0.2rem dashed var(--vs-line-color);
             background-color: var(--vs-file-drop-dragBackgroundColor, var(--vs-no-color));
             box-shadow: 0 0 0.2rem 0.2rem var(--vs-file-drop-border, var(--vs-line-color)) inset;
         }

--- a/packages/vlossom/src/components/vs-file-drop/VsFileDrop.scss
+++ b/packages/vlossom/src/components/vs-file-drop/VsFileDrop.scss
@@ -10,6 +10,10 @@ $file-drop-height-dense: var(--vs-file-drop-height, var(--vs-input-comp-height-d
     width: var(--vs-file-drop-width, 100%);
     height: var(--vs-file-drop-height, auto);
 
+    > div {
+        width: 100%;
+    }
+
     .vs-label-box {
         margin-bottom: 0.5rem;
     }

--- a/packages/vlossom/src/components/vs-file-drop/VsFileDrop.vue
+++ b/packages/vlossom/src/components/vs-file-drop/VsFileDrop.vue
@@ -21,9 +21,10 @@
         <div
             :class="['vs-file-drop', colorSchemeClass, classObj, stateClasses]"
             :style="computedStyleSet"
-            @drop.stop="handleFileDrop($event)"
-            @dragenter.stop="setDragging(true)"
-            @dragleave.stop="setDragging(false)"
+            @drop.prevent.stop="handleFileDrop($event)"
+            @dragenter.prevent.stop="setDragging(true)"
+            @dragover.prevent.stop
+            @dragleave.prevent.stop="setDragging(false)"
         >
             <input
                 type="file"
@@ -164,7 +165,8 @@ export default defineComponent({
 
         const classObj = computed(() => ({
             'vs-hover': hover.value,
-            'vs-dragging': dragging.value && !ctx.slots.default,
+            'vs-dragging': dragging.value,
+            'vs-dragging-shadow': dragging.value && !ctx.slots.default,
             'vs-disabled': computedDisabled.value,
             'vs-readonly': computedReadonly.value,
             'vs-dense': dense.value,

--- a/packages/vlossom/src/components/vs-file-drop/VsFileDrop.vue
+++ b/packages/vlossom/src/components/vs-file-drop/VsFileDrop.vue
@@ -51,7 +51,8 @@
                             no-round
                             @close="handleFileRemoveClick(file)"
                         >
-                            {{ `${file.name} (${file.size} bytes)` }}
+                            <span class="vs-file-drop-file-name">{{ file.name }}</span>
+                            <span class="vs-file-drop-file-size">{{ `(${file.size} bytes)` }}</span>
                         </vs-chip>
                     </div>
 

--- a/packages/vlossom/src/components/vs-file-drop/VsFileDrop.vue
+++ b/packages/vlossom/src/components/vs-file-drop/VsFileDrop.vue
@@ -41,19 +41,19 @@
             <div class="vs-file-drop-content">
                 <slot :dragging="dragging">
                     <div v-if="hasValue" class="vs-file-drop-files">
-                        <vs-chip
-                            v-for="file in computedInputValue"
-                            :key="file.name"
-                            :id="file.name"
-                            :dense="dense"
-                            :color-scheme="colorScheme"
-                            :closable="!computedDisabled"
-                            no-round
-                            @close="handleFileRemoveClick(file)"
-                        >
-                            <span class="vs-file-drop-file-name">{{ file.name }}</span>
-                            <span class="vs-file-drop-file-size">{{ `(${file.size} bytes)` }}</span>
-                        </vs-chip>
+                        <div v-for="file in computedInputValue" :key="file.name">
+                            <vs-chip
+                                :id="file.name"
+                                :dense="dense"
+                                :color-scheme="colorScheme"
+                                :closable="!computedDisabled"
+                                no-round
+                                @close="handleFileRemoveClick(file)"
+                            >
+                                <span class="vs-file-drop-file-name">{{ file.name }}</span>
+                                <span class="vs-file-drop-file-size">{{ `(${file.size} bytes)` }}</span>
+                            </vs-chip>
+                        </div>
                     </div>
 
                     <div v-else class="vs-file-drop-placeholder">

--- a/packages/vlossom/src/components/vs-file-drop/VsFileDrop.vue
+++ b/packages/vlossom/src/components/vs-file-drop/VsFileDrop.vue
@@ -23,7 +23,6 @@
             :style="computedStyleSet"
             @drop.prevent.stop="handleFileDrop($event)"
             @dragenter.prevent.stop="setDragging(true)"
-            @dragover.prevent.stop
             @dragleave.prevent.stop="setDragging(false)"
         >
             <input

--- a/packages/vlossom/src/components/vs-file-drop/VsFileDrop.vue
+++ b/packages/vlossom/src/components/vs-file-drop/VsFileDrop.vue
@@ -68,7 +68,7 @@
 
 <script lang="ts">
 import { computed, defineComponent, PropType, ref, toRefs } from 'vue';
-import { Breakpoints, StateMessage, VsComponent, type ColorScheme } from '@/declaration';
+import { Breakpoints, Message, VsComponent, type ColorScheme } from '@/declaration';
 import { getInputProps, getResponsiveProps } from '@/models';
 import { useColorScheme, useInput, useStyleSet, useStateClass } from '@/composables';
 import { useVsFileDropRules } from './vs-file-drop-rules';
@@ -118,7 +118,7 @@ export default defineComponent({
 
         const dragging = ref(false);
 
-        const compMessages = ref<StateMessage[]>([]);
+        const compMessages = ref<Message<InputValueType>[]>([]);
 
         const { colorSchemeClass } = useColorScheme(name, colorScheme);
 
@@ -137,7 +137,7 @@ export default defineComponent({
                 disabled,
                 readonly,
                 rules,
-                messages: messages.value.length > 0 ? messages : compMessages,
+                messages: computed(() => [...messages.value, ...compMessages.value]),
                 state,
             },
         );

--- a/packages/vlossom/src/components/vs-file-drop/VsFileDrop.vue
+++ b/packages/vlossom/src/components/vs-file-drop/VsFileDrop.vue
@@ -10,6 +10,7 @@
         :dense="dense"
         :readonly="computedReadonly"
         :messages="computedMessages"
+        :no-message="noMessage"
         @mouseenter.stop="setHover(true)"
         @mouseleave.stop="setHover(false)"
     >

--- a/packages/vlossom/src/components/vs-file-drop/VsFileDrop.vue
+++ b/packages/vlossom/src/components/vs-file-drop/VsFileDrop.vue
@@ -55,7 +55,7 @@
                                 @close="handleFileRemoveClick(file)"
                             >
                                 <span class="vs-file-drop-file-name">{{ file.name }}</span>
-                                <span class="vs-file-drop-file-size">{{ `(${file.size} bytes)` }}</span>
+                                <span class="vs-file-drop-file-size">{{ `(${getFileSizeFormat(file.size)})` }}</span>
                             </vs-chip>
                         </div>
                     </div>
@@ -79,6 +79,7 @@ import { useVsFileDropRules } from './vs-file-drop-rules';
 import { VsChip, VsInputWrapper } from '@/components';
 import { VsIcon } from '@/icons';
 import type { InputValueType, VsFileDropStyleSet } from './types';
+import { getFileSizeFormat } from './utils';
 
 const name = VsComponent.VsFileDrop;
 export default defineComponent({
@@ -271,6 +272,7 @@ export default defineComponent({
             handleFileDrop,
             handleFileRemoveClick,
             stateClasses,
+            getFileSizeFormat,
         };
     },
 });

--- a/packages/vlossom/src/components/vs-file-drop/VsFileDrop.vue
+++ b/packages/vlossom/src/components/vs-file-drop/VsFileDrop.vue
@@ -161,7 +161,7 @@ export default defineComponent({
 
         const classObj = computed(() => ({
             'vs-hover': hover.value,
-            'vs-dragging': dragging.value,
+            'vs-dragging': dragging.value && !ctx.slots.default,
             'vs-disabled': computedDisabled.value,
             'vs-readonly': computedReadonly.value,
             'vs-dense': dense.value,

--- a/packages/vlossom/src/components/vs-file-drop/VsFileDrop.vue
+++ b/packages/vlossom/src/components/vs-file-drop/VsFileDrop.vue
@@ -39,7 +39,7 @@
             />
 
             <div class="vs-file-drop-content">
-                <slot :dragging="dragging" :hover="hover">
+                <slot :dragging="dragging">
                     <div v-if="hasValue" class="vs-file-drop-files">
                         <vs-chip
                             v-for="file in computedInputValue"
@@ -259,7 +259,6 @@ export default defineComponent({
             inputValue,
             hasValue,
             dragging,
-            hover,
             setHover,
             setDragging,
             openFileDialog,

--- a/packages/vlossom/src/components/vs-file-drop/VsFileDrop.vue
+++ b/packages/vlossom/src/components/vs-file-drop/VsFileDrop.vue
@@ -58,7 +58,7 @@
 
                     <div v-else class="vs-file-drop-placeholder">
                         <vs-icon icon="attachFile" :size="dense ? 16 : 24" />
-                        <span>{{ placeholder }}</span>
+                        <span class="vs-text-gray">{{ placeholder }}</span>
                     </div>
                 </slot>
             </div>

--- a/packages/vlossom/src/components/vs-file-drop/__tests__/vs-file-drop.test.ts
+++ b/packages/vlossom/src/components/vs-file-drop/__tests__/vs-file-drop.test.ts
@@ -331,22 +331,6 @@ describe('vs-file-drop', () => {
             expect(wrapper.emitted('update:modelValue')?.[0][0]).toEqual(files);
         });
 
-        it('multiple이 false일 때 dialog에서 여러 파일을 선택하면 파일이 등록되지 않는다', async () => {
-            // Given
-            const files = [createFile('a.png'), createFile('b.png')];
-            const wrapper = mount(VsFileDrop, { props: { multiple: false } });
-
-            // When
-            await wrapper.vm.handleFileDialog({
-                target: {
-                    files,
-                },
-            } as unknown as Event);
-
-            // Then
-            expect(wrapper.emitted('update:modelValue')).toBeFalsy();
-        });
-
         it('multiple이 false일 때 여러 개의 파일을 추가하면 에러 메시지가 노출된다', async () => {
             // Given
             const files = [createFile('a.png'), createFile('b.png')];
@@ -433,27 +417,6 @@ describe('vs-file-drop', () => {
             expect(wrapper.emitted('update:modelValue')).toBeTruthy();
             expect(wrapper.emitted('update:modelValue')?.length).toBe(1);
             expect(wrapper.emitted('update:modelValue')?.[0][0]).toEqual(files);
-        });
-
-        it('accept에 맞지 않는 파일은 추가할 수 없다', async () => {
-            // Given
-            const accept = 'image/png';
-            const wrapper = mount(VsFileDrop, { props: { accept } });
-            const files = [createFile('test.txt', 'text/plain')];
-
-            // When
-            await wrapper.vm.handleFileDrop({
-                dataTransfer: {
-                    files,
-                },
-            } as unknown as DragEvent);
-            await wrapper.vm.$nextTick();
-
-            // Then
-            expect(wrapper.emitted('drop')).toBeTruthy();
-            expect(wrapper.emitted('drop')?.length).toBe(1);
-            expect(wrapper.emitted('drop')?.[0][0]).toEqual(files);
-            expect(wrapper.emitted('update:modelValue')).toBeFalsy();
         });
 
         it('accept가 맞지 않는 파일이 추가된 경우, "Only ${accept} files are allowed" 메시지가 노출된다', async () => {
@@ -558,27 +521,6 @@ describe('vs-file-drop', () => {
             expect(wrapper.emitted('update:modelValue')).toBeTruthy();
             expect(wrapper.emitted('update:modelValue')?.length).toBe(1);
             expect(wrapper.emitted('update:modelValue')?.[0][0]).toEqual(files);
-        });
-
-        it('multiple이 false일 때 drag&drop으로 여러 파일을 추가하면 어떤 파일도 등록되지 않는다', async () => {
-            // Given
-            const files = [createFile('a.png'), createFile('b.png')];
-            const wrapper = mount(VsFileDrop, { props: { multiple: false } });
-
-            // When
-            //input.trigger('drop');
-            await wrapper.vm.handleFileDrop({
-                dataTransfer: {
-                    files,
-                },
-            } as unknown as DragEvent);
-            await wrapper.vm.$nextTick();
-
-            // Then
-            expect(wrapper.emitted('drop')).toBeTruthy();
-            expect(wrapper.emitted('drop')?.length).toBe(1);
-            expect(wrapper.emitted('drop')?.[0][0]).toEqual(files);
-            expect(wrapper.emitted('update:modelValue')).toBeFalsy();
         });
 
         it('multiple이 false일 때 drag&drop으로 여러 파일을 추가하면 에러 메시지가 노출된다', async () => {

--- a/packages/vlossom/src/components/vs-file-drop/__tests__/vs-file-drop.test.ts
+++ b/packages/vlossom/src/components/vs-file-drop/__tests__/vs-file-drop.test.ts
@@ -667,22 +667,6 @@ describe('vs-file-drop', () => {
             // Then
             expect(wrapper.text()).toContain('Dragging!');
         });
-
-        it('사용자는 hover 상태를 사용하여 content를 정의할 수 있다', async () => {
-            // Given
-            const wrapper = mount(VsFileDrop, {
-                slots: {
-                    default: (slotProps) => (slotProps.hover ? h('div', 'Hover!') : null),
-                },
-            });
-
-            // When
-            wrapper.vm.hover = true;
-            await wrapper.vm.$nextTick();
-
-            // Then
-            expect(wrapper.text()).toContain('Hover!');
-        });
     });
 
     describe('keyboard control', () => {

--- a/packages/vlossom/src/components/vs-file-drop/utils.ts
+++ b/packages/vlossom/src/components/vs-file-drop/utils.ts
@@ -1,0 +1,12 @@
+export function getFileSizeFormat(number: number): string {
+    if (number < 1e3) {
+        return `${number} bytes`;
+    }
+    if (number >= 1e3 && number < 1e6) {
+        return `${(number / 1e3).toFixed(1)} KB`;
+    }
+    if (number >= 1e6 && number < 1e9) {
+        return `${(number / 1e6).toFixed(1)} MB`;
+    }
+    return `${(number / 1e9).toFixed(1)} GB`;
+}


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary

피드백 논의를 통해 적용이 필요한 기능을 추가하거나 수정합니다.

## Description

- input block display width는 기본값 100%
- dropzone 느낌이 나도록 하는 스타일 추가 - border style 'dash'
- placeholder color 그레이 색 적용
- 아이콘이 정중앙에 오도록 padding placeholder가 하단에 붙도록 변경
- messages와 컴퍼넌트 msg를 함께 보여주도록 변경
- props.noMessages에 의해 msg가 가려지도록 변경
- vs-chip, last element 마진 제거
- vs-chip, 폰트 컬러 comp-primary-bg, bytes 부분은 흐리고 작은 폰트로, 단위는 반응형으로 변경
- slot hover prop 제거
- vs-dragging 속성은 slot이 있을 때 나타나면 안된다
- file size를 크기에 맞게 간축하는 로직 추가 ( KB, MB, GB )
- vs-chip, 위에다가 드래그해도 드래깅 상태가 되어야 한다
- accept verify 체크하는 경우 파일이 등록되도록 변경