### PR TITLE
feat(style): remove `vs-inline-gap` selector

### DIFF
--- a/packages/vlossom/src/components/vs-avatar/VsAvatar.vue
+++ b/packages/vlossom/src/components/vs-avatar/VsAvatar.vue
@@ -1,5 +1,5 @@
 <template>
-    <div :class="['vs-avatar', 'vs-inline-gap', colorSchemeClass]" :style="computedStyleSet">
+    <div :class="['vs-avatar', colorSchemeClass]" :style="computedStyleSet">
         <slot />
     </div>
 </template>

--- a/packages/vlossom/src/components/vs-button/VsButton.vue
+++ b/packages/vlossom/src/components/vs-button/VsButton.vue
@@ -1,7 +1,7 @@
 <template>
     <button
         type="button"
-        :class="['vs-button', 'vs-inline-gap', colorSchemeClass, classObj, stateClasses]"
+        :class="['vs-button', colorSchemeClass, classObj, stateClasses]"
         :style="computedStyleSet"
         :disabled="disabled"
         :aria-label="loading ? 'loading' : undefined"

--- a/packages/vlossom/src/components/vs-chip/VsChip.vue
+++ b/packages/vlossom/src/components/vs-chip/VsChip.vue
@@ -1,5 +1,5 @@
 <template>
-    <div :class="['vs-chip', 'vs-inline-gap', colorSchemeClass, classObj]" :style="computedStyleSet">
+    <div :class="['vs-chip', colorSchemeClass, classObj]" :style="computedStyleSet">
         <span v-if="hasIcon" class="vs-icon-container vs-chip-icon">
             <slot name="icon" />
         </span>

--- a/packages/vlossom/src/components/vs-label-value/VsLabelValue.vue
+++ b/packages/vlossom/src/components/vs-label-value/VsLabelValue.vue
@@ -46,7 +46,6 @@ export default defineComponent({
 
         const classObj = computed(() => ({
             'vs-inline': inline.value,
-            'vs-inline-gap': inline.value,
             'vs-dense': dense.value,
             'vs-primary': primary.value,
         }));

--- a/packages/vlossom/src/styles/base.scss
+++ b/packages/vlossom/src/styles/base.scss
@@ -26,10 +26,6 @@ body {
     background-color: var(--vs-app-background-color);
 }
 
-.vs-inline-gap:has(+ .vs-inline-gap) {
-    margin-right: 0.5rem;
-}
-
 // vlossom scrollbar
 ::-webkit- {
     &scrollbar {


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Feature (feat)

## Summary

`base.scss`에 정의된 `vs-inline-gap` selector와 적용 컴퍼넌트에서 제거합니다.

## Description

개별 element 속성에서 간격을 설정하지 않고, wrapper 컴퍼넌트의 layout과 함께 일관된 방식으로 설정될 수 있도록 합니다.