### PR TITLE
fix(VsFileDrop): remove messages-absolute

### DIFF
--- a/packages/vlossom/src/components/vs-file-drop/VsFileDrop.scss
+++ b/packages/vlossom/src/components/vs-file-drop/VsFileDrop.scss
@@ -168,9 +168,3 @@ $file-drop-height-dense: var(--vs-file-drop-height, var(--vs-input-comp-height-d
         }
     }
 }
-
-.vs-messages {
-    position: absolute;
-    top: 100%;
-    left: 0;
-}


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [X] Fix Bug (fix)

## Summary
vs-file-drop에서 vs-messages 스타일을 수정하고 있어서 해당 스타일 제거합니다

![image](https://github.com/user-attachments/assets/ab485e2e-2e7c-4f09-b283-0e8851e0d80f)
message 영역이 absolute가 아니게 되어서 이제 아래에 있는 컴포넌트와 겹치지 않습니다

<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
